### PR TITLE
Consistency of package names

### DIFF
--- a/examples/1_SimpleNet/pt2ts.py
+++ b/examples/1_SimpleNet/pt2ts.py
@@ -1,4 +1,4 @@
-"""Load a pytorch model and convert it to TorchScript."""
+"""Load a PyTorch model and convert it to TorchScript."""
 
 from typing import Optional
 import torch
@@ -13,12 +13,12 @@ def script_to_torchscript(
     model: torch.nn.Module, filename: Optional[str] = "scripted_model.pt"
 ) -> None:
     """
-    Save pyTorch model to TorchScript using scripting.
+    Save PyTorch model to TorchScript using scripting.
 
     Parameters
     ----------
     model : torch.NN.Module
-        a pyTorch model
+        a PyTorch model
     filename : str
         name of file to save to
     """
@@ -35,12 +35,12 @@ def trace_to_torchscript(
     filename: Optional[str] = "traced_model.pt",
 ) -> None:
     """
-    Save pyTorch model to TorchScript using tracing.
+    Save PyTorch model to TorchScript using tracing.
 
     Parameters
     ----------
     model : torch.NN.Module
-        a pyTorch model
+        a PyTorch model
     dummy_input : torch.Tensor
         appropriate size Tensor to act as input to model
     filename : str
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     saved_ts_filename = "saved_simplenet_model_cpu.pt"
 
     # FPTLIB-TODO
-    # Save the pytorch model using either scripting (recommended where possible) or tracing
+    # Save the PyTorch model using either scripting (recommended where possible) or tracing
     # -----------
     # Scripting
     # -----------

--- a/examples/2_ResNet18/pt2ts.py
+++ b/examples/2_ResNet18/pt2ts.py
@@ -1,4 +1,4 @@
-"""Load a pytorch model and convert it to TorchScript."""
+"""Load a PyTorch model and convert it to TorchScript."""
 
 from typing import Optional
 import torch
@@ -13,12 +13,12 @@ def script_to_torchscript(
     model: torch.nn.Module, filename: Optional[str] = "scripted_model.pt"
 ) -> None:
     """
-    Save pyTorch model to TorchScript using scripting.
+    Save PyTorch model to TorchScript using scripting.
 
     Parameters
     ----------
     model : torch.NN.Module
-        a pyTorch model
+        a PyTorch model
     filename : str
         name of file to save to
     """
@@ -36,12 +36,12 @@ def trace_to_torchscript(
     filename: Optional[str] = "traced_model.pt",
 ) -> None:
     """
-    Save pyTorch model to TorchScript using tracing.
+    Save PyTorch model to TorchScript using tracing.
 
     Parameters
     ----------
     model : torch.NN.Module
-        a pyTorch model
+        a PyTorch model
     dummy_input : torch.Tensor
         appropriate size Tensor to act as input to model
     filename : str
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     saved_ts_filename = "saved_resnet18_model_cpu.pt"
 
     # FPTLIB-TODO
-    # Save the pytorch model using either scripting (recommended where possible) or tracing
+    # Save the PyTorch model using either scripting (recommended where possible) or tracing
     # -----------
     # Scripting
     # -----------

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -194,10 +194,10 @@ contains
   end subroutine torch_tensor_delete
 
   ! Torch Module API
-  !> Loads a Torch Script module (pre-trained PyTorch model saved with Torch Script)
+  !> Loads a TorchScript module (pre-trained PyTorch model saved with TorchScript)
   function torch_module_load(filename) result(module)
     use, intrinsic :: iso_c_binding, only : c_null_char
-    character(*), intent(in) :: filename !! Filename of Torch Script module
+    character(*), intent(in) :: filename !! Filename of TorchScript module
     type(torch_module)            :: module      !! Returned deserialized module
 
     interface
@@ -244,7 +244,7 @@ contains
     call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p)
   end subroutine torch_module_forward
 
-  !> Deallocates a Torch Script module
+  !> Deallocates a TorchScript module
   subroutine torch_module_delete(module)
     type(torch_module), intent(in) :: module     !! Module to deallocate
 

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -92,28 +92,29 @@ module ftorch
 
 contains
 
