### PR TITLE
Add options for eval and gradient required

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -43,6 +43,16 @@ constexpr auto get_device(torch_device_t device)
   }
 }
 
+void set_is_training(torch_jit_script_module_t module, const bool is_training)
+{
+  auto model = static_cast<torch::jit::script::Module*>(module);
+  if (is_training) {
+    model->train();
+  } else {
+    model->eval();
+  }
+}
+
 torch_tensor_t torch_zeros(int ndim, const int64_t* shape, torch_data_t dtype,
                            torch_device_t device, const bool requires_grad)
 {
@@ -171,11 +181,7 @@ torch_jit_script_module_t torch_jit_load(const char* filename,
     delete module;
     exit(EXIT_FAILURE);
   }
-  if (is_training) {
-    module->train();
-  } else {
-    module->eval();
-  }
+  set_is_training(module, is_training);
 
   return module;
 }

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -38,9 +38,11 @@ typedef enum { torch_kCPU, torch_kCUDA } torch_device_t;
  * @param shape of the Tensor
  * @param data type of the elements of the Tensor
  * @param device used (cpu, CUDA, etc.)
+ * @param whether gradient is required
  */
 EXPORT_C torch_tensor_t torch_zeros(int ndim, const int64_t* shape,
-                                    torch_data_t dtype, torch_device_t device);
+                                    torch_data_t dtype, torch_device_t device,
+                                    const bool requires_grad);
 
 /**
  * Function to generate a Torch Tensor of ones
@@ -48,9 +50,11 @@ EXPORT_C torch_tensor_t torch_zeros(int ndim, const int64_t* shape,
  * @param shape of the Tensor
  * @param data type of the elements of the Tensor
  * @param device used (cpu, CUDA, etc.)
+ * @param whether gradient is required
  */
 EXPORT_C torch_tensor_t torch_ones(int ndim, const int64_t* shape,
-                                   torch_data_t dtype, torch_device_t device);
+                                   torch_data_t dtype, torch_device_t device,
+                                   const bool requires_grad);
 
 /**
  * Function to generate an empty Torch Tensor
@@ -58,9 +62,11 @@ EXPORT_C torch_tensor_t torch_ones(int ndim, const int64_t* shape,
  * @param shape of the Tensor
  * @param data type of the elements of the Tensor
  * @param device used (cpu, CUDA, etc.)
+ * @param whether gradient is required
  */
 EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t* shape,
-                                    torch_data_t dtype, torch_device_t device);
+                                    torch_data_t dtype, torch_device_t device,
+                                    const bool requires_grad);
 
 /**
  * Function to create a Torch Tensor from memory location given extra information
@@ -70,13 +76,15 @@ EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t* shape,
  * @param strides to take through data
  * @param data type of the elements of the Tensor
  * @param device used (cpu, CUDA, etc.)
+ * @param whether gradient is required
  * @return Torch Tensor interpretation of the data pointed at
  */
 EXPORT_C torch_tensor_t torch_from_blob(void* data, int ndim,
                                         const int64_t* shape,
                                         const int64_t* strides,
                                         torch_data_t dtype,
-                                        torch_device_t device);
+                                        torch_device_t device,
+                                        const bool requires_grad);
 
 /**
  * Function to print out a Torch Tensor
@@ -93,12 +101,14 @@ EXPORT_C void torch_tensor_print(const torch_tensor_t tensor);
  * @param shape of the Tensor
  * @param data type of the elements of the Tensor
  * @param device used (cpu, CUDA, etc.)
+ * @param whether gradient is required
  * @return Torch Tensor interpretation of the data pointed at
  */
 EXPORT_C torch_tensor_t torch_from_blob_f(void* data, int ndim,
                                         const int64_t* shape,
                                         torch_data_t dtype,
-                                        torch_device_t device);
+                                        torch_device_t device,
+                                        const bool requires_grad);
 
 /**
  * Function to delete a Torch Tensor to clean up
@@ -113,9 +123,12 @@ EXPORT_C void torch_tensor_delete(torch_tensor_t tensor);
 /**
  * Function to load in a Torch model from a TorchScript file and store in a Torch Module
  * @param filename where TorchScript description of model is stored
+ * @param whether gradient is required
+ * @param whether model is being trained
  * @return Torch Module loaded in from file
  */
