### PR TITLE
assign out_data to null ptr (DO NOT MERGE)

### DIFF
--- a/examples/6_Autograd/autograd.f90
+++ b/examples/6_Autograd/autograd.f90
@@ -13,7 +13,7 @@ program example
 
   ! Set up Fortran data structures
   real(wp), dimension(2), target :: in_data
-  real(wp), dimension(:), pointer :: out_data
+  real(wp), dimension(:), pointer :: out_data => null()
   integer :: tensor_layout(1) = [1]
 
   ! Set up Torch data structures


### PR DESCRIPTION
This is a proof of concept that "fixes" an issue seen in PRs #173 and #166 where the autograd test fails.

This is providing an example for PR #175 

**DO NOT MERGE ME**