### PR TITLE
Make fypp CI run on PRs from forks.

### DIFF
--- a/.github/workflows/fypp.yml
+++ b/.github/workflows/fypp.yml
@@ -1,8 +1,15 @@
 name: fypp-checks
 
 on:
-  # run on every push
+  # run on every push - doesn't work on forks
   push:
+  # run on every push (not commit) to a PR, plus open/reopen
+  pull_request:
+    types:
+    - synchronize
+    - opened
+    - reopened
+
 
 jobs:
   various:


### PR DESCRIPTION
FYPP check isn't running in forks as set to:
```
on:
    push:
```
which only works for pushes to the main repo.

This updates it to also run on pull requests from forks.

Means it will run twice on internal PRs but we can live with that.