### PR TITLE
change to_array routines to fix pointer issues

### DIFF
--- a/examples/6_Autograd/CMakeLists.txt
+++ b/examples/6_Autograd/CMakeLists.txt
@@ -33,5 +33,5 @@ if(CMAKE_BUILD_TESTS)
     COMMAND autograd
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(fautograd PROPERTIES PASS_REGULAR_EXPRESSION
-    "2.00000000       3.00000000")
+    "test completed successfully")
 endif()

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -228,6 +228,18 @@ int torch_tensor_get_device_index(const torch_tensor_t tensor)
   return t->device().index();
 }
 
+int torch_tensor_get_rank(const torch_tensor_t tensor)
+{
+  auto t = reinterpret_cast<torch::Tensor*>(tensor);
+  return t->sizes().size();
+}
+
+const long int* torch_tensor_get_sizes(const torch_tensor_t tensor)
+{
+  auto t = reinterpret_cast<torch::Tensor*>(tensor);
+  return t->sizes().data();
+}
+
 void torch_tensor_delete(torch_tensor_t tensor)
 {
   auto t = reinterpret_cast<torch::Tensor*>(tensor);

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -114,6 +114,20 @@ EXPORT_C void torch_tensor_print(const torch_tensor_t tensor);
 EXPORT_C int torch_tensor_get_device_index(const torch_tensor_t tensor);
 
 /**
+ * Function to determine the rank of a Torch Tensor
+ * @param Torch Tensor to determine the rank of
+ * @return rank of the Torch Tensor
+ */
+EXPORT_C int torch_tensor_get_rank(const torch_tensor_t tensor);
+
+/**
+ * Function to determine the sizes (shape) of a Torch Tensor
+ * @param Torch Tensor to determine the rank of
+ * @return pointer to the sizes array of the Torch Tensor
+ */
+EXPORT_C const long int* torch_tensor_get_sizes(const torch_tensor_t tensor);
+
+/**
  * Function to delete a Torch Tensor to clean up
  * @param Torch Tensor to delete
  */

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -1812,432 +1812,720 @@ contains
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int8`
   subroutine torch_tensor_to_array_int8_1d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int8
+    use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt8 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 1(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 1(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int8_1d
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `int8`
   subroutine torch_tensor_to_array_int8_2d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int8
+    use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt8 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 2(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 2(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int8_2d
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `int8`
   subroutine torch_tensor_to_array_int8_3d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int8
+    use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt8 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 3(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 3(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int8_3d
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `int8`
   subroutine torch_tensor_to_array_int8_4d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int8
+    use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt8 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 4(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 4(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int8_4d
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int16`
   subroutine torch_tensor_to_array_int16_1d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int16
+    use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt16 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 1(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 1(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int16_1d
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `int16`
   subroutine torch_tensor_to_array_int16_2d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int16
+    use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt16 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 2(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 2(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int16_2d
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `int16`
   subroutine torch_tensor_to_array_int16_3d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int16
+    use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt16 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 3(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 3(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int16_3d
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `int16`
   subroutine torch_tensor_to_array_int16_4d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int16
+    use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt16 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 4(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 4(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int16_4d
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int32`
   subroutine torch_tensor_to_array_int32_1d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int32
+    use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt32 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 1(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 1(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int32_1d
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `int32`
   subroutine torch_tensor_to_array_int32_2d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int32
+    use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt32 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 2(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 2(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int32_2d
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `int32`
   subroutine torch_tensor_to_array_int32_3d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int32
+    use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt32 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 3(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 3(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int32_3d
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `int32`
   subroutine torch_tensor_to_array_int32_4d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int32
+    use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt32 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 4(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 4(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int32_4d
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int64`
   subroutine torch_tensor_to_array_int64_1d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int64
+    use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt64 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 1(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 1(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int64_1d
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `int64`
   subroutine torch_tensor_to_array_int64_2d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int64
+    use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt64 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 2(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 2(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int64_2d
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `int64`
   subroutine torch_tensor_to_array_int64_3d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int64
+    use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt64 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 3(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 3(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int64_3d
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `int64`
   subroutine torch_tensor_to_array_int64_4d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : int64
+    use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt64 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 4(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 4(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_int64_4d
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `real32`
   subroutine torch_tensor_to_array_real32_1d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : real32
+    use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat32 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 1(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 1(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_real32_1d
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `real32`
   subroutine torch_tensor_to_array_real32_2d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : real32
+    use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat32 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 2(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 2(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_real32_2d
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `real32`
   subroutine torch_tensor_to_array_real32_3d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : real32
+    use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat32 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 3(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 3(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_real32_3d
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `real32`
   subroutine torch_tensor_to_array_real32_4d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : real32
+    use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat32 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 4(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 4(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_real32_4d
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `real64`
   subroutine torch_tensor_to_array_real64_1d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : real64
+    use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat64 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 1(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 1(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_real64_1d
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `real64`
   subroutine torch_tensor_to_array_real64_2d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : real64
+    use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat64 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 2(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 2(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_real64_2d
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `real64`
   subroutine torch_tensor_to_array_real64_3d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : real64
+    use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat64 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 3(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 3(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_real64_3d
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `real64`
   subroutine torch_tensor_to_array_real64_4d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : real64
+    use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat64 !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, 4(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, 4(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_real64_4d
 

--- a/src/ftorch.f90
+++ b/src/ftorch.f90
@@ -1773,33 +1773,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, intent(in) :: sizes(1) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt8 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -1813,33 +1791,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, intent(in) :: sizes(2) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt8 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -1853,33 +1809,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, intent(in) :: sizes(3) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt8 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -1893,33 +1827,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, intent(in) :: sizes(4) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt8 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3),sizes(4)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -1933,33 +1845,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, intent(in) :: sizes(1) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt16 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -1973,33 +1863,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, intent(in) :: sizes(2) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt16 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2013,33 +1881,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, intent(in) :: sizes(3) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt16 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2053,33 +1899,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, intent(in) :: sizes(4) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt16 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3),sizes(4)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2093,33 +1917,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, intent(in) :: sizes(1) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt32 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2133,33 +1935,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, intent(in) :: sizes(2) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt32 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2173,33 +1953,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, intent(in) :: sizes(3) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt32 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2213,33 +1971,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, intent(in) :: sizes(4) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt32 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3),sizes(4)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2253,33 +1989,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, intent(in) :: sizes(1) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt64 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2293,33 +2007,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, intent(in) :: sizes(2) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt64 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2333,33 +2025,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, intent(in) :: sizes(3) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt64 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2373,33 +2043,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, intent(in) :: sizes(4) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kInt64 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3),sizes(4)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2413,33 +2061,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, intent(in) :: sizes(1) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat32 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2453,33 +2079,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, intent(in) :: sizes(2) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat32 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2493,33 +2097,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, intent(in) :: sizes(3) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat32 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2533,33 +2115,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, intent(in) :: sizes(4) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat32 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3),sizes(4)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2573,33 +2133,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(1) !! Number of entries for each rank
+    integer, intent(in) :: sizes(1) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat64 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2613,33 +2151,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(2) !! Number of entries for each rank
+    integer, intent(in) :: sizes(2) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat64 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2653,33 +2169,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(3) !! Number of entries for each rank
+    integer, intent(in) :: sizes(3) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat64 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
@@ -2693,33 +2187,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:,:,:) !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(4) !! Number of entries for each rank
+    integer, intent(in) :: sizes(4) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = torch_kFloat64 !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1),sizes(2),sizes(3),sizes(4)))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -555,18 +555,30 @@ contains
   !> Return the array data associated with a Torch tensor of rank ${RANK}$ and data type `${PREC}$`
   subroutine torch_tensor_to_array_${PREC}$_${RANK}$d(tensor, data_out, sizes)
     use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : ${PREC}$
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$, int64
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     ${f_type(PREC)}$(kind=${PREC}$), pointer, intent(out) :: data_out${ranksuffix(RANK)}$ !! Pointer to tensor data
-    integer, intent(in) :: sizes(${RANK}$) !! Number of entries for each rank
+    integer, optional, intent(in) :: sizes(${RANK}$) !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = ${enum_from_prec(PREC)}$ !! Data type
     type(c_ptr) :: cptr
 
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, ${RANK}$(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, ${RANK}$(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)
-    call c_f_pointer(cptr, data_out, sizes)
+    call c_f_pointer(cptr, data_out, my_shape)
 
   end subroutine torch_tensor_to_array_${PREC}$_${RANK}$d
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -516,33 +516,11 @@ contains
     use, intrinsic :: iso_fortran_env, only : ${PREC}$
     type(torch_tensor), intent(in) :: tensor !! Returned tensor
     ${f_type(PREC)}$(kind=${PREC}$), pointer, intent(out) :: data_out${ranksuffix(RANK)}$ !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(${RANK}$) !! Number of entries for each rank
+    integer, intent(in) :: sizes(${RANK}$) !! Number of entries for each rank
 
     ! Local data
     integer(c_int), parameter :: c_dtype = ${enum_from_prec(PREC)}$ !! Data type
     type(c_ptr) :: cptr
-
-    ! Handle allocation of the pointer array
-    if (present(sizes)) then
-      ! The user may provide an array of sizes, i.e., the number of entries for
-      ! each rank
-      if (all(shape(data_out) == 0)) then
-        ! If the sizes array has been provided and the output array has not
-        ! been allocated (i.e., its shape is all zeros) then allocate it
-        allocate(data_out(sizes(1)#{for i in range(1,RANK)}#,sizes(${i+1}$)#{endfor}#))
-      else if (any(shape(data_out) /= sizes)) then
-        ! Raise an error if the sizes array has been provided and the output
-        ! array has already been allocated but its shape differs from the sizes
-        ! argument
-        write (*,*) "[ERROR]: Array allocated with wrong shape"
-        stop
-      end if
-    else if ((.not. associated(data_out)) .or. (all(shape(data_out) == 0))) then
-      ! Raise an error if the sizes array has not been provided and the pointer
-      ! array has not been allocated
-      write (*,*) "[ERROR]: Pointer array has not been allocated"
-      stop
-    end if
 
     ! Have the data_out array point to the Tensor data
     cptr = torch_to_blob_c(tensor%p, c_dtype)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -39,6 +39,9 @@ module ftorch
   !> Type for holding a Torch tensor.
   type torch_tensor
     type(c_ptr) :: p = c_null_ptr  !! pointer to the tensor in memory
+  contains
+    procedure :: get_rank
+    procedure :: get_shape
   end type torch_tensor
 
   !| Enumerator for Torch data types  
@@ -293,6 +296,45 @@ contains
 
     device_index = torch_tensor_get_device_index_c(tensor%p)
   end function torch_tensor_get_device_index
+
+  !> Determines the rank of a tensor.
+  function get_rank(self) result(rank)
+    class(torch_tensor), intent(in) :: self
+    integer(kind=int32) :: rank  !! rank of tensor
+
+    interface
+      function torch_tensor_get_rank_c(tensor) result(rank) &
+          bind(c, name = 'torch_tensor_get_rank')
+        use, intrinsic :: iso_c_binding, only : c_int, c_ptr
+        type(c_ptr), value, intent(in) :: tensor
+        integer(c_int) :: rank
+      end function torch_tensor_get_rank_c
+    end interface
+
+    rank = torch_tensor_get_rank_c(self%p)
+  end function get_rank
+
+  !> Determines the shape of a tensor.
+  function get_shape(self) result(sizes)
+    use, intrinsic :: iso_c_binding, only : c_int, c_long, c_ptr
+    class(torch_tensor), intent(in) :: self
+    integer(kind=c_long), pointer :: sizes(:) !! Pointer to tensor data
+    integer(kind=int32) :: ndims(1)
+    type(c_ptr) :: cptr
+
+    interface
+      function torch_tensor_get_sizes_c(tensor) result(sizes) &
+          bind(c, name = 'torch_tensor_get_sizes')
+        use, intrinsic :: iso_c_binding, only : c_int, c_long, c_ptr
+        type(c_ptr), value, intent(in) :: tensor
+        type(c_ptr) :: sizes
+      end function torch_tensor_get_sizes_c
+    end interface
+
+    ndims(1) = self%get_rank()
+    cptr = torch_tensor_get_sizes_c(self%p)
+    call c_f_pointer(cptr, sizes, ndims)
+  end function get_shape
 
   !> Deallocates an array of tensors.
   subroutine torch_tensor_array_delete(tensor_array)


### PR DESCRIPTION
this fixes an issue seen in PRs #173  and #166 where the test fails with error:

```
[ERROR]: Array allocated with wrong shape
```

Whilst it looks like I have fixed the problem by simply removing the lines... I can assure the reviewer that I didn't do that deliberately :wink: 

I think I have an idea why it doesn't work, and why those lines need to be removed. It essentially stems from 2 points:
1. the `data_out` pointer is declared as `intent(out)`
https://github.com/Cambridge-ICCS/FTorch/blob/e0d82698cc2543b1281f4606007fcc29d7c5c85b/src/ftorch.f90#L2415 
This means that the following lines don't have much meaning
https://github.com/Cambridge-ICCS/FTorch/blob/e0d82698cc2543b1281f4606007fcc29d7c5c85b/src/ftorch.f90#L2426-L2442
2.  Secondly, `sizes` is marked optional
https://github.com/Cambridge-ICCS/FTorch/blob/e0d82698cc2543b1281f4606007fcc29d7c5c85b/src/ftorch.f90#L2416
But that would make the following line undefined, because if sizes is missing on input, it could have any value or just crash
https://github.com/Cambridge-ICCS/FTorch/blob/e0d82698cc2543b1281f4606007fcc29d7c5c85b/src/ftorch.f90#L2446

I don't see a use case (other than convenience) where you wouldn't need to know the size of your output data. It can be passed in rather easily using `shape()` etc. 

Happy to discuss in our next meeting. I might be overlooking something, but I think this works (at least on my machine)


### Update

I have merged in 2 PRs
- #180 
- #181 

These resolve the issues mentioned above.

I plan to add a test to the integration test `examples/6_Autograd/autograd.f90` to check the new `rank`/`shape` functionality I have added.

- [ ] add test of `get_shape()` and `get_rank()` to `examples/6_Autograd/autograd.f90`