### PR TITLE
add subroutine to delete arrays of tensors

### DIFF
--- a/examples/1_SimpleNet/simplenet_infer_fortran.f90
+++ b/examples/1_SimpleNet/simplenet_infer_fortran.f90
@@ -48,7 +48,7 @@ program inference
 
    ! Cleanup
    call torch_model_delete(model)
-   call torch_tensor_delete(in_tensors(1))
-   call torch_tensor_delete(out_tensors(1))
+   call torch_tensor_array_delete(in_tensors)
+   call torch_tensor_array_delete(out_tensors)
 
 end program inference

--- a/examples/1_SimpleNet/simplenet_infer_fortran.f90
+++ b/examples/1_SimpleNet/simplenet_infer_fortran.f90
@@ -47,8 +47,8 @@ program inference
    write (*,*) out_data(:)
 
    ! Cleanup
-   call torch_model_delete(model)
-   call torch_tensor_array_delete(in_tensors)
-   call torch_tensor_array_delete(out_tensors)
+   call torch_delete(model)
+   call torch_delete(in_tensors)
+   call torch_delete(out_tensors)
 
 end program inference

--- a/examples/2_ResNet18/resnet_infer_fortran.f90
+++ b/examples/2_ResNet18/resnet_infer_fortran.f90
@@ -103,8 +103,8 @@ contains
 
       ! Cleanup
       call torch_model_delete(model)
-      call torch_tensor_delete(in_tensors(1))
-      call torch_tensor_delete(out_tensors(1))
+      call torch_tensor_array_delete(in_tensors)
+      call torch_tensor_array_delete(out_tensors)
       deallocate(in_data)
       deallocate(out_data)
       deallocate(probabilities)

--- a/examples/2_ResNet18/resnet_infer_fortran.f90
+++ b/examples/2_ResNet18/resnet_infer_fortran.f90
@@ -102,9 +102,9 @@ contains
       write (*,*) trim(categories(idx(2))), " (id=", idx(2), "), : probability =", probability
 
       ! Cleanup
-      call torch_model_delete(model)
-      call torch_tensor_array_delete(in_tensors)
-      call torch_tensor_array_delete(out_tensors)
+      call torch_delete(model)
+      call torch_delete(in_tensors)
+      call torch_delete(out_tensors)
       deallocate(in_data)
       deallocate(out_data)
       deallocate(probabilities)

--- a/examples/3_MultiGPU/simplenet_infer_fortran.f90
+++ b/examples/3_MultiGPU/simplenet_infer_fortran.f90
@@ -70,8 +70,8 @@ program inference
 
    ! Cleanup
    call torch_model_delete(model)
-   call torch_tensor_delete(in_tensors(1))
-   call torch_tensor_delete(out_tensors(1))
+   call torch_tensor_array_delete(in_tensors)
+   call torch_tensor_array_delete(out_tensors)
    call mpi_finalize(ierr)
 
 end program inference

--- a/examples/3_MultiGPU/simplenet_infer_fortran.f90
+++ b/examples/3_MultiGPU/simplenet_infer_fortran.f90
@@ -69,9 +69,9 @@ program inference
    200 format("output on rank ", i1,": [", 4(f5.1,","), f5.1,"]")
 
    ! Cleanup
-   call torch_model_delete(model)
-   call torch_tensor_array_delete(in_tensors)
-   call torch_tensor_array_delete(out_tensors)
+   call torch_delete(model)
+   call torch_delete(in_tensors)
+   call torch_delete(out_tensors)
    call mpi_finalize(ierr)
 
 end program inference

--- a/examples/4_MultiIO/multiionet_infer_fortran.f90
+++ b/examples/4_MultiIO/multiionet_infer_fortran.f90
@@ -54,9 +54,7 @@ program inference
 
    ! Cleanup
    call torch_model_delete(model)
-   call torch_tensor_delete(in_tensors(1))
-   call torch_tensor_delete(in_tensors(2))
-   call torch_tensor_delete(out_tensors(1))
-   call torch_tensor_delete(out_tensors(2))
+   call torch_tensor_array_delete(in_tensors)
+   call torch_tensor_array_delete(out_tensors)
 
 end program inference

--- a/examples/4_MultiIO/multiionet_infer_fortran.f90
+++ b/examples/4_MultiIO/multiionet_infer_fortran.f90
@@ -53,8 +53,8 @@ program inference
    write (*,*) out_data2
 
    ! Cleanup
