### PR TITLE
Update for GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ To build and install the library:
           If Torch has been installed as PyTorch in a python [venv (virtual environment)](https://docs.python.org/3/library/venv.html),
           e.g. with `pip install torch`, then this should be `</path/to/venv/>lib/python<3.xx>/site-packages/torch/`._
 
-    <sup>2</sup> _This is often overridden by PyTorch. To ensure a CPU or GPU only version, use one of:
+    <sup>2</sup> _This is often overridden by PyTorch. When installing with pip, the `index-url` flag can be used to ensure a CPU or GPU only version is installed, e.g.
           `pip install torch --index-url https://download.pytorch.org/whl/cpu`
           or
           `pip install torch --index-url https://download.pytorch.org/whl/cu118`
-          (for CUDA 11.8) respectively._
+          (for CUDA 11.8). URLs for alternative versions can be found [here](https://pytorch.org/get-started/locally/)._
 
 
 4. Make and install the code to the chosen location with:

--- a/README.md
+++ b/README.md
@@ -79,12 +79,21 @@ To build and install the library:
     | [`CMAKE_PREFIX_PATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html)        | `</path/to/libTorch/>`       | Location of Torch installation<sup>1</sup>                    |
     | [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)  | `</path/to/install/lib/at/>` | Location at which the library files should be installed. By default this is `/usr/local` |
     | [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)          | `Release` / `Debug`          | Specifies build type. The default is `Debug`, use `Release` for production code|
+    | `CMAKE_ENABLE_CUDA`                                                                               | `TRUE` / `FALSE`             | Specifies whether to check for an enable CUDA<sup>2</sup> |
 
     <sup>1</sup> _The path to the Torch installation needs to allow cmake to locate the relevant Torch cmake files.  
           If Torch has been [installed as libtorch](https://pytorch.org/cppdocs/installing.html)
           then this should be the absolute path to the unzipped libtorch distribution.
           If Torch has been installed as PyTorch in a python [venv (virtual environment)](https://docs.python.org/3/library/venv.html),
           e.g. with `pip install torch`, then this should be `</path/to/venv/>lib/python<3.xx>/site-packages/torch/`._
+
+    <sup>2</sup> _This is often overridden by PyTorch. To ensure a CPU or GPU only version, use one of:
+          `pip install torch --index-url https://download.pytorch.org/whl/cpu`
+          or
+          `pip install torch --index-url https://download.pytorch.org/whl/cu118`
+          (for CUDA 11.8) respectively._
+
+
 4. Make and install the code to the chosen location with:
     ```
     make

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To build and install the library:
     | [`CMAKE_PREFIX_PATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html)        | `</path/to/libTorch/>`       | Location of Torch installation<sup>1</sup>                    |
     | [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)  | `</path/to/install/lib/at/>` | Location at which the library files should be installed. By default this is `/usr/local` |
     | [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)          | `Release` / `Debug`          | Specifies build type. The default is `Debug`, use `Release` for production code|
-    | `CMAKE_ENABLE_CUDA`                                                                               | `TRUE` / `FALSE`             | Specifies whether to check for an enable CUDA<sup>2</sup> |
+    | `CMAKE_ENABLE_CUDA`                                                                               | `TRUE` / `FALSE`             | Specifies whether to check for and enable CUDA<sup>2</sup> |
 
     <sup>1</sup> _The path to the Torch installation needs to allow cmake to locate the relevant Torch cmake files.  
           If Torch has been [installed as libtorch](https://pytorch.org/cppdocs/installing.html)

--- a/README.md
+++ b/README.md
@@ -225,18 +225,18 @@ export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/installation>/lib64
 
 In order to run a model on a GPU, a few changes must be made:
 
-1. When saving your TorchScript model, ensure that is is on the GPU. For example, by adding the following to pt2ts.py in the [examples directories](examples/):
+1. When saving your TorchScript model, ensure that is is on the GPU. For example, when using [pt2ts.py](utils/pt2ts.py), this can be done by uncommenting the following lines:
 
 ```
-device = torch.device("cuda")
+device = torch.device('cuda')
 trained_model = trained_model.to(device)
+trained_model.eval()
+trained_model_dummy_input_1 = trained_model_dummy_input_1.to(device)
+trained_model_dummy_input_2 = trained_model_dummy_input_2.to(device)
 ```
 
-Note: when using pt2ts.py, it is likely that the dummy input tensor(s) must also be moved to the GPU:
+Note: this also moves the dummy input tensors to the GPU. This is not necessary for saving the model, but the tensors must also be on the GPU to test that the models runs.
 
-```
-trained_model_dummy_input = trained_model_dummy_input.to(device)
-```
 
 2. When calling `torch_tensor_from_blob` in Fortran, the device for the input tensor(s), but not the output tensor(s),
    should be set to `torch_kCUDA`, rather than `torch_kCPU`, to ensure that the inputs are on the same device as the model.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To build and install the library:
     | [`CMAKE_PREFIX_PATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html)        | `</path/to/libTorch/>`       | Location of Torch installation<sup>1</sup>                    |
     | [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)  | `</path/to/install/lib/at/>` | Location at which the library files should be installed. By default this is `/usr/local` |
     | [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)          | `Release` / `Debug`          | Specifies build type. The default is `Debug`, use `Release` for production code|
-    | `CMAKE_ENABLE_CUDA`                                                                               | `TRUE` / `FALSE`             | Specifies whether to check for and enable CUDA<sup>2</sup> |
+    | `ENABLE_CUDA`                                                                                     | `TRUE` / `FALSE`             | Specifies whether to check for and enable CUDA<sup>2</sup> |
 
     <sup>1</sup> _The path to the Torch installation needs to allow cmake to locate the relevant Torch cmake files.  
           If Torch has been [installed as libtorch](https://pytorch.org/cppdocs/installing.html)

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/installation>/lib64
 
 ### 4. Running on GPUs
 
-In order to run a model on a GPU, a few changes must be made:
+In order to run a model on a GPU, a two main changes are required:
 
 1. When saving your TorchScript model, ensure that is is on the GPU. For example, when using [pt2ts.py](utils/pt2ts.py), this can be done by uncommenting the following lines:
 
@@ -239,7 +239,7 @@ Note: this also moves the dummy input tensors to the GPU. This is not necessary 
 
 
 2. When calling `torch_tensor_from_blob` in Fortran, the device for the input tensor(s), but not the output tensor(s),
-   should be set to `torch_kCUDA`, rather than `torch_kCPU`, to ensure that the inputs are on the same device as the model.
+   should be set to `torch_kCUDA`, rather than `torch_kCPU`. This ensures that the inputs are on the same device as the model.
 
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -221,6 +221,26 @@ unless installing in a default location:
 export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/installation>/lib64
 ```
 
+### 4. Running on GPUs
+
+In order to run a model on a GPU, a few changes must be made:
+
+1. When saving your TorchScript model, ensure that is is on the GPU. For example, by adding the following to pt2ts.py in the [examples directories](examples/):
+
+```
+device = torch.device("cuda")
+trained_model = trained_model.to(device)
+```
+
+Note: when using pt2ts.py, it is likely that the dummy input tensor(s) must also be moved to the GPU:
+
+```
+trained_model_dummy_input = trained_model_dummy_input.to(device)
+```
+
+2. When calling `torch_tensor_from_blob` in Fortran, the device for the input tensor(s), but not the output tensor(s),
+   should be set to `torch_kCUDA`, rather than `torch_kCPU`, to ensure that the inputs are on the same device as the model.
+
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/installation>/lib64
 
 ### 4. Running on GPUs
 
-In order to run a model on a GPU, a two main changes are required:
+In order to run a model on GPU, two main changes are required:
 
 1. When saving your TorchScript model, ensure that it is on the GPU. For example, when using [pt2ts.py](utils/pt2ts.py), this can be done by uncommenting the following lines:
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/installation>/lib64
 
 In order to run a model on a GPU, a two main changes are required:
 
-1. When saving your TorchScript model, ensure that is is on the GPU. For example, when using [pt2ts.py](utils/pt2ts.py), this can be done by uncommenting the following lines:
+1. When saving your TorchScript model, ensure that it is on the GPU. For example, when using [pt2ts.py](utils/pt2ts.py), this can be done by uncommenting the following lines:
 
 ```
 device = torch.device('cuda')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(CheckLanguage)
-if(CMAKE_ENABLE_CUDA)
+if(ENABLE_CUDA)
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,16 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(CheckLanguage)
+if(CMAKE_ENABLE_CUDA)
+  check_language(CUDA)
+  if(CMAKE_CUDA_COMPILER)
+    enable_language(CUDA)
+  else()
+    message(WARNING "No CUDA support")
+  endif()
+endif()
+
 # Set RPATH behaviour
 set(CMAKE_SKIP_RPATH FALSE)
 set(CMAKE_SKIP_BUILD_RPATH FALSE)

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -230,9 +230,6 @@ void torch_jit_module_forward(const torch_jit_script_module_t module,
     std::cerr << "[ERROR]: " << e.what() << std::endl;
     exit(EXIT_FAILURE);
   }
-  // FIXME: this should be the responsibility of the user
-  if (out->is_cuda())
-    torch::cuda::synchronize();
 }
 
 void torch_jit_module_delete(torch_jit_script_module_t module)

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -52,7 +52,7 @@ torch_tensor_t torch_zeros(int ndim, const int64_t* shape, torch_data_t dtype,
     c10::IntArrayRef vshape(shape, ndim);
     tensor = new torch::Tensor;
     *tensor = torch::zeros(
-        vshape, torch::dtype(get_dtype(dtype)).device(get_device(device)));
+        vshape, torch::dtype(get_dtype(dtype))).to(get_device(device));
   } catch (const torch::Error& e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
     delete tensor;
@@ -74,7 +74,7 @@ torch_tensor_t torch_ones(int ndim, const int64_t* shape, torch_data_t dtype,
     c10::IntArrayRef vshape(shape, ndim);
     tensor = new torch::Tensor;
     *tensor = torch::ones(
-        vshape, torch::dtype(get_dtype(dtype)).device(get_device(device)));
+        vshape, torch::dtype(get_dtype(dtype))).to(get_device(device));
   } catch (const torch::Error& e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
     delete tensor;
@@ -96,7 +96,7 @@ torch_tensor_t torch_empty(int ndim, const int64_t* shape, torch_data_t dtype,
     c10::IntArrayRef vshape(shape, ndim);
     tensor = new torch::Tensor;
     *tensor = torch::empty(
-        vshape, torch::dtype(get_dtype(dtype)).device(get_device(device)));
+        vshape, torch::dtype(get_dtype(dtype))).to(get_device(device));
   } catch (const torch::Error& e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
     delete tensor;
@@ -122,7 +122,7 @@ torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
     tensor = new torch::Tensor;
     *tensor = torch::from_blob(
         data, vshape,
-        torch::dtype(get_dtype(dtype)).device(get_device(device)));
+        torch::dtype(get_dtype(dtype))).to(get_device(device));
   } catch (const torch::Error& e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
     delete tensor;

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -150,7 +150,7 @@ torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
     tensor = new torch::Tensor;
     *tensor = torch::from_blob(
         data, vshape, vstrides,
-        torch::dtype(get_dtype(dtype)).device(get_device(device)));
+        torch::dtype(get_dtype(dtype))).to(get_device(device));
 
   } catch (const torch::Error& e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -51,7 +51,7 @@ contains
       integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
       integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
       integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
-      integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
+      integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kCUDA)
       integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
       type(torch_tensor)             :: tensor     !! Returned tensor
 
@@ -86,7 +86,7 @@ contains
       type(c_ptr), intent(in)          :: data_arr       !! Pointer to data
       integer(c_int64_t), intent(in)   :: tensor_shape(:)   !! Shape of the tensor
       integer(c_int), intent(in)       :: dtype      !! Data type of the tensor
-      integer(c_int), intent(in)       :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
+      integer(c_int), intent(in)       :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kCUDA)
       type(torch_tensor)               :: tensor     !! Returned tensor
 
       integer(c_int)                   :: i          !! loop index
@@ -136,7 +136,7 @@ contains
       integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
       integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
       integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
-      integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
+      integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kCUDA)
       type(torch_tensor)             :: tensor     !! Returned tensor
 
       interface
@@ -160,7 +160,7 @@ contains
       integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
       integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
       integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
-      integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
+      integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kCUDA)
       type(torch_tensor)             :: tensor     !! Returned tensor
 
       interface
@@ -282,7 +282,7 @@ contains
       ! real(c_double), intent(in), target :: data_arr(*)   !! Fortran array of data
       integer(c_int64_t), intent(in)   :: tensor_shape(:)   !! Shape of the tensor
       integer(c_int), parameter :: dtype = torch_kFloat64
-      integer(c_int), intent(in)       :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
+      integer(c_int), intent(in)       :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kCUDA)
       type(torch_tensor)               :: tensor     !! Returned tensor
      
       
@@ -295,7 +295,7 @@ contains
       real(c_float), intent(in), target :: data_arr(*)   !! Fortran array of data
       integer(c_int64_t), intent(in)   :: tensor_shape(:)   !! Shape of the tensor
       integer(c_int), parameter :: dtype = torch_kFloat32
-      integer(c_int), intent(in)       :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
+      integer(c_int), intent(in)       :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kCUDA)
       type(torch_tensor)               :: tensor     !! Returned tensor
      
      tensor = t_t_from_array(c_loc(data_arr), tensor_shape, dtype, device)


### PR DESCRIPTION
Resolves #9 and #45

Initial changes to allow FTorch to run on GPUs.

As discussed in #9, changes for CMake may not be required, but may be useful.

Additional documentation to be added.