-EXPORT_C torch_jit_script_module_t torch_jit_load(const char* filename);
+EXPORT_C torch_jit_script_module_t torch_jit_load(const char* filename,
+                                                  const bool requires_grad, const bool is_training);
 
 /**
  * Function to run the `forward` method of a Torch Module
@@ -123,10 +136,11 @@ EXPORT_C torch_jit_script_module_t torch_jit_load(const char* filename);
  * @param vector of Torch Tensors as inputs to the model
  * @param number of input Tensors in the input vector
  * @param the output Tensor from running the model
+ * @param whether gradient is required
  */
 EXPORT_C void torch_jit_module_forward(const torch_jit_script_module_t module,
                                        const torch_tensor_t *inputs, const int nin,
-                                       torch_tensor_t output);
+                                       torch_tensor_t output, const bool requires_grad);
 
 /**
  * Function to delete a Torch Module to clean up

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -226,11 +226,11 @@ contains
   function torch_module_load(filename, requires_grad_opt, is_training_opt) result(module)
     use, intrinsic :: iso_c_binding, only : c_null_char, c_bool
     character(*), intent(in) :: filename !! Filename of Torch Script module
-    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
-    logical(c_bool), optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_module)            :: module      !! Returned deserialized module
-    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
-    logical(c_bool) :: is_training  !! Whether the model is being trained, rather than evaluated
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical :: is_training  !! Whether the model is being trained, rather than evaluated
 
     interface
       function torch_jit_load_c(filename, requires_grad, is_training) result(module) &
@@ -244,19 +244,19 @@ contains
     end interface
 
     if (.not. present(requires_grad_opt)) then
-      requires_grad = logical(.false., c_bool)
+      requires_grad = .false.
     else
       requires_grad = requires_grad_opt
     end if
 
     if (.not. present(is_training_opt)) then
-      is_training = logical(.false., c_bool)
+      is_training = .false.
     else
       is_training = is_training_opt
     end if
 
     ! Need to append c_null_char at end of filename
-    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, requires_grad, is_training)
+    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, logical(requires_grad, c_bool), logical(is_training, c_bool))
   end function torch_module_load
 
   !> Performs a forward pass of the module with the input tensors
@@ -265,9 +265,9 @@ contains
     type(torch_module), intent(in) :: module        !! Module
     type(torch_tensor), intent(in), dimension(:) :: input_tensors  !! Array of Input tensors
     type(torch_tensor), intent(in) :: output_tensor !! Returned output tensors
-    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     integer(c_int) ::  n_inputs
-    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer :: i
     type(c_ptr), dimension(n_inputs), target  :: input_ptrs
@@ -286,7 +286,7 @@ contains
     end interface
 
     if (.not. present(requires_grad_opt)) then
-      requires_grad = logical(.false., c_bool)
+      requires_grad = .false.
     else
       requires_grad = requires_grad_opt
     end if
@@ -296,7 +296,7 @@ contains
       input_ptrs(i) = input_tensors(i)%p
     end do
 
-    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, requires_grad)
+    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, logical(requires_grad, c_bool))
   end subroutine torch_module_forward
 
   !> Deallocates a Torch Script module

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -73,9 +73,9 @@ module ftorch
   end interface
 
   interface
-    function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device) result(tensor_p) &
+    function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device, requires_grad) result(tensor_p) &
                                bind(c, name = 'torch_from_blob')
-      use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+      use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr, c_bool
 
       ! Arguments
       type(c_ptr), value, intent(in)    :: data
@@ -84,6 +84,7 @@ module ftorch
       integer(c_int64_t), intent(in)    :: strides(*)
       integer(c_int), value, intent(in) :: dtype
       integer(c_int), value, intent(in) :: device
+      logical(c_bool), value, intent(in) :: requires_grad
       type(c_ptr)                       :: tensor_p
     end function torch_from_blob_c
   end interface
@@ -93,72 +94,99 @@ contains
   ! Torch Tensor API
   !| Exposes the given data as a tensor without taking ownership of the original data.
   !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
-  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device, requires_grad_opt) result(tensor)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr, c_bool
     type(c_ptr), intent(in)        :: data       !! Pointer to data
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
+    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
+
 
     integer(c_int)                 :: i          !! loop index
     integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
+
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
 
     strides(layout(1)) = 1
     do i = 2, ndims
       strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
     end do
-    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device)
+    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device, requires_grad)
   end function torch_tensor_from_blob
 
   !> Returns a tensor filled with the scalar value 1.
-  function torch_tensor_ones(ndims, tensor_shape, dtype, device) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
+  function torch_tensor_ones(ndims, tensor_shape, dtype, device, requires_grad_opt) result(tensor)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_bool
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     interface
-      function torch_ones_c(ndims, tensor_shape, dtype, device) result(tensor) &
+      function torch_ones_c(ndims, tensor_shape, dtype, device, requires_grad) result(tensor) &
           bind(c, name = 'torch_ones')
-        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr, c_bool
         integer(c_int), value, intent(in) :: ndims
         integer(c_int64_t), intent(in)    :: tensor_shape(*)
         integer(c_int), value, intent(in) :: dtype
         integer(c_int), value, intent(in) :: device
+        logical(c_bool), value, intent(in) :: requires_grad
         type(c_ptr)                       :: tensor
       end function torch_ones_c
     end interface
 
-    tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device, requires_grad)
   end function torch_tensor_ones
 
   !> Returns a tensor filled with the scalar value 0.
-  function torch_tensor_zeros(ndims, tensor_shape, dtype, device) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
+  function torch_tensor_zeros(ndims, tensor_shape, dtype, device, requires_grad_opt) result(tensor)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_bool
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     interface
-      function torch_zeros_c(ndims, tensor_shape, dtype, device) result(tensor) &
+      function torch_zeros_c(ndims, tensor_shape, dtype, device, requires_grad) result(tensor) &
           bind(c, name = 'torch_zeros')
-        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr, c_bool
         integer(c_int), value, intent(in) :: ndims
         integer(c_int64_t), intent(in)    :: tensor_shape(*)
         integer(c_int), value, intent(in) :: dtype
         integer(c_int), value, intent(in) :: device
+        logical(c_bool), value, intent(in) :: requires_grad
         type(c_ptr)                       :: tensor
       end function torch_zeros_c
     end interface
 
-    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device, requires_grad)
   end function torch_tensor_zeros
 
   !> Prints the contents of a tensor.
@@ -193,53 +221,80 @@ contains
 
   ! Torch Module API
   !> Loads a Torch Script module (pre-trained PyTorch model saved with Torch Script)
-  function torch_module_load(filename) result(module)
-    use, intrinsic :: iso_c_binding, only : c_null_char
+  function torch_module_load(filename, requires_grad_opt, is_training_opt) result(module)
+    use, intrinsic :: iso_c_binding, only : c_null_char, c_bool
     character(*), intent(in) :: filename !! Filename of Torch Script module
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_module)            :: module      !! Returned deserialized module
+    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool) :: is_training  !! Whether the model is being trained, rather than evaluated
 
     interface
-      function torch_jit_load_c(filename) result(module) &
+      function torch_jit_load_c(filename, requires_grad, is_training) result(module) &
           bind(c, name = 'torch_jit_load')
-        use, intrinsic :: iso_c_binding, only : c_char, c_ptr
+        use, intrinsic :: iso_c_binding, only : c_char, c_ptr, c_bool
         character(c_char), intent(in) :: filename(*)
+        logical(c_bool), value, intent(in) :: requires_grad
+        logical(c_bool), value, intent(in) :: is_training
         type(c_ptr)                   :: module
       end function torch_jit_load_c
     end interface
 
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    if (.not. present(is_training_opt)) then
+      is_training = logical(.false., c_bool)
+    else
+      is_training = is_training_opt
+    end if
+
     ! Need to append c_null_char at end of filename
-    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char)
+    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, requires_grad, is_training)
   end function torch_module_load
 
   !> Performs a forward pass of the module with the input tensors
-  subroutine torch_module_forward(module, input_tensors, n_inputs, output_tensor)
-    use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_loc
+  subroutine torch_module_forward(module, input_tensors, n_inputs, output_tensor, requires_grad_opt)
+    use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_loc, c_bool
     type(torch_module), intent(in) :: module        !! Module
     type(torch_tensor), intent(in), dimension(:) :: input_tensors  !! Array of Input tensors
     type(torch_tensor), intent(in) :: output_tensor !! Returned output tensors
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     integer(c_int) ::  n_inputs
+    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer :: i
     type(c_ptr), dimension(n_inputs), target  :: input_ptrs
 
     interface
       subroutine torch_jit_module_forward_c(module, input_tensors, n_inputs, &
-          output_tensor) &
+          output_tensor, requires_grad) &
           bind(c, name = 'torch_jit_module_forward')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int
+        use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_bool
         type(c_ptr), value, intent(in) :: module
         type(c_ptr), value, intent(in) :: input_tensors
         integer(c_int), value, intent(in) :: n_inputs
         type(c_ptr), value, intent(in) :: output_tensor
+        logical(c_bool), value, intent(in) :: requires_grad
       end subroutine torch_jit_module_forward_c
     end interface
+
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
 
     ! Assign array of pointers to the input tensors
     do i = 1, n_inputs
       input_ptrs(i) = input_tensors(i)%p
     end do
 
-    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p)
+    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, requires_grad)
   end subroutine torch_module_forward
 
   !> Deallocates a Torch Script module
@@ -260,14 +315,15 @@ contains
   #:for PREC in PRECISIONS
   #:for RANK in RANKS
   !> Return a Torch tensor pointing to data_in array of rank ${RANK}$ containing data of type `${PREC}$`
-  function torch_tensor_from_array_${PREC}$_${RANK}$d(data_in, layout, c_device) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+  function torch_tensor_from_array_${PREC}$_${RANK}$d(data_in, layout, c_device, requires_grad_opt) result(tensor)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : ${PREC}$
 
     ! inputs
     ${f_type(PREC)}$(kind=${PREC}$), intent(in), target :: data_in${ranksuffix(RANK)}$   !! Input data that tensor will point at
     integer, intent(in)        :: layout(${RANK}$) !! Control order of indices
     integer(c_int), intent(in) :: c_device         !! Device on which the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -278,6 +334,13 @@ contains
     integer(c_int64_t)        :: strides(${RANK}$)                  !! Strides for accessing data
     integer(c_int), parameter :: ndims = ${RANK}$                   !! Number of dimension of input data
     integer                   :: i
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
+
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
 
     c_tensor_shape = shape(data_in)
 
@@ -286,7 +349,7 @@ contains
       strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
     end do
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device)
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_${PREC}$_${RANK}$d
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -224,11 +224,11 @@ contains
   function torch_module_load(filename, requires_grad_opt, is_training_opt) result(module)
     use, intrinsic :: iso_c_binding, only : c_null_char, c_bool
     character(*), intent(in) :: filename !! Filename of Torch Script module
-    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
-    logical(c_bool), optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_module)            :: module      !! Returned deserialized module
-    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
-    logical(c_bool) :: is_training  !! Whether the model is being trained, rather than evaluated
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical :: is_training  !! Whether the model is being trained, rather than evaluated
 
     interface
       function torch_jit_load_c(filename, requires_grad, is_training) result(module) &
@@ -242,19 +242,19 @@ contains
     end interface
 
     if (.not. present(requires_grad_opt)) then
-      requires_grad = logical(.false., c_bool)
+      requires_grad = .false.
     else
       requires_grad = requires_grad_opt
     end if
 
     if (.not. present(is_training_opt)) then
-      is_training = logical(.false., c_bool)
+      is_training = .false.
     else
       is_training = is_training_opt
     end if
 
     ! Need to append c_null_char at end of filename
-    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, requires_grad, is_training)
+    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, logical(requires_grad, c_bool), logical(is_training, c_bool))
   end function torch_module_load
 
   !> Performs a forward pass of the module with the input tensors
@@ -263,9 +263,9 @@ contains
     type(torch_module), intent(in) :: module        !! Module
     type(torch_tensor), intent(in), dimension(:) :: input_tensors  !! Array of Input tensors
     type(torch_tensor), intent(in) :: output_tensor !! Returned output tensors
-    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     integer(c_int) ::  n_inputs
-    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer :: i
     type(c_ptr), dimension(n_inputs), target  :: input_ptrs
@@ -284,7 +284,7 @@ contains
     end interface
 
     if (.not. present(requires_grad_opt)) then
-      requires_grad = logical(.false., c_bool)
+      requires_grad = .false.
     else
       requires_grad = requires_grad_opt
     end if
@@ -294,7 +294,7 @@ contains
       input_ptrs(i) = input_tensors(i)%p
     end do
 
-    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, requires_grad)
+    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, logical(requires_grad, c_bool))
   end subroutine torch_module_forward
 
   !> Deallocates a Torch Script module


### PR DESCRIPTION
Resolves #73

Adds flags in all(?) functions that operate on tensors (tensor creation, model loading, forward) to optionally disable autograd, which should improve performance for inference.

Also adds a similar flag to set evaluation mode for the loaded model.

- Evaluation mode
  - Contrary to my initial comments in #73, from testing evaluation mode does appear to be preserved, both between saving and loading TorchScript, and when applied to the loaded model.
  - In most cases evaluation mode is therefore likely to already be set, but I think it's useful to have the option to change it, particularly if FTorch may be extended to facilitate training (#22).

- NoGradMode
  - Enabling or disabling gradients is more complicated, as it defined via a context manager, which only appears to define the behaviour within its own scope, and so it seems necessary to enable/disable gradients before every code block that operates on tensors (similar to the Python equivalent `with torch.no_grad():`).

- InferenceMode
  - No changes are currently included, but it would be good to support [InferenceMode](https://pytorch.org/cppdocs/notes/inference_mode.html) too eventually, as it should provide further performance benefits over NoGradMode.
  - However, it has stricter requirements, and the mode was only added (as a beta) in PyTorch 1.9, so we would need to be careful if we want to support older versions.

- Model freezing
  - No changes are currently included, and less directly applicable to the main FTorch library, although there are still interactions e.g. freezing the model can allow InferenceMode to be enabled when loading the model.
  - Freezing is currently the "default" when tracing in [pt2ts.py](https://github.com/Cambridge-ICCS/FTorch/blob/main/utils/pt2ts.py), but not for scripting, despite potentially [improving performance](https://pytorch.org/tutorials/prototype/torchscript_freezing.html).
  - Freezing appears to (sometimes) introduce numerical errors when saving the reloading (differences ~10^-6), and can seem to lead to issues loading with Forpy too.

(For more general explanation of autograd/evaluation mode, see [autograd mechanics](https://pytorch.org/docs/1.9.0/notes/autograd.html)).

Note: I've also removed the old, commented out `torch_from_blob` function.