### PR TITLE
Long long fix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+Language: Cpp
+ColumnLimit: 88
+---

--- a/.github/workflows/fypp_checks.yml
+++ b/.github/workflows/fypp_checks.yml
@@ -30,9 +30,9 @@ jobs:
 
     - name: Check ftorch.fypp matches ftorch.f90
       run: |
-        fypp src/ftorch.fypp src/temp.f90_temp
-        if ! diff -q src/ftorch.f90 src/temp.f90_temp; then
-          echo "Error: The code in ftorch.f90 does not match that expected from ftorch.fypp."
+        fypp src/ftorch.fypp src/temp.F90_temp
+        if ! diff -q src/ftorch.F90 src/temp.F90_temp; then
+          echo "Error: The code in ftorch.F90 does not match that expected from ftorch.fypp."
           echo "Please re-run fypp on ftorch.fypp to ensure consistency and re-commit."
           exit 1
         else

--- a/examples/n_c_and_cpp/CMakeLists.txt
+++ b/examples/n_c_and_cpp/CMakeLists.txt
@@ -35,7 +35,7 @@ set(CMAKE_INSTALL_RPATH $ORIGIN/${relDir})
 find_package(Torch REQUIRED)
 
 # Library with C and Fortran bindings
-add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.f90)
+add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.F90)
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
 set_target_properties(${LIB_NAME} PROPERTIES
   PUBLIC_HEADER "ctorch.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,14 @@ set(CMAKE_INSTALL_RPATH $ORIGIN/${relDir})
 find_package(Torch REQUIRED)
 
 # Library with C and Fortran bindings
-add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.f90 ftorch_test_utils.f90)
+add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.F90 ftorch_test_utils.f90)
+
+if(UNIX)
+  if(NOT APPLE) # only add definition for linux (not apple which is also unix)
+    target_compile_definitions(${LIB_NAME} PRIVATE UNIX)
+  endif()
+endif()
+
 # Add an alias FTorch::ftorch for the library
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
 set_target_properties(${LIB_NAME} PROPERTIES

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -224,10 +224,17 @@ int torch_tensor_get_rank(const torch_tensor_t tensor) {
   return t->sizes().size();
 }
 
+#ifdef UNIX
 const long int *torch_tensor_get_sizes(const torch_tensor_t tensor) {
   auto t = reinterpret_cast<torch::Tensor *>(tensor);
   return t->sizes().data();
 }
+#else
+const long long int *torch_tensor_get_sizes(const torch_tensor_t tensor) {
+  auto t = reinterpret_cast<torch::Tensor *>(tensor);
+  return t->sizes().data();
+}
+#endif
 
 void torch_tensor_delete(torch_tensor_t tensor) {
   auto t = reinterpret_cast<torch::Tensor *>(tensor);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -26,8 +26,7 @@ constexpr auto get_dtype(torch_data_t dtype) {
   case torch_kFloat64:
     return torch::kFloat64;
   default:
-    std::cerr << "[WARNING]: unknown data type, setting to torch_kFloat32"
-              << std::endl;
+    std::cerr << "[WARNING]: unknown data type, setting to torch_kFloat32" << std::endl;
     return torch::kFloat32;
   }
 }
@@ -36,33 +35,28 @@ const auto get_device(torch_device_t device_type, int device_index) {
   switch (device_type) {
   case torch_kCPU:
     if (device_index != -1) {
-      std::cerr << "[WARNING]: device index unused for CPU-only runs"
-                << std::endl;
+      std::cerr << "[WARNING]: device index unused for CPU-only runs" << std::endl;
     }
     return torch::Device(torch::kCPU);
   case torch_kCUDA:
     if (device_index == -1) {
-      std::cerr << "[WARNING]: device index unset, defaulting to 0"
-                << std::endl;
+      std::cerr << "[WARNING]: device index unset, defaulting to 0" << std::endl;
       device_index = 0;
     }
     if (device_index >= 0 && device_index < torch::cuda::device_count()) {
       return torch::Device(torch::kCUDA, device_index);
     } else {
       std::cerr << "[ERROR]: invalid device index " << device_index
-                << " for device count " << torch::cuda::device_count()
-                << std::endl;
+                << " for device count " << torch::cuda::device_count() << std::endl;
       exit(EXIT_FAILURE);
     }
   default:
-    std::cerr << "[WARNING]: unknown device type, setting to torch_kCPU"
-              << std::endl;
+    std::cerr << "[WARNING]: unknown device type, setting to torch_kCPU" << std::endl;
     return torch::Device(torch::kCPU);
   }
 }
 
-void set_is_training(torch_jit_script_module_t module,
-                     const bool is_training = false) {
+void set_is_training(torch_jit_script_module_t module, const bool is_training = false) {
   auto model = static_cast<torch::jit::script::Module *>(module);
   if (is_training) {
     model->train();
@@ -144,8 +138,7 @@ torch_tensor_t torch_empty(int ndim, const int64_t *shape, torch_data_t dtype,
 // data
 torch_tensor_t torch_from_blob(void *data, int ndim, const int64_t *shape,
                                const int64_t *strides, torch_data_t dtype,
-                               torch_device_t device_type,
-                               int device_index = -1,
+                               torch_device_t device_type, int device_index = -1,
                                const bool requires_grad = false) {
   torch::AutoGradMode enable_grad(requires_grad);
   torch::Tensor *tensor = nullptr;
@@ -155,9 +148,8 @@ torch_tensor_t torch_from_blob(void *data, int ndim, const int64_t *shape,
     c10::IntArrayRef vshape(shape, ndim);
     c10::IntArrayRef vstrides(strides, ndim);
     tensor = new torch::Tensor;
-    *tensor =
-        torch::from_blob(data, vshape, vstrides, torch::dtype(get_dtype(dtype)))
-            .to(get_device(device_type, device_index));
+    *tensor = torch::from_blob(data, vshape, vstrides, torch::dtype(get_dtype(dtype)))
+                  .to(get_device(device_type, device_index));
 
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
@@ -241,11 +233,11 @@ void torch_tensor_delete(torch_tensor_t tensor) {
   delete t;
 }
 
-torch_jit_script_module_t
-torch_jit_load(const char *filename,
-               const torch_device_t device_type = torch_kCPU,
-               const int device_index = -1, const bool requires_grad = false,
-               const bool is_training = false) {
+torch_jit_script_module_t torch_jit_load(const char *filename,
+                                         const torch_device_t device_type = torch_kCPU,
+                                         const int device_index = -1,
+                                         const bool requires_grad = false,
+                                         const bool is_training = false) {
   torch::AutoGradMode enable_grad(requires_grad);
   torch::jit::script::Module *module = nullptr;
   try {
@@ -304,8 +296,7 @@ void torch_jit_module_forward(const torch_jit_script_module_t module,
     } else {
       // If for some reason the forward method does not return a Tensor it
       // should raise an error when trying to cast to a Tensor type
-      std::cerr << "[ERROR]: Model Output is neither Tensor nor Tuple."
-                << std::endl;
+      std::cerr << "[ERROR]: Model Output is neither Tensor nor Tuple." << std::endl;
     }
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -42,10 +42,9 @@ typedef enum { torch_kCPU, torch_kCUDA } torch_device_t;
  * @param device index for the CUDA case
  * @param whether gradient is required
  */
-EXPORT_C torch_tensor_t torch_zeros(int ndim, const int64_t *shape,
-                                    torch_data_t dtype,
-                                    torch_device_t device_type,
-                                    int device_index, const bool requires_grad);
+EXPORT_C torch_tensor_t torch_zeros(int ndim, const int64_t *shape, torch_data_t dtype,
+                                    torch_device_t device_type, int device_index,
+                                    const bool requires_grad);
 
 /**
  * Function to generate a Torch Tensor of ones
@@ -56,8 +55,7 @@ EXPORT_C torch_tensor_t torch_zeros(int ndim, const int64_t *shape,
  * @param device index for the CUDA case
  * @param whether gradient is required
  */
-EXPORT_C torch_tensor_t torch_ones(int ndim, const int64_t *shape,
-                                   torch_data_t dtype,
+EXPORT_C torch_tensor_t torch_ones(int ndim, const int64_t *shape, torch_data_t dtype,
                                    torch_device_t device_type, int device_index,
                                    const bool requires_grad);
 
@@ -70,10 +68,9 @@ EXPORT_C torch_tensor_t torch_ones(int ndim, const int64_t *shape,
  * @param device index for the CUDA case
  * @param whether gradient is required
  */
-EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t *shape,
-                                    torch_data_t dtype,
-                                    torch_device_t device_type,
-                                    int device_index, const bool requires_grad);
+EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t *shape, torch_data_t dtype,
+                                    torch_device_t device_type, int device_index,
+                                    const bool requires_grad);
 
 /**
  * Function to create a Torch Tensor from memory location given extra
@@ -88,10 +85,10 @@ EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t *shape,
  * @param whether gradient is required
  * @return Torch Tensor interpretation of the data pointed at
  */
-EXPORT_C torch_tensor_t torch_from_blob(
-    void *data, int ndim, const int64_t *shape, const int64_t *strides,
-    torch_data_t dtype, torch_device_t device_type, int device_index,
-    const bool requires_grad);
+EXPORT_C torch_tensor_t torch_from_blob(void *data, int ndim, const int64_t *shape,
+                                        const int64_t *strides, torch_data_t dtype,
+                                        torch_device_t device_type, int device_index,
+                                        const bool requires_grad);
 
 /**
  * Function to extract a C-array from a Torch Tensor's data.
@@ -100,8 +97,7 @@ EXPORT_C torch_tensor_t torch_from_blob(
  * @param data type of the elements of the Tensor
  * @return pointer to the Tensor in memory
  */
-EXPORT_C void *torch_to_blob(const torch_tensor_t tensor,
-                             const torch_data_t dtype);
+EXPORT_C void *torch_to_blob(const torch_tensor_t tensor, const torch_data_t dtype);
 
 /**
  * Function to print out a Torch Tensor
@@ -131,8 +127,7 @@ EXPORT_C int torch_tensor_get_rank(const torch_tensor_t tensor);
 #ifdef UNIX
 EXPORT_C const long int *torch_tensor_get_sizes(const torch_tensor_t tensor);
 #else
-EXPORT_C const long long int *
-torch_tensor_get_sizes(const torch_tensor_t tensor);
+EXPORT_C const long long int *torch_tensor_get_sizes(const torch_tensor_t tensor);
 #endif
 
 /**
@@ -154,9 +149,11 @@ EXPORT_C void torch_tensor_delete(torch_tensor_t tensor);
  * @param whether model is being trained
  * @return Torch Module loaded in from file
  */
-EXPORT_C torch_jit_script_module_t torch_jit_load(
-    const char *filename, const torch_device_t device_type,
-    const int device_index, const bool requires_grad, const bool is_training);
+EXPORT_C torch_jit_script_module_t torch_jit_load(const char *filename,
+                                                  const torch_device_t device_type,
+                                                  const int device_index,
+                                                  const bool requires_grad,
+                                                  const bool is_training);
 
 /**
  * Function to run the `forward` method of a Torch Module
@@ -168,9 +165,8 @@ EXPORT_C torch_jit_script_module_t torch_jit_load(
  * @param whether gradient is required
  */
 EXPORT_C void torch_jit_module_forward(const torch_jit_script_module_t module,
-                                       const torch_tensor_t *inputs,
-                                       const int nin, torch_tensor_t *outputs,
-                                       const int nout,
+                                       const torch_tensor_t *inputs, const int nin,
+                                       torch_tensor_t *outputs, const int nout,
                                        const bool requires_grad);
 
 /**

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -128,7 +128,12 @@ EXPORT_C int torch_tensor_get_rank(const torch_tensor_t tensor);
  * @param Torch Tensor to determine the rank of
  * @return pointer to the sizes array of the Torch Tensor
  */
+#ifdef UNIX
 EXPORT_C const long int *torch_tensor_get_sizes(const torch_tensor_t tensor);
+#else
+EXPORT_C const long long int *
+torch_tensor_get_sizes(const torch_tensor_t tensor);
+#endif
 
 /**
  * Function to delete a Torch Tensor to clean up

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -367,9 +367,13 @@ contains
 
   !> Determines the shape of a tensor.
   function get_shape(self) result(sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_long, c_ptr
+    use, intrinsic :: iso_c_binding, only : c_int, c_long, c_long_long, c_ptr
     class(torch_tensor), intent(in) :: self
+#ifdef UNIX
     integer(kind=c_long), pointer :: sizes(:) !! Pointer to tensor data
+#else
+    integer(kind=c_long_long), pointer :: sizes(:) !! Pointer to tensor data
+#endif
     integer(kind=int32) :: ndims(1)
     type(c_ptr) :: cptr
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -334,9 +334,13 @@ contains
 
   !> Determines the shape of a tensor.
   function get_shape(self) result(sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_long, c_ptr
+    use, intrinsic :: iso_c_binding, only : c_int, c_long, c_long_long, c_ptr
     class(torch_tensor), intent(in) :: self
+#ifdef UNIX
     integer(kind=c_long), pointer :: sizes(:) !! Pointer to tensor data
+#else
+    integer(kind=c_long_long), pointer :: sizes(:) !! Pointer to tensor data
+#endif
     integer(kind=int32) :: ndims(1)
     type(c_ptr) :: cptr
 


### PR DESCRIPTION
closes #183 

## Problem
This issue also affected windows and is also fixed by this PR.

Tldr; `FTorch` expects a `long int*` whilst the `libtorch` binary seems to be returning a `long long int*`.

Example output below.
```
[ 25%] Building CXX object CMakeFiles/ftorch.dir/ctorch.cpp.o
/Users/user/FTorch/src/ctorch.cpp: In function 'const long int* torch_tensor_get_sizes(torch_tensor_t)':
/Users/user/FTorch/src/ctorch.cpp:240:25: error: invalid conversion from 'const long long int*' to 'const long int*' [-fpermissive]
  240 |   return t->sizes().data();
      |          ~~~~~~~~~~~~~~~^~
      |                         |
      |                         const long long int*
```
## Solution
The solution is to check which system we are running on (OS and architecture) and create a preprocess macro `-DUNIX` that we can use to switch between `long long int` and `long int` versions of the `libtorch` library. 
https://github.com/Cambridge-ICCS/FTorch/blob/5fb08873c1910f0eff7e6b0424e7ce63a365fcde/src/CMakeLists.txt#L57-L62

Then in the source code we check for that macro e.g.,
https://github.com/Cambridge-ICCS/FTorch/blob/5fb08873c1910f0eff7e6b0424e7ce63a365fcde/src/ctorch.h#L128-L132

## TODO
- [x] works on windows
- [x] works on linux
- [ ] works on mac (M1/M2)
- [x] create windows CI (this will be a separate PR) #168