-   call torch_model_delete(model)
-   call torch_tensor_array_delete(in_tensors)
-   call torch_tensor_array_delete(out_tensors)
+   call torch_delete(model)
+   call torch_delete(in_tensors)
+   call torch_delete(out_tensors)
 
 end program inference

--- a/pages/examples.md
+++ b/pages/examples.md
@@ -90,8 +90,8 @@ write(*,*) output
 
 ! Clean up
 call torch_model_delete(model)
-call torch_tensor_delete(model_input_arr(1))
-call torch_tensor_delete(model_output_arr(1))
+call torch_tensor_array_delete(model_input_arr)
+call torch_tensor_array_delete(model_output_arr)
 ```
 
 #### 3. Build the code

--- a/pages/examples.md
+++ b/pages/examples.md
@@ -89,9 +89,9 @@ call torch_model_forward(model, model_input_arr, model_output_arr)
 write(*,*) output
 
 ! Clean up
-call torch_model_delete(model)
-call torch_tensor_array_delete(model_input_arr)
-call torch_tensor_array_delete(model_output_arr)
+call torch_delete(model)
+call torch_delete(model_input_arr)
+call torch_delete(model_output_arr)
 ```
 
 #### 3. Build the code

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -270,9 +270,20 @@ contains
     device_index = torch_tensor_get_device_index_c(tensor%p)
   end function torch_tensor_get_device_index
 
+  !> Deallocates an array of tensors.
+  subroutine torch_tensor_array_delete(tensor_array)
+    type(torch_tensor), dimension(:), intent(inout) :: tensor_array
+    integer :: i
+
+    ! use bounds rather than (1, N) because it's safer
+    do i = lbound(tensor_array, dim=1), ubound(tensor_array, dim=1)
+      call torch_tensor_delete(tensor_array(i))
+    end do
+  end subroutine torch_tensor_array_delete
+
   !> Deallocates a tensor.
   subroutine torch_tensor_delete(tensor)
-    type(torch_tensor), intent(in) :: tensor     !! Input tensor
+    type(torch_tensor), intent(inout) :: tensor
 
     interface
       subroutine torch_tensor_delete_c(tensor) &

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -74,6 +74,13 @@ module ftorch
     module procedure torch_tensor_from_array_real64_4d
   end interface
 
+  !> Interface for deleting generic torch objects
+  interface torch_delete
+    module procedure torch_model_delete
+    module procedure torch_tensor_delete
+    module procedure torch_tensor_array_delete
+  end interface
+
   interface
     function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, &
                                device_type, device_index, &

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -268,9 +268,20 @@ contains
     device_index = torch_tensor_get_device_index_c(tensor%p)
   end function torch_tensor_get_device_index
 
+  !> Deallocates an array of tensors.
+  subroutine torch_tensor_array_delete(tensor_array)
+    type(torch_tensor), dimension(:), intent(inout) :: tensor_array
+    integer :: i
+
+    ! use bounds rather than (1, N) because it's safer
+    do i = lbound(tensor_array, dim=1), ubound(tensor_array, dim=1)
+      call torch_tensor_delete(tensor_array(i))
+    end do
+  end subroutine torch_tensor_array_delete
+
   !> Deallocates a tensor.
   subroutine torch_tensor_delete(tensor)
-    type(torch_tensor), intent(in) :: tensor     !! Input tensor
+    type(torch_tensor), intent(inout) :: tensor
 
     interface
       subroutine torch_tensor_delete_c(tensor) &

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -72,6 +72,13 @@ module ftorch
     #:endfor
   end interface
 
+  !> Interface for deleting generic torch objects
+  interface torch_delete
+    module procedure torch_model_delete
+    module procedure torch_tensor_delete
+    module procedure torch_tensor_array_delete
+  end interface
+
   interface
     function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, &
                                device_type, device_index, &


### PR DESCRIPTION
This PR adds a subroutine (`torch_tensor_array_delete`) to delete arrays of tensors. This eliminate the need to manually loop over all elements of the array calling `torch_tensor_delete`, see e.g.,

https://github.com/Cambridge-ICCS/FTorch/blob/490272ef5662936be26697d496b14f6a281214fa/examples/4_MultiIO/multiionet_infer_fortran.f90#L57-L60

Which now becomes,

https://github.com/Cambridge-ICCS/FTorch/blob/e24c38024e0ec8b03ecd0f8a3e6c269e42ac2a0c/examples/4_MultiIO/multiionet_infer_fortran.f90#L57-L58


- [x] add `torch_tensor_array_delete` to delete arrays of tensors
- [x] update tests
- [x] update docs 