### PR TITLE
Update Windows help

### DIFF
--- a/pages/troubleshooting.md
+++ b/pages/troubleshooting.md
@@ -16,8 +16,9 @@ If you need to build in native Windows please read the following information:
 It is possible to build using Visual Studio and the Intel Fortran Compiler  
 In this case you must install 
 
-* [Visual Studio](https://visualstudio.microsoft.com/)
-* [Intel OneAPI Base and HPC toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html) (ensure that the Intel Fortran compiler and VS integration is selected).
+* [Visual Studio](https://visualstudio.microsoft.com/) ensuring C++ tools are selected and installed.
+* [Intel OneAPI Basetoolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html)
+* [Intel OneAPI HPC toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html) ensuring that the Intel Fortran compiler and VS integration is selected.
 
 You will then need to load the intel Fortran compilers using `setvars.bat`
 which is found in the Intel compiler install directory (see the 
@@ -32,7 +33,7 @@ Finally you will need to add `-G "NMake Makefiles"` to the `cmake` command in th
 [regular install instructions](doc/page/cmake.html).<br>
 So the basic command to build from CMD becomes:
 ```
-cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\melt\Downloads\libtorch-win-shared-with-deps-2.1.0+cpu\libtorch" -DCMAKE_BUILD_TYPE=Release ..
+cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\<path-to-libtorch>\libtorch-win-shared-with-deps-2.1.0+cpu\libtorch" -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cmake --install .
 ```
@@ -40,7 +41,7 @@ cmake --install .
 If using powershell the setvars and build commands become:
 ```
 cmd /k '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'
-cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\melt\Downloads\libtorch-win-shared-with-deps-2.1.0+cpu\libtorch" -DCMAKE_BUILD_TYPE=Release ..
+cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\<path-to-libtorch>\libtorch-win-shared-with-deps-2.1.0+cpu\libtorch" -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cmake --install .
 ```

--- a/pages/troubleshooting.md
+++ b/pages/troubleshooting.md
@@ -33,7 +33,7 @@ Finally you will need to add `-G "NMake Makefiles"` to the `cmake` command in th
 [regular install instructions](doc/page/cmake.html).<br>
 So the basic command to build from CMD becomes:
 ```
-cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\<path-to-libtorch>\libtorch-win-shared-with-deps-2.1.0+cpu\libtorch" -DCMAKE_BUILD_TYPE=Release ..
+cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\<path-to-libtorch-download>\libtorch" -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cmake --install .
 ```
@@ -41,7 +41,7 @@ cmake --install .
 If using powershell the setvars and build commands become:
 ```
 cmd /k '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'
-cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\<path-to-libtorch>\libtorch-win-shared-with-deps-2.1.0+cpu\libtorch" -DCMAKE_BUILD_TYPE=Release ..
+cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="C:\Users\<path-to-libtorch-download>\libtorch" -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cmake --install .
 ```


### PR DESCRIPTION
Whilst working through helping a Windows user in #124 I found that the advice we provide could be clearer:

- Clarify that you need the C++ tools as part of the VS install 
- Link to the Base and HPC toolkits separately - currently we name both, but only link to the base
- Remove hardcoded filepath to be more generic