### PR TITLE
test: make integration tests cross-platform

### DIFF
--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -68,7 +68,12 @@ jobs:
           export BUILD_DIR=$(pwd)/src/build
           mkdir ${BUILD_DIR}
           cd ${BUILD_DIR}
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} -DCMAKE_BUILD_TESTS=TRUE -DCMAKE_Fortran_FLAGS="-std=${{ matrix.std }}"
+          cmake .. \
+            -DPython_EXECUTABLE="$(which python)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} \
+            -DCMAKE_BUILD_TESTS=TRUE \
+            -DCMAKE_Fortran_FLAGS="-std=${{matrix.std}}"
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -69,15 +69,23 @@ jobs:
         shell: cmd
         run: |
           cd src
-          cmake -Bbuild -G "NMake Makefiles" -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" -DCMAKE_PREFIX_PATH="C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages" -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER=ifx -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icx -DCMAKE_BUILD_TESTS=TRUE
+          cmake ^
+            -Bbuild ^
+            -G "NMake Makefiles" ^
+            -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" ^
+            -DCMAKE_PREFIX_PATH="C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages" ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            -DCMAKE_Fortran_COMPILER=ifx ^
+            -DCMAKE_C_COMPILER=icx ^
+            -DCMAKE_CXX_COMPILER=icx ^
+            -DCMAKE_BUILD_TESTS=TRUE
           cmake --build build
           cmake --install build
 
       - name: Integration tests
         shell: cmd
         run: |
-          cd src
           set PATH=C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages;%PATH%
           set PATH=C:\Program Files (x86)\FTorch\bin;%PATH%
           set PATH=C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages\torch\lib;%PATH%
-          ..\run_integration_tests.bat
+          run_integration_tests.bat

--- a/examples/1_SimpleNet/CMakeLists.txt
+++ b/examples/1_SimpleNet/CMakeLists.txt
@@ -24,18 +24,18 @@ if(CMAKE_BUILD_TESTS)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
   add_test(NAME simplenet
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py)
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py)
 
   # 2. Check the model is saved to file in the expected location with the pt2ts.py script
   add_test(NAME pt2ts
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
     ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 3. Check the model can be loaded from file and run in Python and that its outputs
   #    meet expectations
   add_test(NAME simplenet_infer_python
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet_infer_python.py
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet_infer_python.py
     ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 

--- a/examples/1_SimpleNet/pt2ts.py
+++ b/examples/1_SimpleNet/pt2ts.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os

--- a/examples/1_SimpleNet/simplenet.py
+++ b/examples/1_SimpleNet/simplenet.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Module defining a simple PyTorch 'Net' for coupling to Fortran."""
 
 import torch

--- a/examples/1_SimpleNet/simplenet_infer_python.py
+++ b/examples/1_SimpleNet/simplenet_infer_python.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Load saved SimpleNet to TorchScript and run inference example."""
 
 import os

--- a/examples/2_ResNet18/CMakeLists.txt
+++ b/examples/2_ResNet18/CMakeLists.txt
@@ -24,12 +24,12 @@ if(CMAKE_BUILD_TESTS)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
   add_test(NAME resnet18
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/resnet18.py
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/resnet18.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
   # 2. Check the model is saved to file in the expected location with the pt2ts.py script
   add_test(NAME pt2ts
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
     ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 

--- a/examples/2_ResNet18/pt2ts.py
+++ b/examples/2_ResNet18/pt2ts.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os

--- a/examples/2_ResNet18/resnet18.py
+++ b/examples/2_ResNet18/resnet18.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Load and run pretrained ResNet-18 from TorchVision."""
 
 import numpy as np

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -24,18 +24,18 @@ if(CMAKE_BUILD_TESTS)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
   add_test(NAME multiionet
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet.py)
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet.py)
 
   # 2. Check the model is saved to file in the expected location with the pt2ts.py script
   add_test(NAME pt2ts
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
     ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 3. Check the model can be loaded from file and run in Python and that its outputs
   #    meet expectations
   add_test(NAME multiionet_infer_python
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet_infer_python.py
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet_infer_python.py
     ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 

--- a/examples/4_MultiIO/multiionet.py
+++ b/examples/4_MultiIO/multiionet.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Module defining a simple PyTorch 'Net' for coupling to Fortran."""
 
 import torch

--- a/examples/4_MultiIO/multiionet_infer_python.py
+++ b/examples/4_MultiIO/multiionet_infer_python.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Load saved MultIONet to TorchScript and run inference example."""
 
 import os

--- a/examples/4_MultiIO/pt2ts.py
+++ b/examples/4_MultiIO/pt2ts.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os

--- a/examples/5_Looping/simplenet.py
+++ b/examples/5_Looping/simplenet.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Module defining a simple PyTorch 'Net' for coupling to Fortran."""
 
 import torch

--- a/examples/6_Autograd/CMakeLists.txt
+++ b/examples/6_Autograd/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CMAKE_BUILD_TESTS)
 
   # 1. Check the Python Autograd script runs successfully
   add_test(NAME pyautograd
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/autograd.py)
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/autograd.py)
 
   # 2. Check the Fortran Autograd script runs successfully
   add_test(NAME fautograd

--- a/examples/6_Autograd/autograd.py
+++ b/examples/6_Autograd/autograd.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Autograd demo taken from https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html."""
 
 import torch

--- a/run_integration_tests.bat
+++ b/run_integration_tests.bat
@@ -9,7 +9,7 @@ rem See `src/test/README.md` for more details on integration testing.
 rem ---
 
 for /d %%i in (1_SimpleNet 2_ResNet18 4_MultiIO) do (
-pushd build\test\examples\%%i
+pushd src\build\test\examples\%%i
 rem run the tests
 ctest
 rem The following line will propagate the error back to the cmd shell

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,10 +102,8 @@ install(FILES "${CMAKE_BINARY_DIR}/modules/ftorch_test_utils.mod"
 # Build integration tests
 if(CMAKE_BUILD_TESTS)
 
-  if (WIN32)
-    find_package (Python COMPONENTS Interpreter)
-    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-  endif ()
+  set (Python3_FIND_VIRTUALENV FIRST)
+  find_package (Python COMPONENTS Interpreter REQUIRED)
 
   file(MAKE_DIRECTORY test/examples)
   file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/CMakeLists.txt

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -30,5 +30,5 @@ which operating system you are running, you will need:
 - `./run_integration_tests.sh` for unix (mac and linux)
 - `run_integration_tests.bat` for windows
 
-This will automatically install any additional dependencies for the examples and
-run the tests.
+This will automatically install any additional Python dependencies for the
+examples and run the tests.


### PR DESCRIPTION
this makes the integration tests more portable.

- [x] change permissions on python files so they are no longer executables
- [x] remove python shebang from said python files
- [x] update `CMakeLists.txt` to require python interpreter (for building tests only) and use `Python_EXECUTABLE` which is set by `find_package (Python COMPONENTS Interpreter REQUIRED)`