### PR TITLE
Rename input to inputs

### DIFF
--- a/FTorch.md
+++ b/FTorch.md
@@ -45,11 +45,11 @@ Presentations
 
 The following presentations contain information about FTorch:
 
-* Reducing the overheads for coupling PyTorch machine learning models to Fortran\
-  ML & DL Seminars, LSCE, IPSL, Paris - November 2023\
-  [Slides](IPSL_FTorch/IPSL_FTorch.html) - [Recording](https://www.youtube.com/watch?v=-NJGuV6Rz6U)
-* Reducing the Overhead of Coupled Machine Learning Models between Python and Fortran\
-  RSECon23, Swansea - September 2023\
+* Reducing the overheads for coupling PyTorch machine learning models to Fortran<br>
+  ML & DL Seminars, LSCE, IPSL, Paris - November 2023<br>
+  [Slides](https://jackatkinson.net/slides/IPSL_FTorch/IPSL_FTorch.html) - [Recording](https://www.youtube.com/watch?v=-NJGuV6Rz6U)
+* Reducing the Overhead of Coupled Machine Learning Models between Python and Fortran<br>
+  RSECon23, Swansea - September 2023<br>
   [Slides](https://jackatkinson.net/slides/RSECon23/RSECon23.html) - [Recording](https://www.youtube.com/watch?v=Ei6H_BoQ7g4&list=PL27mQJy8eDHmibt_aL3M68x-4gnXpxvZP&index=33)
 
 License

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ examples for performing coupling.
 use ftorch
 ...
 type(torch_module) :: model
-type(torch_tensor), dimension(n_inputs) :: model_input_arr
+type(torch_tensor), dimension(n_inputs) :: model_inputs_arr
 type(torch_tensor) :: model_output
 ...
 model = torch_module_load("/my/saved/TorchScript/model.pt")
-model_input_arr(1) = torch_tensor_from_array(input_fortran, in_layout, torch_kCPU)
+model_inputs_arr(1) = torch_tensor_from_array(input_fortran, in_layout, torch_kCPU)
 model_output = torch_tensor_from_array(output_fortran, out_layout, torch_kCPU)
 
 call torch_module_forward(model, model_input_arr, n_inputs, model_output)

--- a/examples/1_SimpleNet/simplenet_infer_fortran.f90
+++ b/examples/1_SimpleNet/simplenet_infer_fortran.f90
@@ -8,7 +8,7 @@ program inference
 
    implicit none
   
-   ! Set precision for reals
+   ! Set working precision for reals
    integer, parameter :: wp = sp
    
    integer :: num_args, ix
@@ -21,8 +21,9 @@ program inference
    integer :: tensor_layout(1) = [1]
 
    ! Set up Torch data structures
+   ! The net, a vector of input tensors (in this case we only have one), and the output tensor
    type(torch_module) :: model
-   type(torch_tensor), dimension(1) :: in_tensor
+   type(torch_tensor), dimension(1) :: in_tensors
    type(torch_tensor) :: out_tensor
 
    ! Get TorchScript model file as a command line argument
@@ -36,19 +37,19 @@ program inference
    in_data = [0.0, 1.0, 2.0, 3.0, 4.0]
 
    ! Create Torch input/output tensors from the above arrays
-   in_tensor(1) = torch_tensor_from_array(in_data, tensor_layout, torch_kCPU)
+   in_tensors(1) = torch_tensor_from_array(in_data, tensor_layout, torch_kCPU)
    out_tensor = torch_tensor_from_array(out_data, tensor_layout, torch_kCPU)
 
    ! Load ML model
    model = torch_module_load(args(1))
 
    ! Infer
-   call torch_module_forward(model, in_tensor, n_inputs, out_tensor)
+   call torch_module_forward(model, in_tensors, n_inputs, out_tensor)
    write (*,*) out_data(:)
 
    ! Cleanup
    call torch_module_delete(model)
-   call torch_tensor_delete(in_tensor(1))
+   call torch_tensor_delete(in_tensors(1))
    call torch_tensor_delete(out_tensor)
 
 end program inference

--- a/examples/2_ResNet18/resnet_infer_fortran.f90
+++ b/examples/2_ResNet18/resnet_infer_fortran.f90
@@ -21,7 +21,7 @@ contains
 
       ! Set up types of input and output data
       type(torch_module) :: model
-      type(torch_tensor), dimension(1) :: in_tensor
+      type(torch_tensor), dimension(1) :: in_tensors
       type(torch_tensor) :: out_tensor
 
       real(wp), dimension(:,:,:,:), allocatable, target :: in_data
@@ -66,7 +66,7 @@ contains
       call load_data(filename, tensor_length, in_data)
 
       ! Create input/output tensors from the above arrays
-      in_tensor(1) = torch_tensor_from_array(in_data, in_layout, torch_kCPU)
+      in_tensors(1) = torch_tensor_from_array(in_data, in_layout, torch_kCPU)
 
       out_tensor = torch_tensor_from_array(out_data, out_layout, torch_kCPU)
 
@@ -74,7 +74,7 @@ contains
       model = torch_module_load(args(1))
 
       ! Infer
-      call torch_module_forward(model, in_tensor, n_inputs, out_tensor)
+      call torch_module_forward(model, in_tensors, n_inputs, out_tensor)
 
       ! Load categories
       call load_categories(filename_cats, N_cats, categories)
@@ -93,7 +93,7 @@ contains
 
       ! Cleanup
       call torch_module_delete(model)
-      call torch_tensor_delete(in_tensor(1))
+      call torch_tensor_delete(in_tensors(1))
       call torch_tensor_delete(out_tensor)
       deallocate(in_data)
       deallocate(out_data)

--- a/examples/3_MultiGPU/simplenet_infer_fortran.f90
+++ b/examples/3_MultiGPU/simplenet_infer_fortran.f90
@@ -25,7 +25,7 @@ program inference
 
    ! Set up Torch data structures
    type(torch_module) :: model
-   type(torch_tensor), dimension(1) :: in_tensor
+   type(torch_tensor), dimension(1) :: in_tensors
    type(torch_tensor) :: out_tensor
 
    ! MPI configuration
@@ -46,13 +46,15 @@ program inference
    write (6, 100) rank, in_data(:)
    100 format("input on rank ", i1,": [", 4(f5.1,","), f5.1,"]")
 
-   ! Create Torch input tensor from the above array. We use the torch_kCUDA
-   ! device type and the device index corresponding to the MPI rank.
-   in_tensor(1) = torch_tensor_from_array(in_data, tensor_layout, torch_kCUDA, &
+   ! Create Torch input tensor from the above array and assign it to the first (and only)
+   ! element in the array of input tensors.
+   ! We use the torch_kCUDA device type with device index corresponding to the MPI rank.
+   in_tensors(1) = torch_tensor_from_array(in_data, tensor_layout, torch_kCUDA, &
                                           device_index=rank)
 
-   ! Create Torch input tensor from the above array. Here we use the
-   ! torch_kCPU device type since the tensor is for output only.
+   ! Create Torch output tensor from the above array.
+   ! Here we use the torch_kCPU device type since the tensor is for output only
+   ! i.e. to be subsequently used by Fortran on CPU.
    out_tensor = torch_tensor_from_array(out_data, tensor_layout, torch_kCPU)
 
    ! Load ML model. Ensure that the same device type and device index are used
@@ -61,7 +63,7 @@ program inference
                              device_index=rank)
 
    ! Infer
-   call torch_module_forward(model, in_tensor, n_inputs, out_tensor)
+   call torch_module_forward(model, in_tensors, n_inputs, out_tensor)
 
    ! Print the values computed on each MPI rank.
    write (6, 200) rank, out_data(:)
@@ -69,7 +71,7 @@ program inference
 
    ! Cleanup
    call torch_module_delete(model)
-   call torch_tensor_delete(in_tensor(1))
+   call torch_tensor_delete(in_tensors(1))
    call torch_tensor_delete(out_tensor)
    call mpi_finalize(ierr)
 

--- a/pages/examples.md
+++ b/pages/examples.md
@@ -51,12 +51,13 @@ implicit none
 ! Generate an object to hold the Torch model
 type(torch_module) :: model
 
-! Set up types of input and output data
+! Set up array of n_inputs input tensors and the output tensor
+! Note: In this example there is only one input tensor (n_inputs = 1)
 integer, parameter :: n_inputs = 1
 type(torch_tensor), dimension(n_inputs) :: model_input_arr
 type(torch_tensor) :: model_output
 
-! Set up the model input and output as Fortran arrays
+! Set up the model inputs and output as Fortran arrays
 real, dimension(10,10), target  :: input
 real, dimension(5), target   :: output
 

--- a/pages/gpu.md
+++ b/pages/gpu.md
@@ -41,14 +41,14 @@ For example, the following code snippet sets up a Torch tensor with GPU device i
 
 ```fortran
 device_index = 2
-in_tensor(1) = torch_tensor_from_array(in_data, tensor_layout, torch_kCUDA,    &
+in_tensors(1) = torch_tensor_from_array(in_data, tensor_layout, torch_kCUDA,    &
                                        device_index=device_index)
 ```
 
 Whereas the following code snippet sets up a Torch tensor with (default) device index 0:
 
 ```fortran
-in_tensor(1) = torch_tensor_from_array(in_data, tensor_layout, torch_kCUDA)
+in_tensors(1) = torch_tensor_from_array(in_data, tensor_layout, torch_kCUDA)
 ```
 
 See the

--- a/pages/troubleshooting.md
+++ b/pages/troubleshooting.md
@@ -60,3 +60,18 @@ However, the version of PyTorch provided by pip install provides an ARM binary
 for libtorch which works on Apple Silicon.
 Therefore you should `pip install torch` in this situation and follow the guidance
 on locating Torch within a virtual environment (venv) for CMake.
+
+## FAQ
+
+### Why are inputs to torch models an array?
+
+The reason input tensors to [[torch_module_forward(subroutine)]] are contained in an
+array is because it is possible to pass multiple input tensors to the `forward()`
+method of a torch net.\
+The nature of Fortran means that it is not possible to set an arbitrary number
+of inputs to the `torch_module_forward` subroutine, so instead we use an single array
+of input tensors which _can_ have an arbitrary length of `n_inputs`.
+
+Note that this does not refer to batching data.
+This should be done in the same way as in Torch; by extending the dimensionality of
+the input tensors.


### PR DESCRIPTION
Should close #109 

Following the discussion in #108 naming the array of input tensors `inputs` rather than `input` in any examples should increase clarity to new users.

I also added a short FAQ item on the subject.