### PR TITLE
Remove specification of fortran compiler standard from CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,10 +12,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if(NOT CMAKE_Fortran_FLAGS)
-    set(CMAKE_Fortran_FLAGS "-std=f2008")
-endif()
-
 include(CheckLanguage)
 if(ENABLE_CUDA)
   check_language(CUDA)


### PR DESCRIPTION
Potential to close #188 

Removes the specification of `-std=f2008` as a Fortran compiler flag in CMakeLists.

This is a gcc specific flag that raises warnings for other compilers e.g. intel.

Whilst we could implement if-else blocks for different compilers this may still cause unforeseen issues and I do not believe it is necessary - see discussions at https://gitlab.kitware.com/cmake/cmake/-/issues/25006 and https://gitlab.kitware.com/cmake/cmake/-/issues/22235

Most compilers enable the latest Fortran standards that they support by default (different to C++ and C).
We still enforce this flag during the test suite as a check that code is compliant, but it is more of a guard against the introduction of features from a new spec rather than to enable features that may otherwise be unavailable.

I think specifying that we need a Fortran compiler that supports the 2008 standard as part of the documentation is sufficient for this.

Therefore I propose removing these lines (which would be overwritten by any `CMAKE_Fortran_FLAGS` a user might specify anyway!!).