### PR TITLE
Update requirements.txt for 1_SimpleNet

### DIFF
--- a/examples/1_SimpleNet/requirements.txt
+++ b/examples/1_SimpleNet/requirements.txt
@@ -1,1 +1,2 @@
 torch
+numpy


### PR DESCRIPTION
Very minor fix- missing `numpy` in requirements for this example, which is needed (internally by `torch` on this code). Otherwise you get messages like:
```
UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
```
popping up. 