-  ! Torch Tensor API
-  !| Exposes the given data as a tensor without taking ownership of the original data.
-  !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
-  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
-    type(c_ptr), intent(in)        :: data       !! Pointer to data
+  !> Returns a tensor filled with the scalar value 0.
+  function torch_tensor_zeros(ndims, tensor_shape, dtype, device) result(tensor)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
     type(torch_tensor)             :: tensor     !! Returned tensor
 
-    integer(c_int)                 :: i          !! loop index
-    integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
+    interface
+      function torch_zeros_c(ndims, tensor_shape, dtype, device) result(tensor) &
+          bind(c, name = 'torch_zeros')
+        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+        integer(c_int), value, intent(in) :: ndims
+        integer(c_int64_t), intent(in)    :: tensor_shape(*)
+        integer(c_int), value, intent(in) :: dtype
+        integer(c_int), value, intent(in) :: device
+        type(c_ptr)                       :: tensor
+      end function torch_zeros_c
+    end interface
 
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-    end do
-    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device)
-  end function torch_tensor_from_blob
+    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device)
+  end function torch_tensor_zeros
 
   !> Returns a tensor filled with the scalar value 1.
   function torch_tensor_ones(ndims, tensor_shape, dtype, device) result(tensor)
@@ -139,29 +140,28 @@ contains
     tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device)
   end function torch_tensor_ones
 
-  !> Returns a tensor filled with the scalar value 0.
-  function torch_tensor_zeros(ndims, tensor_shape, dtype, device) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
+  ! Torch Tensor API
+  !| Exposes the given data as a tensor without taking ownership of the original data.
+  !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
+  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device) result(tensor)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+    type(c_ptr), intent(in)        :: data       !! Pointer to data
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
     type(torch_tensor)             :: tensor     !! Returned tensor
 
-    interface
-      function torch_zeros_c(ndims, tensor_shape, dtype, device) result(tensor) &
-          bind(c, name = 'torch_zeros')
-        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
-        integer(c_int), value, intent(in) :: ndims
-        integer(c_int64_t), intent(in)    :: tensor_shape(*)
-        integer(c_int), value, intent(in) :: dtype
-        integer(c_int), value, intent(in) :: device
-        type(c_ptr)                       :: tensor
-      end function torch_zeros_c
-    end interface
+    integer(c_int)                 :: i          !! loop index
+    integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
 
-    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device)
-  end function torch_tensor_zeros
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
+    end do
+    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device)
+  end function torch_tensor_from_blob
 
   !> Prints the contents of a tensor.
   subroutine torch_tensor_print(tensor)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -90,28 +90,29 @@ module ftorch
 
 contains
 
-  ! Torch Tensor API
-  !| Exposes the given data as a tensor without taking ownership of the original data.
-  !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
-  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
-    type(c_ptr), intent(in)        :: data       !! Pointer to data
+  !> Returns a tensor filled with the scalar value 0.
+  function torch_tensor_zeros(ndims, tensor_shape, dtype, device) result(tensor)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
     type(torch_tensor)             :: tensor     !! Returned tensor
 
-    integer(c_int)                 :: i          !! loop index
-    integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
+    interface
+      function torch_zeros_c(ndims, tensor_shape, dtype, device) result(tensor) &
+          bind(c, name = 'torch_zeros')
+        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+        integer(c_int), value, intent(in) :: ndims
+        integer(c_int64_t), intent(in)    :: tensor_shape(*)
+        integer(c_int), value, intent(in) :: dtype
+        integer(c_int), value, intent(in) :: device
+        type(c_ptr)                       :: tensor
+      end function torch_zeros_c
+    end interface
 
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-    end do
-    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device)
-  end function torch_tensor_from_blob
+    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device)
+  end function torch_tensor_zeros
 
   !> Returns a tensor filled with the scalar value 1.
   function torch_tensor_ones(ndims, tensor_shape, dtype, device) result(tensor)
