### PR TITLE
Require ftorch when coupling

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -41,11 +41,13 @@ jobs:
         run: |
           . ftorch/bin/activate
           VN=$(python -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
-          export Torch_DIR=${VIRTUAL_ENV}/lib/python${VN}/site-packages
+          export Torch_DIR=${VIRTUAL_ENV}/lib/python${VN}/site-packages/torch
           export BUILD_DIR=$(pwd)/src/build
           mkdir ${BUILD_DIR}
           cd ${BUILD_DIR}
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} -DCMAKE_BUILD_TESTS=TRUE
+          echo Building in ${BUILD_DIR}
+          echo Torch in ${Torch_DIR}
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} -DCMAKE_BUILD_TESTS=TRUE -DCMAKE_PREFIX_PATH=${Torch_DIR}
           cmake --build .
           cmake --install .
 

--- a/examples/1_SimpleNet/CMakeLists.txt
+++ b/examples/1_SimpleNet/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
 endif()
 
-find_package(FTorch)
+find_package(FTorch REQUIRED)
 message(STATUS "Building with Fortran PyTorch coupling")
 
 # Fortran example

--- a/examples/2_ResNet18/CMakeLists.txt
+++ b/examples/2_ResNet18/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
 endif()
 
-find_package(FTorch)
+find_package(FTorch REQUIRED)
 message(STATUS "Building with Fortran PyTorch coupling")
 
 # Fortran example

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
 endif()
 
-find_package(FTorch)
+find_package(FTorch REQUIRED)
 find_package(MPI REQUIRED)
 message(STATUS "Building with Fortran PyTorch coupling")
 

--- a/pages/cmake.md
+++ b/pages/cmake.md
@@ -112,7 +112,7 @@ If doing this you need to include the following in the `CMakeLists.txt` file to
 find the FTorch installation and link it to the executable.
 
 ```CMake
-find_package(FTorch)
+find_package(FTorch REQUIRED)
 target_link_libraries( <executable> PRIVATE FTorch::ftorch )
 message(STATUS "Building with Fortran PyTorch coupling")
 ```


### PR DESCRIPTION
Closes #133

It came up in #124 that some linking could pass undetected for the examples as CMake does not currently '`REQUIRE`' FTorch.

This PR changes that for the examples (which are then pulled into the tests) and in the online coupling guidance.