### PR TITLE
Increase assertion tolerance for Python inference

### DIFF
--- a/examples/2_ResNet18/resnet_infer_python.py
+++ b/examples/2_ResNet18/resnet_infer_python.py
@@ -64,7 +64,7 @@ def check_results(output: torch.Tensor) -> None:
     assert isclose(
         torch.max(torch.nn.functional.softmax(output[0], dim=0)),
         expected_prob,
-        abs_tol=1e-8,
+        abs_tol=1e-5,
     )
 
 


### PR DESCRIPTION
Increase the tolerance slightly to match the example Fortran tolerance, as the results may only match to around five significant figures.

(Without this change, it threw an assertion error for me when running `python resnet_infer_python.py`)