### PR TITLE
 Add options for eval and gradient required #78 - rebase

### DIFF
--- a/pages/troubleshooting.md
+++ b/pages/troubleshooting.md
@@ -22,14 +22,14 @@ In this case you must install
 You will then need to load the intel Fortran compilers using `setvars.bat`
 which is found in the Intel compiler install directory (see the 
 [intel docs](https://www.intel.com/content/www/us/en/docs/oneapi/programming-guide/2023-2/use-the-setvars-script-with-windows.html))
-for more details.\
+for more details.<br>
 From CMD this can be done with:
 ```
 "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
 ```
 
 Finally you will need to add `-G "NMake Makefiles"` to the `cmake` command in the
-[regular install instructions](doc/page/cmake.html).\
+[regular install instructions](doc/page/cmake.html).<br>
 So the basic command to build from CMD becomes:
 ```
 cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\melt\Downloads\libtorch-win-shared-with-deps-2.1.0+cpu\libtorch" -DCMAKE_BUILD_TYPE=Release ..
@@ -67,7 +67,7 @@ on locating Torch within a virtual environment (venv) for CMake.
 
 The reason input tensors to [[torch_module_forward(subroutine)]] are contained in an
 array is because it is possible to pass multiple input tensors to the `forward()`
-method of a torch net.\
+method of a torch net.<br>
 The nature of Fortran means that it is not possible to set an arbitrary number
 of inputs to the `torch_module_forward` subroutine, so instead we use an single array
 of input tensors which _can_ have an arbitrary length of `n_inputs`.
@@ -75,3 +75,11 @@ of input tensors which _can_ have an arbitrary length of `n_inputs`.
 Note that this does not refer to batching data.
 This should be done in the same way as in Torch; by extending the dimensionality of
 the input tensors.
+
+### Do I need to set torch.no_grad() or torch.eval() somewhere like in PyTorch?
+
+By default we disable gradient calculations for tensors and models and place models in
+evaluation mode for efficiency.
+These can be adjusted using the `requires_grad` and `is_training` optional arguments
+in the Fortran interface. See the [API procedures documentation](lists/procedures.html)
+for details.

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -59,6 +59,16 @@ const auto get_device(torch_device_t device_type, int device_index)
   }
 }
 
+void set_is_training(torch_jit_script_module_t module, const bool is_training)
+{
+  auto model = static_cast<torch::jit::script::Module*>(module);
+  if (is_training) {
+    model->train();
+  } else {
+    model->eval();
+  }
+}
+
 torch_tensor_t torch_zeros(int ndim, const int64_t* shape, torch_data_t dtype,
                            torch_device_t device_type, int device_index = -1, const bool requires_grad)
 {
@@ -197,11 +207,7 @@ torch_jit_script_module_t torch_jit_load(const char* filename,
     delete module;
     exit(EXIT_FAILURE);
   }
-  if (is_training) {
-    module->train();
-  } else {
-    module->eval();
-  }
+  set_is_training(module, is_training);
 
   return module;
 }

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -60,8 +60,9 @@ const auto get_device(torch_device_t device_type, int device_index)
 }
 
 torch_tensor_t torch_zeros(int ndim, const int64_t* shape, torch_data_t dtype,
-                           torch_device_t device_type, int device_index = -1)
+                           torch_device_t device_type, int device_index = -1, const bool requires_grad)
 {
+  torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor* tensor = nullptr;
   try {
     // This doesn't throw if shape and dimensions are incompatible
@@ -82,8 +83,9 @@ torch_tensor_t torch_zeros(int ndim, const int64_t* shape, torch_data_t dtype,
 }
 
 torch_tensor_t torch_ones(int ndim, const int64_t* shape, torch_data_t dtype,
-                          torch_device_t device_type, int device_index = -1)
+                          torch_device_t device_type, int device_index = -1, const bool requires_grad)
 {
+  torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor* tensor = nullptr;
   try {
     // This doesn't throw if shape and dimensions are incompatible
@@ -104,8 +106,9 @@ torch_tensor_t torch_ones(int ndim, const int64_t* shape, torch_data_t dtype,
 }
 
 torch_tensor_t torch_empty(int ndim, const int64_t* shape, torch_data_t dtype,
-                           torch_device_t device_type, int device_index = -1)
+                           torch_device_t device_type, int device_index = -1, const bool requires_grad)
 {
+  torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor* tensor = nullptr;
   try {
     // This doesn't throw if shape and dimensions are incompatible
@@ -129,8 +132,10 @@ torch_tensor_t torch_empty(int ndim, const int64_t* shape, torch_data_t dtype,
 // data
 torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
                                const int64_t* strides, torch_data_t dtype,
-                               torch_device_t device_type, int device_index = -1)
+                               torch_device_t device_type, int device_index = -1,
+                               const bool requires_grad)
 {
+  torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor* tensor = nullptr;
 
   try {
@@ -174,8 +179,11 @@ void torch_tensor_delete(torch_tensor_t tensor)
 
 torch_jit_script_module_t torch_jit_load(const char* filename,
                                          const torch_device_t device_type = torch_kCPU,
-                                         const int device_index = -1)
+                                         const int device_index = -1,
+                                         const bool requires_grad,
+                                         const bool is_training)
 {
+  torch::AutoGradMode enable_grad(requires_grad);
   torch::jit::script::Module* module = nullptr;
   try {
     module = new torch::jit::script::Module;
@@ -189,14 +197,20 @@ torch_jit_script_module_t torch_jit_load(const char* filename,
     delete module;
     exit(EXIT_FAILURE);
   }
+  if (is_training) {
+    module->train();
+  } else {
+    module->eval();
+  }
 
   return module;
 }
 
 void torch_jit_module_forward(const torch_jit_script_module_t module,
                               const torch_tensor_t *inputs, const int nin,
-			      torch_tensor_t output)
+			      torch_tensor_t output, const bool requires_grad)
 {
+  torch::AutoGradMode enable_grad(requires_grad);
   // Here we cast the pointers we recieved in to Tensor objects
   auto model = static_cast<torch::jit::script::Module*>(module);
   auto in = reinterpret_cast<torch::Tensor* const*>(inputs);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -59,7 +59,8 @@ const auto get_device(torch_device_t device_type, int device_index)
   }
 }
 
-void set_is_training(torch_jit_script_module_t module, const bool is_training)
+void set_is_training(torch_jit_script_module_t module,
+                     const bool is_training=false)
 {
   auto model = static_cast<torch::jit::script::Module*>(module);
   if (is_training) {
@@ -70,7 +71,8 @@ void set_is_training(torch_jit_script_module_t module, const bool is_training)
 }
 
 torch_tensor_t torch_zeros(int ndim, const int64_t* shape, torch_data_t dtype,
-                           torch_device_t device_type, int device_index = -1, const bool requires_grad)
+                           torch_device_t device_type, int device_index = -1,
+                           const bool requires_grad=false)
 {
   torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor* tensor = nullptr;
@@ -93,7 +95,8 @@ torch_tensor_t torch_zeros(int ndim, const int64_t* shape, torch_data_t dtype,
 }
 
 torch_tensor_t torch_ones(int ndim, const int64_t* shape, torch_data_t dtype,
-                          torch_device_t device_type, int device_index = -1, const bool requires_grad)
+                          torch_device_t device_type, int device_index = -1,
+                          const bool requires_grad=false)
 {
   torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor* tensor = nullptr;
@@ -116,7 +119,8 @@ torch_tensor_t torch_ones(int ndim, const int64_t* shape, torch_data_t dtype,
 }
 
 torch_tensor_t torch_empty(int ndim, const int64_t* shape, torch_data_t dtype,
-                           torch_device_t device_type, int device_index = -1, const bool requires_grad)
+                           torch_device_t device_type, int device_index = -1,
+                           const bool requires_grad=false)
 {
   torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor* tensor = nullptr;
@@ -143,7 +147,7 @@ torch_tensor_t torch_empty(int ndim, const int64_t* shape, torch_data_t dtype,
 torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
                                const int64_t* strides, torch_data_t dtype,
                                torch_device_t device_type, int device_index = -1,
-                               const bool requires_grad)
+                               const bool requires_grad=false)
 {
   torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor* tensor = nullptr;
@@ -190,8 +194,8 @@ void torch_tensor_delete(torch_tensor_t tensor)
 torch_jit_script_module_t torch_jit_load(const char* filename,
                                          const torch_device_t device_type = torch_kCPU,
                                          const int device_index = -1,
-                                         const bool requires_grad,
-                                         const bool is_training)
+                                         const bool requires_grad=false,
+                                         const bool is_training=false)
 {
   torch::AutoGradMode enable_grad(requires_grad);
   torch::jit::script::Module* module = nullptr;
@@ -214,7 +218,7 @@ torch_jit_script_module_t torch_jit_load(const char* filename,
 
 void torch_jit_module_forward(const torch_jit_script_module_t module,
                               const torch_tensor_t *inputs, const int nin,
-			      torch_tensor_t output, const bool requires_grad)
+			                        torch_tensor_t output, const bool requires_grad=false)
 {
   torch::AutoGradMode enable_grad(requires_grad);
   // Here we cast the pointers we recieved in to Tensor objects

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -218,7 +218,7 @@ torch_jit_script_module_t torch_jit_load(const char* filename,
 
 void torch_jit_module_forward(const torch_jit_script_module_t module,
                               const torch_tensor_t *inputs, const int nin,
-			                        torch_tensor_t output, const bool requires_grad=false)
+                              torch_tensor_t output, const bool requires_grad=false)
 {
   torch::AutoGradMode enable_grad(requires_grad);
   // Here we cast the pointers we recieved in to Tensor objects

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -39,10 +39,11 @@ typedef enum { torch_kCPU, torch_kCUDA } torch_device_t;
  * @param data type of the elements of the Tensor
  * @param device type used (cpu, CUDA, etc.)
  * @param device index for the CUDA case
+ * @param whether gradient is required
  */
 EXPORT_C torch_tensor_t torch_zeros(int ndim, const int64_t* shape,
                                     torch_data_t dtype, torch_device_t device_type,
-                                    int device_index);
+                                    int device_index, const bool requires_grad);
 
 /**
  * Function to generate a Torch Tensor of ones
@@ -51,10 +52,11 @@ EXPORT_C torch_tensor_t torch_zeros(int ndim, const int64_t* shape,
  * @param data type of the elements of the Tensor
  * @param device type used (cpu, CUDA, etc.)
  * @param device index for the CUDA case
+ * @param whether gradient is required
  */
 EXPORT_C torch_tensor_t torch_ones(int ndim, const int64_t* shape,
                                    torch_data_t dtype, torch_device_t device_type,
-                                   int device_index);
+                                   int device_index, const bool requires_grad);
 
 /**
  * Function to generate an empty Torch Tensor
@@ -63,10 +65,11 @@ EXPORT_C torch_tensor_t torch_ones(int ndim, const int64_t* shape,
  * @param data type of the elements of the Tensor
  * @param device type used (cpu, CUDA, etc.)
  * @param device index for the CUDA case
+ * @param whether gradient is required
  */
 EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t* shape,
                                     torch_data_t dtype, torch_device_t device_type,
-                                    int device_index);
+                                    int device_index, const bool requires_grad);
 
 /**
  * Function to create a Torch Tensor from memory location given extra information
@@ -77,6 +80,7 @@ EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t* shape,
  * @param data type of the elements of the Tensor
  * @param device type used (cpu, CUDA, etc.)
  * @param device index for the CUDA case
+ * @param whether gradient is required
  * @return Torch Tensor interpretation of the data pointed at
  */
 EXPORT_C torch_tensor_t torch_from_blob(void* data, int ndim,
@@ -84,7 +88,8 @@ EXPORT_C torch_tensor_t torch_from_blob(void* data, int ndim,
                                         const int64_t* strides,
                                         torch_data_t dtype,
                                         torch_device_t device_type,
-                                        int device_index);
+                                        int device_index,
+                                        const bool requires_grad);
 
 /**
  * Function to print out a Torch Tensor
@@ -114,11 +119,15 @@ EXPORT_C void torch_tensor_delete(torch_tensor_t tensor);
  * @param filename where TorchScript description of model is stored
  * @param device type used (cpu, CUDA, etc.)
  * @param device index for the CUDA case
+ * @param whether gradient is required
+ * @param whether model is being trained
  * @return Torch Module loaded in from file
  */
 EXPORT_C torch_jit_script_module_t torch_jit_load(const char* filename,
                                                   const torch_device_t device_type,
-                                                  const int device_index);
+                                                  const int device_index,
+                                                  const bool requires_grad,
+                                                  const bool is_training);
 
 /**
  * Function to run the `forward` method of a Torch Module
@@ -126,10 +135,11 @@ EXPORT_C torch_jit_script_module_t torch_jit_load(const char* filename,
  * @param vector of Torch Tensors as inputs to the model
  * @param number of input Tensors in the input vector
  * @param the output Tensor from running the model
+ * @param whether gradient is required
  */
 EXPORT_C void torch_jit_module_forward(const torch_jit_script_module_t module,
                                        const torch_tensor_t *inputs, const int nin,
-                                       torch_tensor_t output);
+                                       torch_tensor_t output, const bool requires_grad);
 
 /**
  * Function to delete a Torch Module to clean up

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -206,6 +206,12 @@ contains
     integer(c_int)                 :: device_index_value  !! device index used
     logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
     strides(layout(1)) = 1
     do i = 2, ndims
       strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
@@ -385,7 +391,7 @@ contains
   end subroutine torch_module_delete
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int8`
-  function torch_tensor_from_array_int8_1d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int8_1d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int8
 
@@ -435,7 +441,7 @@ contains
   end function torch_tensor_from_array_int8_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int8`
-  function torch_tensor_from_array_int8_2d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int8_2d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int8
 
@@ -485,7 +491,7 @@ contains
   end function torch_tensor_from_array_int8_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int8`
-  function torch_tensor_from_array_int8_3d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int8_3d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int8
 
@@ -535,7 +541,7 @@ contains
   end function torch_tensor_from_array_int8_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int8`
-  function torch_tensor_from_array_int8_4d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int8_4d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int8
 
@@ -585,7 +591,7 @@ contains
   end function torch_tensor_from_array_int8_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int16`
-  function torch_tensor_from_array_int16_1d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int16_1d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int16
 
@@ -635,7 +641,7 @@ contains
   end function torch_tensor_from_array_int16_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int16`
-  function torch_tensor_from_array_int16_2d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int16_2d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int16
 
@@ -685,7 +691,7 @@ contains
   end function torch_tensor_from_array_int16_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int16`
-  function torch_tensor_from_array_int16_3d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int16_3d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int16
 
@@ -735,7 +741,7 @@ contains
   end function torch_tensor_from_array_int16_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int16`
-  function torch_tensor_from_array_int16_4d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int16_4d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int16
 
@@ -785,7 +791,7 @@ contains
   end function torch_tensor_from_array_int16_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int32`
-  function torch_tensor_from_array_int32_1d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int32_1d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int32
 
@@ -835,7 +841,7 @@ contains
   end function torch_tensor_from_array_int32_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int32`
-  function torch_tensor_from_array_int32_2d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int32_2d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int32
 
@@ -885,7 +891,7 @@ contains
   end function torch_tensor_from_array_int32_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int32`
-  function torch_tensor_from_array_int32_3d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int32_3d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int32
 
@@ -935,7 +941,7 @@ contains
   end function torch_tensor_from_array_int32_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int32`
-  function torch_tensor_from_array_int32_4d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int32_4d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int32
 
@@ -985,7 +991,7 @@ contains
   end function torch_tensor_from_array_int32_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int64`
-  function torch_tensor_from_array_int64_1d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int64_1d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int64
 
@@ -1035,7 +1041,7 @@ contains
   end function torch_tensor_from_array_int64_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int64`
-  function torch_tensor_from_array_int64_2d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int64_2d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int64
 
@@ -1085,7 +1091,7 @@ contains
   end function torch_tensor_from_array_int64_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int64`
-  function torch_tensor_from_array_int64_3d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int64_3d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int64
 
@@ -1135,7 +1141,7 @@ contains
   end function torch_tensor_from_array_int64_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int64`
-  function torch_tensor_from_array_int64_4d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_int64_4d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int64
 
@@ -1185,7 +1191,7 @@ contains
   end function torch_tensor_from_array_int64_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `real32`
-  function torch_tensor_from_array_real32_1d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_real32_1d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real32
 
@@ -1235,7 +1241,7 @@ contains
   end function torch_tensor_from_array_real32_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `real32`
-  function torch_tensor_from_array_real32_2d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_real32_2d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real32
 
@@ -1285,7 +1291,7 @@ contains
   end function torch_tensor_from_array_real32_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `real32`
-  function torch_tensor_from_array_real32_3d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_real32_3d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real32
 
@@ -1335,7 +1341,7 @@ contains
   end function torch_tensor_from_array_real32_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `real32`
-  function torch_tensor_from_array_real32_4d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_real32_4d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real32
 
@@ -1385,7 +1391,7 @@ contains
   end function torch_tensor_from_array_real32_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `real64`
-  function torch_tensor_from_array_real64_1d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_real64_1d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real64
 
@@ -1435,7 +1441,7 @@ contains
   end function torch_tensor_from_array_real64_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `real64`
-  function torch_tensor_from_array_real64_2d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_real64_2d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real64
 
@@ -1485,7 +1491,7 @@ contains
   end function torch_tensor_from_array_real64_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `real64`
-  function torch_tensor_from_array_real64_3d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_real64_3d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real64
 
@@ -1535,7 +1541,7 @@ contains
   end function torch_tensor_from_array_real64_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `real64`
-  function torch_tensor_from_array_real64_4d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_real64_4d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real64
 

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -75,9 +75,11 @@ module ftorch
   end interface
 
   interface
-    function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device_type, device_index) result(tensor_p) &
+    function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, &
+                               device_type, device_index, &
+                               requires_grad) result(tensor_p) &
                                bind(c, name = 'torch_from_blob')
-      use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+      use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr, c_bool
 
       ! Arguments
       type(c_ptr), value, intent(in)    :: data
@@ -87,6 +89,7 @@ module ftorch
       integer(c_int), value, intent(in) :: dtype
       integer(c_int), value, intent(in) :: device_type
       integer(c_int), value, intent(in) :: device_index
+      logical(c_bool), value, intent(in) :: requires_grad
       type(c_ptr)                       :: tensor_p
     end function torch_from_blob_c
   end interface
@@ -94,25 +97,28 @@ module ftorch
 contains
 
   !> Returns a tensor filled with the scalar value 0.
-  function torch_tensor_zeros(ndims, tensor_shape, dtype, device_type, device_index) result(tensor)
+  function torch_tensor_zeros(ndims, tensor_shape, dtype, device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
     integer(c_int)                 :: device_index_value  !! device index used
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     interface
-      function torch_zeros_c(ndims, tensor_shape, dtype, device_type, device_index) result(tensor) &
+      function torch_zeros_c(ndims, tensor_shape, dtype, device_type, device_index, requires_grad) result(tensor) &
           bind(c, name = 'torch_zeros')
-        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr, c_bool
         integer(c_int), value, intent(in) :: ndims
         integer(c_int64_t), intent(in)    :: tensor_shape(*)
         integer(c_int), value, intent(in) :: dtype
         integer(c_int), value, intent(in) :: device_type
         integer(c_int), value, intent(in) :: device_index
+        logical(c_bool), value, intent(in) :: requires_grad
         type(c_ptr)                       :: tensor
       end function torch_zeros_c
     end interface
@@ -126,22 +132,30 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device_type, device_index_value, requires_grad)
   end function torch_tensor_zeros
 
   !> Returns a tensor filled with the scalar value 1.
-  function torch_tensor_ones(ndims, tensor_shape, dtype, device_type, device_index) result(tensor)
+  function torch_tensor_ones(ndims, tensor_shape, dtype, device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
     integer(c_int)                 :: device_index_value  !! device index used
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     interface
-      function torch_ones_c(ndims, tensor_shape, dtype, device_type, device_index) result(tensor) &
+      function torch_ones_c(ndims, tensor_shape, dtype, device_type, device_index, requires_grad) result(tensor) &
           bind(c, name = 'torch_ones')
         use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
         integer(c_int), value, intent(in) :: ndims
@@ -149,6 +163,7 @@ contains
         integer(c_int), value, intent(in) :: dtype
         integer(c_int), value, intent(in) :: device_type
         integer(c_int), value, intent(in) :: device_index
+        logical(c_bool), value, intent(in) :: requires_grad
         type(c_ptr)                       :: tensor
       end function torch_ones_c
     end interface
@@ -162,26 +177,34 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device_type, device_index_value, requires_grad)
   end function torch_tensor_ones
 
   ! Torch Tensor API
   !| Exposes the given data as a tensor without taking ownership of the original data.
   !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
-  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device_type, device_index) result(tensor)
+  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
     type(c_ptr), intent(in)        :: data       !! Pointer to data
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
+    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
-    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
 
     integer(c_int)                 :: i          !! loop index
     integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
     integer(c_int)                 :: device_index_value  !! device index used
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     strides(layout(1)) = 1
     do i = 2, ndims
@@ -197,7 +220,7 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device_type, device_index_value)
+    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device_type, device_index_value, requires_grad)
   end function torch_tensor_from_blob
 
   !> Prints the contents of a tensor.
@@ -250,22 +273,28 @@ contains
 
   ! Torch Module API
   !> Loads a TorchScript module (pre-trained PyTorch model saved with TorchScript)
-  function torch_module_load(filename, device_type, device_index) result(module)
+  function torch_module_load(filename, device_type, device_index, requires_grad_opt, is_training_opt) result(module)
     use, intrinsic :: iso_c_binding, only : c_int, c_null_char
     character(*), intent(in)   :: filename !! Filename of TorchScript module
     integer(c_int), optional, intent(in) :: device_type !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index !! device index to use for `torch_kCUDA` case
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_module)         :: module   !! Returned deserialized module
     integer(c_int) :: device_type_value
     integer(c_int) :: device_index_value
+    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool) :: is_training  !! Whether the model is being trained, rather than evaluated
 
     interface
-      function torch_jit_load_c(filename, device_type, device_index) result(module) &
+      function torch_jit_load_c(filename, device_type, device_index, requires_grad, is_training) result(module) &
           bind(c, name = 'torch_jit_load')
-        use, intrinsic :: iso_c_binding, only : c_char, c_int, c_ptr
+        use, intrinsic :: iso_c_binding, only : c_char, c_int, c_ptr, c_bool
         character(c_char), intent(in) :: filename(*)
         integer(c_int), value, intent(in)    :: device_type
         integer(c_int), value, intent(in)    :: device_index
+        logical(c_bool), value, intent(in) :: requires_grad
+        logical(c_bool), value, intent(in) :: is_training
         type(c_ptr)                   :: module
       end function torch_jit_load_c
     end interface
@@ -284,39 +313,60 @@ contains
       device_index_value = 0
     endif
 
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    if (.not. present(is_training_opt)) then
+      is_training = logical(.false., c_bool)
+    else
+      is_training = is_training_opt
+    end if
+
     ! Need to append c_null_char at end of filename
-    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, device_type_value, device_index_value)
+    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, device_type_value, device_index_value, requires_grad, is_training)
   end function torch_module_load
 
   !> Performs a forward pass of the module with the input tensors
-  subroutine torch_module_forward(module, input_tensors, n_inputs, output_tensor)
-    use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_loc
+  subroutine torch_module_forward(module, input_tensors, n_inputs, output_tensor, requires_grad_opt)
+    use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_loc, c_bool
     type(torch_module), intent(in) :: module        !! Module
     type(torch_tensor), intent(in), dimension(:) :: input_tensors  !! Array of Input tensors
     type(torch_tensor), intent(in) :: output_tensor !! Returned output tensors
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     integer(c_int) ::  n_inputs
+    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer :: i
     type(c_ptr), dimension(n_inputs), target  :: input_ptrs
 
     interface
       subroutine torch_jit_module_forward_c(module, input_tensors, n_inputs, &
-          output_tensor) &
+          output_tensor, requires_grad) &
           bind(c, name = 'torch_jit_module_forward')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int
+        use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_bool
         type(c_ptr), value, intent(in) :: module
         type(c_ptr), value, intent(in) :: input_tensors
         integer(c_int), value, intent(in) :: n_inputs
         type(c_ptr), value, intent(in) :: output_tensor
+        logical(c_bool), value, intent(in) :: requires_grad
       end subroutine torch_jit_module_forward_c
     end interface
+
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
 
     ! Assign array of pointers to the input tensors
     do i = 1, n_inputs
       input_ptrs(i) = input_tensors(i)%p
     end do
 
-    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p)
+    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, requires_grad)
   end subroutine torch_module_forward
 
   !> Deallocates a TorchScript module
@@ -336,7 +386,7 @@ contains
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int8`
   function torch_tensor_from_array_int8_1d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! inputs
@@ -344,6 +394,7 @@ contains
     integer, intent(in)        :: layout(1) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -355,13 +406,7 @@ contains
     integer(c_int), parameter :: ndims = 1                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -372,13 +417,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int8_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int8`
   function torch_tensor_from_array_int8_2d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! inputs
@@ -386,6 +444,7 @@ contains
     integer, intent(in)        :: layout(2) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -397,13 +456,7 @@ contains
     integer(c_int), parameter :: ndims = 2                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -414,13 +467,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int8_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int8`
   function torch_tensor_from_array_int8_3d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! inputs
@@ -428,6 +494,7 @@ contains
     integer, intent(in)        :: layout(3) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -439,13 +506,7 @@ contains
     integer(c_int), parameter :: ndims = 3                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -456,13 +517,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int8_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int8`
   function torch_tensor_from_array_int8_4d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! inputs
@@ -470,6 +544,7 @@ contains
     integer, intent(in)        :: layout(4) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -481,13 +556,7 @@ contains
     integer(c_int), parameter :: ndims = 4                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -498,13 +567,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int8_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int16`
   function torch_tensor_from_array_int16_1d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! inputs
@@ -512,6 +594,7 @@ contains
     integer, intent(in)        :: layout(1) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -523,13 +606,7 @@ contains
     integer(c_int), parameter :: ndims = 1                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -540,13 +617,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int16_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int16`
   function torch_tensor_from_array_int16_2d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! inputs
@@ -554,6 +644,7 @@ contains
     integer, intent(in)        :: layout(2) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -565,13 +656,7 @@ contains
     integer(c_int), parameter :: ndims = 2                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -582,13 +667,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int16_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int16`
   function torch_tensor_from_array_int16_3d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! inputs
@@ -596,6 +694,7 @@ contains
     integer, intent(in)        :: layout(3) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -607,13 +706,7 @@ contains
     integer(c_int), parameter :: ndims = 3                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -624,13 +717,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int16_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int16`
   function torch_tensor_from_array_int16_4d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! inputs
@@ -638,6 +744,7 @@ contains
     integer, intent(in)        :: layout(4) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -649,13 +756,7 @@ contains
     integer(c_int), parameter :: ndims = 4                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -666,13 +767,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int16_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int32`
   function torch_tensor_from_array_int32_1d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! inputs
@@ -680,6 +794,7 @@ contains
     integer, intent(in)        :: layout(1) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -691,13 +806,7 @@ contains
     integer(c_int), parameter :: ndims = 1                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -708,13 +817,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int32_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int32`
   function torch_tensor_from_array_int32_2d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! inputs
@@ -722,6 +844,7 @@ contains
     integer, intent(in)        :: layout(2) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -733,13 +856,7 @@ contains
     integer(c_int), parameter :: ndims = 2                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -750,13 +867,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int32_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int32`
   function torch_tensor_from_array_int32_3d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! inputs
@@ -764,6 +894,7 @@ contains
     integer, intent(in)        :: layout(3) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -775,13 +906,7 @@ contains
     integer(c_int), parameter :: ndims = 3                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -792,13 +917,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int32_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int32`
   function torch_tensor_from_array_int32_4d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! inputs
@@ -806,6 +944,7 @@ contains
     integer, intent(in)        :: layout(4) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -817,13 +956,7 @@ contains
     integer(c_int), parameter :: ndims = 4                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -834,13 +967,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int32_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int64`
   function torch_tensor_from_array_int64_1d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! inputs
@@ -848,6 +994,7 @@ contains
     integer, intent(in)        :: layout(1) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -859,13 +1006,7 @@ contains
     integer(c_int), parameter :: ndims = 1                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -876,13 +1017,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int64_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int64`
   function torch_tensor_from_array_int64_2d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! inputs
@@ -890,6 +1044,7 @@ contains
     integer, intent(in)        :: layout(2) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -901,13 +1056,7 @@ contains
     integer(c_int), parameter :: ndims = 2                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -918,13 +1067,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int64_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int64`
   function torch_tensor_from_array_int64_3d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! inputs
@@ -932,6 +1094,7 @@ contains
     integer, intent(in)        :: layout(3) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -943,13 +1106,7 @@ contains
     integer(c_int), parameter :: ndims = 3                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -960,13 +1117,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int64_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int64`
   function torch_tensor_from_array_int64_4d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! inputs
@@ -974,6 +1144,7 @@ contains
     integer, intent(in)        :: layout(4) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -985,13 +1156,7 @@ contains
     integer(c_int), parameter :: ndims = 4                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1002,13 +1167,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_int64_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `real32`
   function torch_tensor_from_array_real32_1d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! inputs
@@ -1016,6 +1194,7 @@ contains
     integer, intent(in)        :: layout(1) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -1027,13 +1206,7 @@ contains
     integer(c_int), parameter :: ndims = 1                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1044,13 +1217,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_real32_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `real32`
   function torch_tensor_from_array_real32_2d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! inputs
@@ -1058,6 +1244,7 @@ contains
     integer, intent(in)        :: layout(2) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -1069,13 +1256,7 @@ contains
     integer(c_int), parameter :: ndims = 2                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1086,13 +1267,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_real32_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `real32`
   function torch_tensor_from_array_real32_3d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! inputs
@@ -1100,6 +1294,7 @@ contains
     integer, intent(in)        :: layout(3) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -1111,13 +1306,7 @@ contains
     integer(c_int), parameter :: ndims = 3                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1128,13 +1317,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_real32_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `real32`
   function torch_tensor_from_array_real32_4d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! inputs
@@ -1142,6 +1344,7 @@ contains
     integer, intent(in)        :: layout(4) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -1153,13 +1356,7 @@ contains
     integer(c_int), parameter :: ndims = 4                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1170,13 +1367,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_real32_4d
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `real64`
   function torch_tensor_from_array_real64_1d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! inputs
@@ -1184,6 +1394,7 @@ contains
     integer, intent(in)        :: layout(1) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -1195,13 +1406,7 @@ contains
     integer(c_int), parameter :: ndims = 1                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1212,13 +1417,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_real64_1d
 
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `real64`
   function torch_tensor_from_array_real64_2d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! inputs
@@ -1226,6 +1444,7 @@ contains
     integer, intent(in)        :: layout(2) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -1237,13 +1456,7 @@ contains
     integer(c_int), parameter :: ndims = 2                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1254,13 +1467,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_real64_2d
 
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `real64`
   function torch_tensor_from_array_real64_3d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! inputs
@@ -1268,6 +1494,7 @@ contains
     integer, intent(in)        :: layout(3) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -1279,13 +1506,7 @@ contains
     integer(c_int), parameter :: ndims = 3                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1296,13 +1517,26 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_real64_3d
 
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `real64`
   function torch_tensor_from_array_real64_4d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! inputs
@@ -1310,6 +1544,7 @@ contains
     integer, intent(in)        :: layout(4) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -1321,13 +1556,7 @@ contains
     integer(c_int), parameter :: ndims = 4                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -1338,7 +1567,20 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_real64_4d
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -73,9 +73,11 @@ module ftorch
   end interface
 
   interface
-    function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device_type, device_index) result(tensor_p) &
+    function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, &
+                               device_type, device_index, &
+                               requires_grad) result(tensor_p) &
                                bind(c, name = 'torch_from_blob')
-      use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+      use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr, c_bool
 
       ! Arguments
       type(c_ptr), value, intent(in)    :: data
@@ -85,6 +87,7 @@ module ftorch
       integer(c_int), value, intent(in) :: dtype
       integer(c_int), value, intent(in) :: device_type
       integer(c_int), value, intent(in) :: device_index
+      logical(c_bool), value, intent(in) :: requires_grad
       type(c_ptr)                       :: tensor_p
     end function torch_from_blob_c
   end interface
@@ -92,25 +95,28 @@ module ftorch
 contains
 
   !> Returns a tensor filled with the scalar value 0.
-  function torch_tensor_zeros(ndims, tensor_shape, dtype, device_type, device_index) result(tensor)
+  function torch_tensor_zeros(ndims, tensor_shape, dtype, device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
     integer(c_int)                 :: device_index_value  !! device index used
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     interface
-      function torch_zeros_c(ndims, tensor_shape, dtype, device_type, device_index) result(tensor) &
+      function torch_zeros_c(ndims, tensor_shape, dtype, device_type, device_index, requires_grad) result(tensor) &
           bind(c, name = 'torch_zeros')
-        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr, c_bool
         integer(c_int), value, intent(in) :: ndims
         integer(c_int64_t), intent(in)    :: tensor_shape(*)
         integer(c_int), value, intent(in) :: dtype
         integer(c_int), value, intent(in) :: device_type
         integer(c_int), value, intent(in) :: device_index
+        logical(c_bool), value, intent(in) :: requires_grad
         type(c_ptr)                       :: tensor
       end function torch_zeros_c
     end interface
@@ -124,22 +130,30 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device_type, device_index_value, requires_grad)
   end function torch_tensor_zeros
 
   !> Returns a tensor filled with the scalar value 1.
-  function torch_tensor_ones(ndims, tensor_shape, dtype, device_type, device_index) result(tensor)
+  function torch_tensor_ones(ndims, tensor_shape, dtype, device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
     integer(c_int)                 :: device_index_value  !! device index used
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     interface
-      function torch_ones_c(ndims, tensor_shape, dtype, device_type, device_index) result(tensor) &
+      function torch_ones_c(ndims, tensor_shape, dtype, device_type, device_index, requires_grad) result(tensor) &
           bind(c, name = 'torch_ones')
         use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
         integer(c_int), value, intent(in) :: ndims
@@ -147,6 +161,7 @@ contains
         integer(c_int), value, intent(in) :: dtype
         integer(c_int), value, intent(in) :: device_type
         integer(c_int), value, intent(in) :: device_index
+        logical(c_bool), value, intent(in) :: requires_grad
         type(c_ptr)                       :: tensor
       end function torch_ones_c
     end interface
@@ -160,26 +175,34 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device_type, device_index_value, requires_grad)
   end function torch_tensor_ones
 
   ! Torch Tensor API
   !| Exposes the given data as a tensor without taking ownership of the original data.
   !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
-  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device_type, device_index) result(tensor)
+  function torch_tensor_from_blob(data, ndims, tensor_shape, layout, dtype, device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
     type(c_ptr), intent(in)        :: data       !! Pointer to data
     integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
     integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
+    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
     integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)     :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
-    integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_tensor)             :: tensor     !! Returned tensor
 
     integer(c_int)                 :: i          !! loop index
     integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
     integer(c_int)                 :: device_index_value  !! device index used
+    logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     strides(layout(1)) = 1
     do i = 2, ndims
@@ -195,7 +218,7 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device_type, device_index_value)
+    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device_type, device_index_value, requires_grad)
   end function torch_tensor_from_blob
 
   !> Prints the contents of a tensor.
@@ -248,22 +271,28 @@ contains
 
   ! Torch Module API
   !> Loads a TorchScript module (pre-trained PyTorch model saved with TorchScript)
-  function torch_module_load(filename, device_type, device_index) result(module)
+  function torch_module_load(filename, device_type, device_index, requires_grad_opt, is_training_opt) result(module)
     use, intrinsic :: iso_c_binding, only : c_int, c_null_char
     character(*), intent(in)   :: filename !! Filename of TorchScript module
     integer(c_int), optional, intent(in) :: device_type !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index !! device index to use for `torch_kCUDA` case
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_module)         :: module   !! Returned deserialized module
     integer(c_int) :: device_type_value
     integer(c_int) :: device_index_value
+    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool) :: is_training  !! Whether the model is being trained, rather than evaluated
 
     interface
-      function torch_jit_load_c(filename, device_type, device_index) result(module) &
+      function torch_jit_load_c(filename, device_type, device_index, requires_grad, is_training) result(module) &
           bind(c, name = 'torch_jit_load')
-        use, intrinsic :: iso_c_binding, only : c_char, c_int, c_ptr
+        use, intrinsic :: iso_c_binding, only : c_char, c_int, c_ptr, c_bool
         character(c_char), intent(in) :: filename(*)
         integer(c_int), value, intent(in)    :: device_type
         integer(c_int), value, intent(in)    :: device_index
+        logical(c_bool), value, intent(in) :: requires_grad
+        logical(c_bool), value, intent(in) :: is_training
         type(c_ptr)                   :: module
       end function torch_jit_load_c
     end interface
@@ -282,39 +311,60 @@ contains
       device_index_value = 0
     endif
 
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    if (.not. present(is_training_opt)) then
+      is_training = logical(.false., c_bool)
+    else
+      is_training = is_training_opt
+    end if
+
     ! Need to append c_null_char at end of filename
-    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, device_type_value, device_index_value)
+    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, device_type_value, device_index_value, requires_grad, is_training)
   end function torch_module_load
 
   !> Performs a forward pass of the module with the input tensors
-  subroutine torch_module_forward(module, input_tensors, n_inputs, output_tensor)
-    use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_loc
+  subroutine torch_module_forward(module, input_tensors, n_inputs, output_tensor, requires_grad_opt)
+    use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_loc, c_bool
     type(torch_module), intent(in) :: module        !! Module
     type(torch_tensor), intent(in), dimension(:) :: input_tensors  !! Array of Input tensors
     type(torch_tensor), intent(in) :: output_tensor !! Returned output tensors
+    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     integer(c_int) ::  n_inputs
+    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer :: i
     type(c_ptr), dimension(n_inputs), target  :: input_ptrs
 
     interface
       subroutine torch_jit_module_forward_c(module, input_tensors, n_inputs, &
-          output_tensor) &
+          output_tensor, requires_grad) &
           bind(c, name = 'torch_jit_module_forward')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int
+        use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_bool
         type(c_ptr), value, intent(in) :: module
         type(c_ptr), value, intent(in) :: input_tensors
         integer(c_int), value, intent(in) :: n_inputs
         type(c_ptr), value, intent(in) :: output_tensor
+        logical(c_bool), value, intent(in) :: requires_grad
       end subroutine torch_jit_module_forward_c
     end interface
+
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
 
     ! Assign array of pointers to the input tensors
     do i = 1, n_inputs
       input_ptrs(i) = input_tensors(i)%p
     end do
 
-    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p)
+    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, requires_grad)
   end subroutine torch_module_forward
 
   !> Deallocates a TorchScript module
@@ -336,7 +386,7 @@ contains
   #:for RANK in RANKS
   !> Return a Torch tensor pointing to data_in array of rank ${RANK}$ containing data of type `${PREC}$`
   function torch_tensor_from_array_${PREC}$_${RANK}$d(data_in, layout, c_device_type, device_index) result(tensor)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : ${PREC}$
 
     ! inputs
@@ -344,6 +394,7 @@ contains
     integer, intent(in)        :: layout(${RANK}$) !! Control order of indices
     integer(c_int), intent(in) :: c_device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
 
     ! output tensory
     type(torch_tensor) :: tensor     !! Returned tensor
@@ -355,13 +406,7 @@ contains
     integer(c_int), parameter :: ndims = ${RANK}$                   !! Number of dimension of input data
     integer                   :: i
     integer(c_int)            :: device_index_value
-
-    c_tensor_shape = shape(data_in)
-
-    strides(layout(1)) = 1
-    do i = 2, ndims
-      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
-    end do
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -372,7 +417,20 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value)
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = .false.
+    else
+      requires_grad = requires_grad_opt
+    end if
+
+    c_tensor_shape = shape(data_in)
+
+    strides(layout(1)) = 1
+    do i = 2, ndims
+      strides(layout(i)) = strides(layout(i - 1)) * c_tensor_shape(layout(i - 1))
+    end do
+
+    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, c_tensor_shape, strides, c_dtype, c_device_type, device_index_value, logical(requires_grad, c_bool))
 
   end function torch_tensor_from_array_${PREC}$_${RANK}$d
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -276,13 +276,13 @@ contains
     character(*), intent(in)   :: filename !! Filename of TorchScript module
     integer(c_int), optional, intent(in) :: device_type !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
-    logical(c_bool), optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: is_training_opt  !! Whether gradients need to be computed for the created tensor
     type(torch_module)         :: module   !! Returned deserialized module
     integer(c_int) :: device_type_value
     integer(c_int) :: device_index_value
-    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
-    logical(c_bool) :: is_training  !! Whether the model is being trained, rather than evaluated
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical :: is_training  !! Whether the model is being trained, rather than evaluated
 
     interface
       function torch_jit_load_c(filename, device_type, device_index, requires_grad, is_training) result(module) &
@@ -312,19 +312,19 @@ contains
     endif
 
     if (.not. present(requires_grad_opt)) then
-      requires_grad = logical(.false., c_bool)
+      requires_grad = .false.
     else
       requires_grad = requires_grad_opt
     end if
 
     if (.not. present(is_training_opt)) then
-      is_training = logical(.false., c_bool)
+      is_training = .false.
     else
       is_training = is_training_opt
     end if
 
     ! Need to append c_null_char at end of filename
-    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, device_type_value, device_index_value, requires_grad, is_training)
+    module%p = torch_jit_load_c(trim(adjustl(filename))//c_null_char, device_type_value, device_index_value, logical(requires_grad, c_bool), logical(is_training, c_bool))
   end function torch_module_load
 
   !> Performs a forward pass of the module with the input tensors
@@ -333,9 +333,9 @@ contains
     type(torch_module), intent(in) :: module        !! Module
     type(torch_tensor), intent(in), dimension(:) :: input_tensors  !! Array of Input tensors
     type(torch_tensor), intent(in) :: output_tensor !! Returned output tensors
-    logical(c_bool), optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad_opt  !! Whether gradients need to be computed for the created tensor
     integer(c_int) ::  n_inputs
-    logical(c_bool) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer :: i
     type(c_ptr), dimension(n_inputs), target  :: input_ptrs
@@ -354,7 +354,7 @@ contains
     end interface
 
     if (.not. present(requires_grad_opt)) then
-      requires_grad = logical(.false., c_bool)
+      requires_grad = .false.
     else
       requires_grad = requires_grad_opt
     end if
@@ -364,7 +364,7 @@ contains
       input_ptrs(i) = input_tensors(i)%p
     end do
 
-    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, requires_grad)
+    call torch_jit_module_forward_c(module%p, c_loc(input_ptrs), n_inputs, output_tensor%p, logical(requires_grad, c_bool))
   end subroutine torch_module_forward
 
   !> Deallocates a TorchScript module

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -204,6 +204,12 @@ contains
     integer(c_int)                 :: device_index_value  !! device index used
     logical(c_bool)                :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
+    if (.not. present(requires_grad_opt)) then
+      requires_grad = logical(.false., c_bool)
+    else
+      requires_grad = requires_grad_opt
+    end if
+
     strides(layout(1)) = 1
     do i = 2, ndims
       strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
@@ -385,7 +391,7 @@ contains
   #:for PREC in PRECISIONS
   #:for RANK in RANKS
   !> Return a Torch tensor pointing to data_in array of rank ${RANK}$ containing data of type `${PREC}$`
-  function torch_tensor_from_array_${PREC}$_${RANK}$d(data_in, layout, c_device_type, device_index) result(tensor)
+  function torch_tensor_from_array_${PREC}$_${RANK}$d(data_in, layout, c_device_type, device_index, requires_grad_opt) result(tensor)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_float, c_loc, c_bool
     use, intrinsic :: iso_fortran_env, only : ${PREC}$
 


### PR DESCRIPTION
This is an updated version of #78 rebased onto main after the GPU changes by @jwallwork23

@ElliottKasoar's comment on the original PR:

Resolves #73

Adds flags in all(?) functions that operate on tensors (tensor creation, model loading, forward) to optionally disable autograd, which should improve performance for inference.

Also adds a similar flag to set evaluation mode for the loaded model.

- Evaluation mode
  - Contrary to my initial comments in #73, from testing evaluation mode does appear to be preserved, both between saving and loading TorchScript, and when applied to the loaded model.
  - In most cases evaluation mode is therefore likely to already be set, but I think it's useful to have the option to change it, particularly if FTorch may be extended to facilitate training (#22).

- NoGradMode
  - Enabling or disabling gradients is more complicated, as it defined via a context manager, which only appears to define the behaviour within its own scope, and so it seems necessary to enable/disable gradients before every code block that operates on tensors (similar to the Python equivalent `with torch.no_grad():`).

- InferenceMode
  - No changes are currently included, but it would be good to support [InferenceMode](https://pytorch.org/cppdocs/notes/inference_mode.html) too eventually, as it should provide further performance benefits over NoGradMode.
  - However, it has stricter requirements, and the mode was only added (as a beta) in PyTorch 1.9, so we would need to be careful if we want to support older versions.

- Model freezing
  - No changes are currently included, and less directly applicable to the main FTorch library, although there are still interactions e.g. freezing the model can allow InferenceMode to be enabled when loading the model.
  - Freezing is currently the "default" when tracing in [pt2ts.py](https://github.com/Cambridge-ICCS/FTorch/blob/main/utils/pt2ts.py), but not for scripting, despite potentially [improving performance](https://pytorch.org/tutorials/prototype/torchscript_freezing.html).
  - Freezing appears to (sometimes) introduce numerical errors when saving the reloading (differences ~10^-6), and can seem to lead to issues loading with Forpy too.

(For more general explanation of autograd/evaluation mode, see [autograd mechanics](https://pytorch.org/docs/1.9.0/notes/autograd.html)).

Note: I've also removed the old, commented out `torch_from_blob` function.