### PR TITLE
Set pointer in example 6 to null

### DIFF
--- a/examples/6_Autograd/autograd.f90
+++ b/examples/6_Autograd/autograd.f90
@@ -13,7 +13,7 @@ program example
 
   ! Set up Fortran data structures
   real(wp), dimension(2), target :: in_data
-  real(wp), dimension(:), pointer :: out_data
+  real(wp), dimension(:), pointer :: out_data => null()
   integer :: tensor_layout(1) = [1]
 
   ! Set up Torch data structures


### PR DESCRIPTION
I believe this change resolves the issue originally seen in #166, again in #173, and investigated in #174, #175, #176.

After a pointer (pun intended) from @TomMelt towards initialising as null in #176 I conducted further investigations in #174
Checking the Fortran standards declaring a pointer has the default association state is undefined.
This is what we were doing in the autograd example with `out_data`.

When it is passed to `torch_tensor_to array` it could be unassociated, in which case the example runs as expected, registering this, and assigning/allocating the array.
However, it could also be associated, in which case this is picked up in `torch_tensor_to_array`, a mismatch in sizes registered, and an error raised.

The solution here is to ensure that we declare the pointer as `null()` at initialisation so that we avoid undefined behaviour.

This PR should fix the autograd example where it crashes in CI above, but future work by @jwallwork23 as he finalises this feature will need to make sure that there is good documentation to warn users that they need to be careful with pointers, and avoid undefined initialisation.