### PR TITLE
Add comment to readme.md for SimpleNet about setting compiler

### DIFF
--- a/examples/1_SimpleNet/README.md
+++ b/examples/1_SimpleNet/README.md
@@ -78,6 +78,10 @@ cmake .. -DCMAKE_PREFIX_PATH=<path/to/your/installation/of/library/> -DCMAKE_BUI
 cmake --build .
 ```
 
+(Note that you can choose the Fortran compiler with the `-DCMAKE_Fortran_COMPILER` flag, i.e., to match
+the Fortran compiler that was used to build your install of FTorch if the default found by CMake is
+different.)
+
 To run the compiled code calling the saved SimpleNet TorchScript from Fortran run the
 executable with an argument of the saved model file:
 ```

--- a/examples/1_SimpleNet/README.md
+++ b/examples/1_SimpleNet/README.md
@@ -78,9 +78,8 @@ cmake .. -DCMAKE_PREFIX_PATH=<path/to/your/installation/of/library/> -DCMAKE_BUI
 cmake --build .
 ```
 
-(Note that you can choose the Fortran compiler with the `-DCMAKE_Fortran_COMPILER` flag, i.e., to match
-the Fortran compiler that was used to build your install of FTorch if the default found by CMake is
-different.)
+(Note that the Fortran compiler can be chosen explicitly with the `-DCMAKE_Fortran_COMPILER` flag,
+and should match the compiler that was used to locally build FTorch.)
 
 To run the compiled code calling the saved SimpleNet TorchScript from Fortran run the
 executable with an argument of the saved model file:

--- a/examples/2_ResNet18/README.md
+++ b/examples/2_ResNet18/README.md
@@ -74,6 +74,9 @@ cmake .. -DCMAKE_PREFIX_PATH=<path/to/your/installation/of/library/> -DCMAKE_BUI
 cmake --build .
 ```
 
+(Note that the Fortran compiler can be chosen explicitly with the `-DCMAKE_Fortran_COMPILER` flag,
+and should match the compiler that was used to locally build FTorch.)
+
 To run the compiled code calling the saved ResNet-18 TorchScript from Fortran run the
 executable with an argument of the saved model file:
 ```

--- a/examples/3_MultiGPU/README.md
+++ b/examples/3_MultiGPU/README.md
@@ -86,6 +86,9 @@ cmake .. -DCMAKE_PREFIX_PATH=<path/to/your/installation/of/library/> -DCMAKE_BUI
 cmake --build .
 ```
 
+(Note that the Fortran compiler can be chosen explicitly with the `-DCMAKE_Fortran_COMPILER` flag,
+and should match the compiler that was used to locally build FTorch.)
+
 To run the compiled code calling the saved SimpleNet TorchScript from Fortran, run the
 executable with an argument of the saved model file. Again, specify the number of MPI
 processes according to the desired number of GPUs:

--- a/examples/4_MultiIO/README.md
+++ b/examples/4_MultiIO/README.md
@@ -84,6 +84,9 @@ cmake .. -DCMAKE_PREFIX_PATH=<path/to/your/installation/of/library/> -DCMAKE_BUI
 cmake --build .
 ```
 
+(Note that the Fortran compiler can be chosen explicitly with the `-DCMAKE_Fortran_COMPILER` flag,
+and should match the compiler that was used to locally build FTorch.)
+
 To run the compiled code calling the saved MultiIONet TorchScript from Fortran,
 run the executable with an argument of the saved model file:
 ```

--- a/examples/5_Autograd/README.md
+++ b/examples/5_Autograd/README.md
@@ -56,6 +56,9 @@ cmake .. -DCMAKE_PREFIX_PATH=<path/to/your/installation/of/library/> -DCMAKE_BUI
 cmake --build .
 ```
 
+(Note that the Fortran compiler can be chosen explicitly with the `-DCMAKE_Fortran_COMPILER` flag,
+and should match the compiler that was used to locally build FTorch.)
+
 To run the compiled code, simply use
 ```
 ./autograd


### PR DESCRIPTION
A note to remind how to set the compiler in the examples if you built FTorch using a different compiler to that found automatically by CMake (this just bit me, bizarrely only after upgrading mac OS).