### PR TITLE
Update documentation on pt2ts readme to clarify where the Torchscript…

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -16,4 +16,5 @@ Dependencies:
 3. Import your model into `pt2ts.py` and amend options as necessary (search for `FPTLIB-TODO`).
 4. Run with `python3 pt2ts.py`.
 
-The model will be saved in the location from which `pt2ts.py` is running.
+The Torchscript model will be saved locally in the same location from which the `pt2ts.py`
+script is being run.


### PR DESCRIPTION
Clarify where the Torchscript model will be saved.

May close #52 

Depends on whether we feel we should output the Torchscript to the local place a user is running `pt2ts` from (currently what this PR clarifies) or to the place the `pt2ts` script is located (would require changes to the pt2ts code).

Under principle of least surprise I would go for the former, but this does place it inside the CMake `build` directory in the examples rather than alongside the model.

I would argue that the examples are something of a contrived case, however, and in reality users will place pt2ts next to their python source and run to obtain the model alongside. They will also likely not be running the Fortran from the same directory as the python model and training in a 'real' application.