### PR TITLE
CMake fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To build and install the library:
     ```
     This will place the following directories at the install location:  
     * `CMAKE_INSTALL_PREFIX/include/` - contains header and mod files
-    * `CMAKE_INSTALL_PREFIX/lib64/` - contains `cmake` directory and `.so` files
+    * `CMAKE_INSTALL_PREFIX/lib/` - contains `cmake` directory and `.so` files
 
 
 ## Usage
@@ -206,13 +206,13 @@ FCFLAGS += -I<path/to/install/location>/include/ftorch
 
 When compiling the final executable add the following link flag:
 ```
-LDFLAGS += -L<path/to/install/location>/lib* -lftorch
+LDFLAGS += -L<path/to/install/location>/lib -lftorch
 ```
 
 You may also need to add the location of the `.so` files to your `LD_LIBRARY_PATH`
 unless installing in a default location:
 ```
-export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/install/location>/lib*
+export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/install/location>/lib
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,10 @@ find_package(FTorch)
 target_link_libraries( <executable> PRIVATE FTorch::ftorch )
 message(STATUS "Building with Fortran PyTorch coupling")
 ```
-and using the `-DFTorch_DIR=</path/to/install/location>` flag when running cmake.
+and using the `-DCMAKE_PREFIX_PATH=</path/to/install/location>` flag when running cmake.  
+Note: If you used the `CMAKE_INSTALL_PREFIX` argument when
+[building and installing the library](#libaray-installation) above then you should use
+the same path for `</path/to/install/location>`.
 
 #### Make
 To build with make we need to include the library when compiling and link the executable
@@ -203,13 +206,13 @@ FCFLAGS += -I<path/to/install/location>/include/ftorch
 
 When compiling the final executable add the following link flag:
 ```
-LDFLAGS += -L<path/to/install/location>/lib64 -lftorch
+LDFLAGS += -L<path/to/install/location>/lib* -lftorch
 ```
 
 You may also need to add the location of the `.so` files to your `LD_LIBRARY_PATH`
 unless installing in a default location:
 ```
-export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/installation>/lib64
+export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/install/location>/lib*
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ target_link_libraries( <executable> PRIVATE FTorch::ftorch )
 message(STATUS "Building with Fortran PyTorch coupling")
 ```
 and using the `-DCMAKE_PREFIX_PATH=</path/to/install/location>` flag when running cmake.  
-Note: If you used the `CMAKE_INSTALL_PREFIX` argument when
+_Note: If you used the `CMAKE_INSTALL_PREFIX` argument when
 [building and installing the library](#library-installation) above then you should use
-the same path for `</path/to/install/location>`.
+the same path for `</path/to/install/location>`._
 
 #### Make
 To build with make we need to include the library when compiling and link the executable

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ message(STATUS "Building with Fortran PyTorch coupling")
 ```
 and using the `-DCMAKE_PREFIX_PATH=</path/to/install/location>` flag when running cmake.  
 Note: If you used the `CMAKE_INSTALL_PREFIX` argument when
