### PR TITLE
Remove unused code

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -109,33 +109,6 @@ torch_tensor_t torch_empty(int ndim, const int64_t* shape, torch_data_t dtype,
   return tensor;
 }
 
-/*
-// Exposes the given data as a Tensor without taking ownership of the original
-// data
-torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
-                               torch_data_t dtype, torch_device_t device)
-{
-  torch::Tensor* tensor = nullptr;
-  try {
-    // This doesn't throw if shape and dimensions are incompatible
-    c10::IntArrayRef vshape(shape, ndim);
-    tensor = new torch::Tensor;
-    *tensor = torch::from_blob(
-        data, vshape,
-        torch::dtype(get_dtype(dtype))).to(get_device(device));
-  } catch (const torch::Error& e) {
-    std::cerr << "[ERROR]: " << e.msg() << std::endl;
-    delete tensor;
-    exit(EXIT_FAILURE);
-  } catch (const std::exception& e) {
-    std::cerr << "[ERROR]: " << e.what() << std::endl;
-    delete tensor;
-    exit(EXIT_FAILURE);
-  }
-  return tensor;
-}
-
-*/
 // New version of torch_from_blob that uses strides
 torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
                                const int64_t* strides, torch_data_t dtype,

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -109,7 +109,8 @@ torch_tensor_t torch_empty(int ndim, const int64_t* shape, torch_data_t dtype,
   return tensor;
 }
 
-// New version of torch_from_blob that uses strides
+// Exposes the given data as a Tensor without taking ownership of the original
+// data
 torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
                                const int64_t* strides, torch_data_t dtype,
                                torch_device_t device)

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -85,22 +85,6 @@ EXPORT_C torch_tensor_t torch_from_blob(void* data, int ndim,
 EXPORT_C void torch_tensor_print(const torch_tensor_t tensor);
 
 /**
- * Function to create a Torch Tensor from memory location given extra information
- * This is a rework for torch_from_blob that uses strides, and will eventually
- * replace torch_from_blob.
- * @param pointer to the Tensor in memory
- * @param number of dimensions of the Tensor
- * @param shape of the Tensor
- * @param data type of the elements of the Tensor
- * @param device used (cpu, CUDA, etc.)
- * @return Torch Tensor interpretation of the data pointed at
- */
-EXPORT_C torch_tensor_t torch_from_blob_f(void* data, int ndim,
-                                        const int64_t* shape,
-                                        torch_data_t dtype,
-                                        torch_device_t device);
-
-/**
  * Function to delete a Torch Tensor to clean up
  * @param Torch Tensor to delete
  */


### PR DESCRIPTION
Closes #89.

Drops commented out `torch_from_blob` C++ code and unused `torch_from_blob_f` header.