@@ -137,29 +138,28 @@ contains
     tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device)
   end function torch_tensor_ones
 
-  !> Returns a tensor filled with the scalar value 0.
-  function torch_tensor_zeros(ndims, tensor_shape, dtype, device) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
+  ! Torch Tensor API
+  !| Exposes the given data as a tensor without taking ownership of the original data.
+  !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
+  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device) result(tensor)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+    type(c_ptr), intent(in)        :: data       !! Pointer to data
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
     type(torch_tensor)             :: tensor     !! Returned tensor
 
-    interface
-      function torch_zeros_c(ndims, tensor_shape, dtype, device) result(tensor) &
-          bind(c, name = 'torch_zeros')
-        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
-        integer(c_int), value, intent(in) :: ndims
-        integer(c_int64_t), intent(in)    :: tensor_shape(*)
-        integer(c_int), value, intent(in) :: dtype
-        integer(c_int), value, intent(in) :: device
-        type(c_ptr)                       :: tensor
-      end function torch_zeros_c
-    end interface
+    integer(c_int)                 :: i          !! loop index
+    integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
 
-    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device)
-  end function torch_tensor_zeros
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
+    end do
+    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device)
+  end function torch_tensor_from_blob
 
   !> Prints the contents of a tensor.
   subroutine torch_tensor_print(tensor)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -192,10 +192,10 @@ contains
   end subroutine torch_tensor_delete
 
   ! Torch Module API
-  !> Loads a Torch Script module (pre-trained PyTorch model saved with Torch Script)
+  !> Loads a TorchScript module (pre-trained PyTorch model saved with TorchScript)
   function torch_module_load(filename) result(module)
     use, intrinsic :: iso_c_binding, only : c_null_char
-    character(*), intent(in) :: filename !! Filename of Torch Script module
+    character(*), intent(in) :: filename !! Filename of TorchScript module
     type(torch_module)            :: module      !! Returned deserialized module
 
     interface
@@ -242,7 +242,7 @@ contains
     call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p)
   end subroutine torch_module_forward
 
-  !> Deallocates a Torch Script module
+  !> Deallocates a TorchScript module
   subroutine torch_module_delete(module)
     type(torch_module), intent(in) :: module     !! Module to deallocate
 

--- a/utils/pt2ts.py
+++ b/utils/pt2ts.py
@@ -1,4 +1,4 @@
-"""Load a pytorch model and convert it to TorchScript."""
+"""Load a PyTorch model and convert it to TorchScript."""
 
 from typing import Optional
 import torch
@@ -13,12 +13,12 @@ def script_to_torchscript(
     model: torch.nn.Module, filename: Optional[str] = "scripted_model.pt"
 ) -> None:
     """
-    Save pyTorch model to TorchScript using scripting.
+    Save PyTorch model to TorchScript using scripting.
 
     Parameters
     ----------
     model : torch.NN.Module
-        a pyTorch model
+        a PyTorch model
     filename : str
         name of file to save to
     """
@@ -34,12 +34,12 @@ def trace_to_torchscript(
     filename: Optional[str] = "traced_model.pt",
 ) -> None:
     """
-    Save pyTorch model to TorchScript using tracing.
+    Save PyTorch model to TorchScript using tracing.
 
     Parameters
     ----------
     model : torch.NN.Module
-        a pyTorch model
+        a PyTorch model
     dummy_input : torch.Tensor
         appropriate size Tensor to act as input to model
     filename : str
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     saved_ts_filename = "saved_model.pt"
 
     # FPTLIB-TODO
-    # Save the pytorch model using either scripting (recommended where possible) or tracing
+    # Save the PyTorch model using either scripting (recommended where possible) or tracing
     # -----------
     # Scripting
     # -----------


### PR DESCRIPTION
Closes #90.

This PR ensures the names PyTorch and TorchScript are used consistently throughout.

It also implements a nice-to-have reordering of the Fortran subroutines so that they are consistent with the C++ functions. (Happy to revert this if it is unwanted.)