### PR TITLE
Add tests for different Fortran standards

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -18,6 +18,10 @@ jobs:
   test-suite:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        std: ["f95", "f2003", "f2008", "f2018"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -45,7 +49,7 @@ jobs:
           export BUILD_DIR=$(pwd)/src/build
           mkdir ${BUILD_DIR}
           cd ${BUILD_DIR}
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} -DCMAKE_BUILD_TESTS=TRUE
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} -DCMAKE_BUILD_TESTS=TRUE -DCMAKE_Fortran_FLAGS="-std=${{ matrix.std }}"
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        std: ["f95", "f2003", "f2008", "f2018"]
+        std: ["f2008", "f2018"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **_A library for coupling (Py)Torch machine learning models to Fortran_**
 
 ![GitHub](https://img.shields.io/github/license/Cambridge-ICCS/FTorch)
+![Fortran](https://img.shields.io/badge/Fortran-2008-purple)
 
 This repository contains code, utilities, and examples for directly calling PyTorch ML
 models from Fortran.
@@ -73,7 +74,7 @@ To install the library requires the following to be installed on the system:
 
 * CMake >= 3.1
 * [libtorch](https://pytorch.org/cppdocs/installing.html)<sup>*</sup> or [PyTorch](https://pytorch.org/)
-* Fortran, C++ (must fully support C++17), and C compilers
+* Fortran (2008 standard compliant), C++ (must fully support C++17), and C compilers
 
 <sup>*</sup> _The minimal example provided downloads the CPU-only Linux Nightly binary. [Alternative versions](https://pytorch.org/get-started/locally/) may be required._
 

--- a/pages/cmake.md
+++ b/pages/cmake.md
@@ -6,6 +6,15 @@ Installation of FTorch is done by CMake.
 
 This is controlled by the `CMakeLists.txt` file in `src/`.
 
+## Dependencies
+
+To install the library requires the following to be installed on the system:
+
+- CMake >= 3.1
+- libtorch or PyTorch
+- Fortran (2008 standard compliant), C++ (must fully support C++17), and C compilers
+
+
 ## Basic instructions
 
 To build the library, first clone it from GitHub to your local machine and then run:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if(NOT CMAKE_Fortran_FLAGS)
+    set(CMAKE_Fortran_FLAGS "-std=f2008")
+endif()
+
 include(CheckLanguage)
 if(ENABLE_CUDA)
   check_language(CUDA)


### PR DESCRIPTION
Aims to resolve #130.

From [tests on my fork](https://github.com/ElliottKasoar/FTorch/actions/runs/9688663217), it looks like there are a number of incompatibilities with the 95 and 2003s standards.

Some may be relatively simple to adjust for, particularly for the 2003 standard. For example, we use `iso_fortran_env` types that were [not added until 2008](https://fortranwiki.org/fortran/show/iso_fortran_env), and in some cases variables have `no IMPLICIT type`.

The exact difference is obscured by fypp, but it appears there are significantly more issues for the 95 standard.

Given that I'm not aware of anyone encountering compatibility issues, stating support for 2008+ (e.g. similar to [DL POLY](https://ccp5.gitlab.io/dlpoly-setup/setup.html#requirements)) is perhaps the best first step, and arguably all we need to do.

Whether it's worth extending support for 2003 is probably best answered by people more familiar with the Fortran (HPC) ecosystem, but I'm generally wary of limiting access to newer features.

However, that's probably a separate PR anyway, so I'm happy to change the test matrix to 2008+ for now, and add a note in the requirements of the README accordingly if this sounds reasonable?