### PR TITLE
Add MPS and XPU devices

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -52,6 +52,12 @@ const auto get_device(torch_device_t device_type, int device_index)
                 << std::endl;
       exit(EXIT_FAILURE);
     }
+  case torch_kMPS:
+    if (device_index != -1 && device_index != 0) {
+      std::cerr << "[WARNING]: Only one device is available for MPS runs"
+                << std::endl;
+    }
+    return torch::Device(torch::kMPS);
   default:
     std::cerr << "[WARNING]: unknown device type, setting to torch_kCPU"
               << std::endl;

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -58,6 +58,12 @@ const auto get_device(torch_device_t device_type, int device_index)
                 << std::endl;
     }
     return torch::Device(torch::kMPS);
+  case torch_kXPU:
+    if (device_index != -1) {
+      std::cerr << "[WARNING]: device index unused for XPU runs"
+                << std::endl;
+    }
+    return torch::Device(torch::kXPU);
   default:
     std::cerr << "[WARNING]: unknown device type, setting to torch_kCPU"
               << std::endl;

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -26,7 +26,7 @@ typedef enum {
 } torch_data_t;
 
 // Device types
-typedef enum { torch_kCPU, torch_kCUDA, torch_kMPS } torch_device_t;
+typedef enum { torch_kCPU, torch_kCUDA, torch_kMPS, torch_kXPU } torch_device_t;
 
 
 // =====================================================================================

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -26,7 +26,7 @@ typedef enum {
 } torch_data_t;
 
 // Device types
-typedef enum { torch_kCPU, torch_kCUDA } torch_device_t;
+typedef enum { torch_kCPU, torch_kCUDA, torch_kMPS } torch_device_t;
 
 
 // =====================================================================================

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -44,6 +44,7 @@ module ftorch
   enum, bind(c)
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
+    enumerator :: torch_kMPS = 2
   end enum
 
   !> Interface for directing `torch_tensor_from_array` to possible input types and ranks

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -45,6 +45,7 @@ module ftorch
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
     enumerator :: torch_kMPS = 2
+    enumerator :: torch_kXPU = 3
   end enum
 
   !> Interface for directing `torch_tensor_from_array` to possible input types and ranks

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -62,6 +62,7 @@ module ftorch
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
     enumerator :: torch_kMPS = 2
+    enumerator :: torch_kXPU = 3
   end enum
 
   !> Interface for directing `torch_tensor_from_array` to possible input types and ranks

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -61,6 +61,7 @@ module ftorch
   enum, bind(c)
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
+    enumerator :: torch_kMPS = 2
   end enum
 
   !> Interface for directing `torch_tensor_from_array` to possible input types and ranks


### PR DESCRIPTION
Adds device options for MPS ([Apple GPU](https://pytorch.org/docs/stable/notes/mps.html)) and XPU ([Intel GPU](https://pytorch.org/tutorials/recipes/intel_extension_for_pytorch.html)), similarly to the addition of GPUs via CUDA.

In theory there are quite a few additional devices we could add (full list [here](https://pytorch.org/cppdocs/api/file_c10_core_DeviceType.h.html#variables) / [here](https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h)), but these two are of most interest from discussions with @jatkinson1000.

I haven't been able to test the XPU device, but basic tests with MPS seem to suggest it's working as expected:

In example 2, resnet_infer_fortran, setting:
```
model = torch_module_load(args(1), device_type=torch_kMPS)
```
without changing the input tensor device throws an error:
```
RuntimeError: slow_conv2d_forward_mps: input(device='cpu') and weight(device=mps:0')  must be on the same device
```

Similarly, setting the input tensor device, but not the model
```
in_tensor(1) = torch_tensor_from_array(in_data, in_layout, torch_kMPS)
```
throws an error:
```
RuntimeError: Input type (MPSFloatType) and weight type (CPUFloatType) should be the same
```

Setting both works and the expected output is produced:

```
Samoyed (id=         259 ), : probability =  0.884624064
```

I also see spikes in activity on my GPU (for the largest spikes, I added a loop around the example inference):

![image](https://github.com/Cambridge-ICCS/FTorch/assets/45317199/bce0b732-8d7e-4bad-8187-803860c88f22)


Note, when running 10,000 iterations of the inference, I got an error:

```
RuntimeError: MPS backend out of memory (MPS allocated: 45.89 GB, other allocations: 9.72 MB, max allowed: 45.90 GB). Tried to allocate 784.00 KB on private pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).
```
which might suggest a problem with cleanup.

I don't think this is specific to MPS, so might be worth checking on GPU too (you can reduce the CUDA memory to debug more easily, if it helps).