-[building and installing the library](#libaray-installation) above then you should use
+[building and installing the library](#library-installation) above then you should use
 the same path for `</path/to/install/location>`.
 
 #### Make

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ To build and install the library:
     ```
     This will place the following directories at the install location:  
     * `CMAKE_INSTALL_PREFIX/include/` - contains header and mod files
-    * `CMAKE_INSTALL_PREFIX/lib/` - contains `cmake` directory and `.so` files
+    * `CMAKE_INSTALL_PREFIX/lib/` - contains `cmake` directory and `.so` files  
+       _Note: depending on your system and architecture `lib` may be `lib64`, and 
+       you may have `.dll` files or similar._
 
 
 ## Usage
@@ -214,6 +216,7 @@ unless installing in a default location:
 ```
 export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/install/location>/lib
 ```
+_Note: depending on your system and architecture `lib` may be `lib64` or something similar._
 
 
 ## Examples

--- a/examples/1_SimpleNet/README.md
+++ b/examples/1_SimpleNet/README.md
@@ -74,10 +74,9 @@ This can be done using the included `CMakeLists.txt` as follows:
 ```
 mkdir build
 cd build
-cmake .. -DFTorch_DIR=<path/to/your/installation/of/library/>lib/cmake/ -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_PREFIX_PATH=<path/to/your/installation/of/library/> -DCMAKE_BUILD_TYPE=Release
 make
 ```
-Make sure that the  `FTorch_DIR` flag points to the `lib/cmake/` folder within the installation of the FTorch library.  
 
 To run the compiled code calling the saved SimpleNet TorchScript from Fortran run the
 executable with an argument of the saved model file:

--- a/examples/2_ResNet18/Makefile
+++ b/examples/2_ResNet18/Makefile
@@ -6,7 +6,7 @@ FC = gfortran
 FCFLAGS = -O3 -I</path/to/installation>/include/ftorch
 
 # link flags
-LDFLAGS = -L</path/to/installation>/lib64/ -lftorch
+LDFLAGS = -L</path/to/installation>/lib/ -lftorch
 
 PROGRAM = resnet_infer_fortran
 SRC = resnet_infer_fortran.f90

--- a/examples/2_ResNet18/README.md
+++ b/examples/2_ResNet18/README.md
@@ -70,10 +70,9 @@ This can be done using the included `CMakeLists.txt` as follows:
 ```
 mkdir build
 cd build
-cmake .. -DFTorch_DIR=<path/to/your/installation/of/library/>lib/cmake/ -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_PREFIX_PATH=<path/to/your/installation/of/library/> -DCMAKE_BUILD_TYPE=Release
 make
 ```
-Make sure that the  `FTorch_DIR` flag points to the `lib/cmake/` folder within the installation of the FTorch library.  
 
 To run the compiled code calling the saved ResNet-18 TorchScript from Fortran run the
 executable with an argument of the saved model file:

--- a/examples/2_ResNet18/README.md
+++ b/examples/2_ResNet18/README.md
@@ -95,7 +95,7 @@ installation of FTorch as described in the main documentation. Also check that t
 You will also likely need to add the location of the `.so` files to your `LD_LIBRARY_PATH`:
 ```
 make
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:</path/to/library/installation>/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:</path/to/library/installation>/lib
 ./resnet_infer_fortran saved_resnet18_model_cpu.pt
 ```
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,12 +36,15 @@ find_package(Torch REQUIRED)
 
 # Library with C and Fortran bindings
 add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.f90)
+# Add an alias FTorch::ftorch for the library
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
 set_target_properties(${LIB_NAME} PROPERTIES
   PUBLIC_HEADER "ctorch.h"
   Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/modules"
   )
+# Link TorchScript
 target_link_libraries(${LIB_NAME} PRIVATE ${TORCH_LIBRARIES})
+# Include the Fortran mod files in the library
 target_include_directories(${LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/modules>
@@ -61,7 +64,7 @@ install(TARGETS "${LIB_NAME}"
 install(EXPORT ${PROJECT_NAME}
   FILE ${PROJECT_NAME}Config.cmake
   NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
   )
 
 # Install Fortran module files


### PR DESCRIPTION
I believe this closes #14 

Namely the comments below the main one regarding install location.
cmake files are now placed at `$CMAKE_INSTALL_PREFIX/lib/cmake/FTorch/` allowing CMake to locate things automatically if passed `CMAKE_PREFIX_PATH = $CMAKE_INSTALL_PREFIX`.

This means we no longer specify the `FTorch_DIR` argument, instead using `CMAKE_PREFIX_PATH` as standard.

Regarding the other items in #14:
- Documentation has no dependencies as it is deployed by a GitHub action
- Examples exist as standalone items with their own CMake - I would argue that they should not in any way be combined with the main CMakeLists
- Currently no testing dependencies (or testing 😬) but we can make this a flag option when we write them.

Tested on apple M1 mac to build library, install, and build/run examples 1 and 2.
Would appreciate someone else replicating on a different system.