### PR TITLE
Extend FTorch to cover 5-dimensional tensors.

### DIFF
--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -5,7 +5,7 @@ $:'' if RANK == 0 else '(' + ':' + ',:' * (RANK - 1) + ')'
 #:set C_PRECISIONS = ['c_int8_t', 'c_int16_t', 'c_int32_t', 'c_int64_t', 'c_float', 'c_double']
 #:set C_PRECISIONS = dict(zip(PRECISIONS, C_PRECISIONS))
 #:set ENUMS = dict(zip(PRECISIONS, ['torch_kInt8', 'torch_kInt16', 'torch_kInt32', 'torch_kInt64', 'torch_kFloat32', 'torch_kFloat64']))
-#:set RANKS = range(1, 5)
+#:set RANKS = range(1, 6)
 #:def enum_from_prec(PRECISION)
 $:ENUMS[PRECISION]
 #:enddef enum_from_prec


### PR DESCRIPTION
Closes #172 

We have had a request for 5D tensor support.
This is from the ConvLSTM: https://paperswithcode.com/method/convlstm which is a type of NN used to analyse gridded data.
Given our initial application (climate sciences) it would make sense to support this as standard.

I have extended the ranks argument in the fypp code to now support 5-D (rank 5) tensors.

One point to discuss is whether we want to support slightly higher in anticipation of other applications (Rank 6 or perhaps 7) bearing in mind that doing so adds quite a lot of code/functions in the f90 file.

We should also perhaps add documentation noting the limit in Rank, and perhaps describing how to extend it for specific cases.