### PR TITLE
Apply CMake formatting

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -107,11 +107,11 @@ jobs:
           ruff format --diff ./
           ruff check --diff ./
 
-      # Apply CMake formatter, cmake-format
+      # Apply CMake linter, cmake-lint
       - name: cmake
         if: always()
         run: |
           cd ${{ github.workspace }}
           . ftorch_venv/bin/activate
           pip install cmakelang
-          cmake-format -i $(find . -name CMakeLists.txt)
+          cmake-lint $(find . -name CMakeLists.txt)

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -62,6 +62,15 @@ jobs:
           cd ${BUILD_DIR}
           cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} -DCMAKE_Fortran_FLAGS="-std=f2008" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
+      # Apply CMake linter, cmake-lint
+      - name: cmake
+        if: always()
+        run: |
+          cd ${{ github.workspace }}
+          . ftorch_venv/bin/activate
+          pip install cmakelang
+          cmake-lint $(find . -name CMakeLists.txt)
+
       # Apply Fortran linter, fortitude
       # Configurable using the fortitude.toml file if present
       - name: fortitude source
@@ -106,12 +115,3 @@ jobs:
           . ftorch_venv/bin/activate
           ruff format --diff ./
           ruff check --diff ./
-
-      # Apply CMake linter, cmake-lint
-      - name: cmake
-        if: always()
-        run: |
-          cd ${{ github.workspace }}
-          . ftorch_venv/bin/activate
-          pip install cmakelang
-          cmake-lint $(find . -name CMakeLists.txt)

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -68,7 +68,6 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           . ftorch_venv/bin/activate
-          pip install cmakelang
           cmake-lint $(find . -name CMakeLists.txt)
 
       # Apply Fortran linter, fortitude

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -98,6 +98,7 @@ jobs:
           . ftorch_venv/bin/activate
           fortitude check examples
 
+      # Apply Python linter, ruff
       - name: ruff
         if: always()
         run: |
@@ -105,3 +106,12 @@ jobs:
           . ftorch_venv/bin/activate
           ruff format --diff ./
           ruff check --diff ./
+
+      # Apply CMake formatter, cmake-format
+      - name: cmake
+        if: always()
+        run: |
+          cd ${{ github.workspace }}
+          . ftorch_venv/bin/activate
+          pip install cmakelang
+          cmake-format -i $(find . -name CMakeLists.txt)

--- a/examples/1_SimpleNet/CMakeLists.txt
+++ b/examples/1_SimpleNet/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-#policy CMP0076 - target_sources source files are relative to file where target_sources is run
-cmake_policy (SET CMP0076 NEW)
+# policy CMP0076 - target_sources source files are relative to file where
+# target_sources is run
+cmake_policy(SET CMP0076 NEW)
 
 set(PROJECT_NAME SimpleNetExample)
 
@@ -8,7 +9,9 @@ project(${PROJECT_NAME} LANGUAGES Fortran)
 
 # Build in Debug mode if not specified
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+  set(CMAKE_BUILD_TYPE
+      Debug
+      CACHE STRING "" FORCE)
 endif()
 
 find_package(FTorch)
@@ -23,28 +26,37 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
-  add_test(NAME simplenet
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py)
+  add_test(NAME simplenet COMMAND ${PYTHON_EXECUTABLE}
+                                  ${PROJECT_SOURCE_DIR}/simplenet.py)
 
-  # 2. Check the model is saved to file in the expected location with the pt2ts.py script
-  add_test(NAME pt2ts
+  # 1. Check the model is saved to file in the expected location with the
+  #   pt2ts.py script
+  add_test(
+    NAME pt2ts
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-    ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving the model
+            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
+                                  # the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-  # 3. Check the model can be loaded from file and run in Python and that its outputs
-  #    meet expectations
-  add_test(NAME simplenet_infer_python
+  # 1. Check the model can be loaded from file and run in Python and that its
+  #   outputs meet expectations
+  add_test(
+    NAME simplenet_infer_python
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet_infer_python.py
-    ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the model
+            ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the
+                                  # model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-  # 4. Check the model can be loaded from file and run in Fortran and that its outputs
-  #    meet expectations
-  add_test(NAME simplenet_infer_fortran
-    COMMAND simplenet_infer_fortran
-    ${PROJECT_BINARY_DIR}/saved_simplenet_model_cpu.pt # Command line argument: model file
+  # 1. Check the model can be loaded from file and run in Fortran and that its
+  #   outputs meet expectations
+  add_test(
+    NAME simplenet_infer_fortran
+    COMMAND
+      simplenet_infer_fortran
+      ${PROJECT_BINARY_DIR}/saved_simplenet_model_cpu.pt # Command line
+                                                         # argument: model file
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  set_tests_properties(simplenet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-    "SimpleNet example ran successfully")
+  set_tests_properties(
+    simplenet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+                                       "SimpleNet example ran successfully")
 endif()

--- a/examples/1_SimpleNet/CMakeLists.txt
+++ b/examples/1_SimpleNet/CMakeLists.txt
@@ -34,8 +34,8 @@ if(CMAKE_BUILD_TESTS)
   add_test(
     NAME pt2ts
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
-                                  # the model
+            ${PROJECT_BINARY_DIR}
+    # Command line argument: filepath for saving the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 1. Check the model can be loaded from file and run in Python and that its
@@ -43,8 +43,8 @@ if(CMAKE_BUILD_TESTS)
   add_test(
     NAME simplenet_infer_python
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet_infer_python.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the
-                                  # model
+            ${PROJECT_BINARY_DIR}
+    # Command line argument: filepath to find the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 1. Check the model can be loaded from file and run in Fortran and that its
@@ -53,8 +53,8 @@ if(CMAKE_BUILD_TESTS)
     NAME simplenet_infer_fortran
     COMMAND
       simplenet_infer_fortran
-      ${PROJECT_BINARY_DIR}/saved_simplenet_model_cpu.pt # Command line
-                                                         # argument: model file
+      ${PROJECT_BINARY_DIR}/saved_simplenet_model_cpu.pt
+      # Command line argument: model file
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(
     simplenet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION

--- a/examples/2_ResNet18/CMakeLists.txt
+++ b/examples/2_ResNet18/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-#policy CMP0076 - target_sources source files are relative to file where target_sources is run
-cmake_policy (SET CMP0076 NEW)
+# policy CMP0076 - target_sources source files are relative to file where
+# target_sources is run
+cmake_policy(SET CMP0076 NEW)
 
 set(PROJECT_NAME ResNetExample)
 
@@ -8,7 +9,9 @@ project(${PROJECT_NAME} LANGUAGES Fortran)
 
 # Build in Debug mode if not specified
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+  set(CMAKE_BUILD_TYPE
+      Debug
+      CACHE STRING "" FORCE)
 endif()
 
 find_package(FTorch)
@@ -23,23 +26,32 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
-  add_test(NAME resnet18
+  add_test(
+    NAME resnet18
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/resnet18.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
-  # 2. Check the model is saved to file in the expected location with the pt2ts.py script
-  add_test(NAME pt2ts
+  # 1. Check the model is saved to file in the expected location with the
+  #   pt2ts.py script
+  add_test(
+    NAME pt2ts
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-    ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving the model
+            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
+                                  # the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-  # 3. Check the model can be loaded from file and run in Fortran and that its outputs
-  #    meet expectations
-  add_test(NAME resnet_infer_fortran
-    COMMAND resnet_infer_fortran
-    ${PROJECT_BINARY_DIR}/saved_resnet18_model_cpu.pt # Command line argument: model file
-    ${PROJECT_SOURCE_DIR}/data # Command line argument: data directory filepath
+  # 1. Check the model can be loaded from file and run in Fortran and that its
+  #   outputs meet expectations
+  add_test(
+    NAME resnet_infer_fortran
+    COMMAND
+      resnet_infer_fortran
+      ${PROJECT_BINARY_DIR}/saved_resnet18_model_cpu.pt # Command line argument:
+                                                        # model file
+      ${PROJECT_SOURCE_DIR}/data # Command line argument: data directory
+                                 # filepath
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  set_tests_properties(resnet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-    "ResNet18 example ran successfully")
+  set_tests_properties(
+    resnet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+                                    "ResNet18 example ran successfully")
 endif()

--- a/examples/2_ResNet18/CMakeLists.txt
+++ b/examples/2_ResNet18/CMakeLists.txt
@@ -36,8 +36,8 @@ if(CMAKE_BUILD_TESTS)
   add_test(
     NAME pt2ts
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
-                                  # the model
+            ${PROJECT_BINARY_DIR}
+    # Command line argument: filepath for saving the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 1. Check the model can be loaded from file and run in Fortran and that its
@@ -46,10 +46,9 @@ if(CMAKE_BUILD_TESTS)
     NAME resnet_infer_fortran
     COMMAND
       resnet_infer_fortran
-      ${PROJECT_BINARY_DIR}/saved_resnet18_model_cpu.pt # Command line argument:
-                                                        # model file
-      ${PROJECT_SOURCE_DIR}/data # Command line argument: data directory
-                                 # filepath
+      ${PROJECT_BINARY_DIR}/saved_resnet18_model_cpu.pt
+      ${PROJECT_SOURCE_DIR}/data
+      # Command line arguments: model file and data directory filepath
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(
     resnet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-#policy CMP0076 - target_sources source files are relative to file where target_sources is run
-cmake_policy (SET CMP0076 NEW)
+# policy CMP0076 - target_sources source files are relative to file where
+# target_sources is run
+cmake_policy(SET CMP0076 NEW)
 
 set(PROJECT_NAME MultiGPUExample)
 
@@ -8,7 +9,9 @@ project(${PROJECT_NAME} LANGUAGES Fortran)
 
 # Build in Debug mode if not specified
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+  set(CMAKE_BUILD_TYPE
+      Debug
+      CACHE STRING "" FORCE)
 endif()
 
 find_package(FTorch)

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-#policy CMP0076 - target_sources source files are relative to file where target_sources is run
-cmake_policy (SET CMP0076 NEW)
+# policy CMP0076 - target_sources source files are relative to file where
+# target_sources is run
+cmake_policy(SET CMP0076 NEW)
 
 set(PROJECT_NAME MultiIONetExample)
 
@@ -8,7 +9,9 @@ project(${PROJECT_NAME} LANGUAGES Fortran)
 
 # Build in Debug mode if not specified
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+  set(CMAKE_BUILD_TYPE
+      Debug
+      CACHE STRING "" FORCE)
 endif()
 
 find_package(FTorch)
@@ -23,28 +26,37 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
-  add_test(NAME multiionet
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet.py)
+  add_test(NAME multiionet COMMAND ${PYTHON_EXECUTABLE}
+                                   ${PROJECT_SOURCE_DIR}/multiionet.py)
 
-  # 2. Check the model is saved to file in the expected location with the pt2ts.py script
-  add_test(NAME pt2ts
+  # 1. Check the model is saved to file in the expected location with the
+  #   pt2ts.py script
+  add_test(
+    NAME pt2ts
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-    ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving the model
+            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
+                                  # the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-  # 3. Check the model can be loaded from file and run in Python and that its outputs
-  #    meet expectations
-  add_test(NAME multiionet_infer_python
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet_infer_python.py
-    ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the model
+  # 1. Check the model can be loaded from file and run in Python and that its
+  #   outputs meet expectations
+  add_test(
+    NAME multiionet_infer_python
+    COMMAND
+      ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet_infer_python.py
+      ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-  # 4. Check the model can be loaded from file and run in Fortran and that its outputs
-  #    meet expectations
-  add_test(NAME multiionet_infer_fortran
-    COMMAND multiionet_infer_fortran
-    ${PROJECT_BINARY_DIR}/saved_multiio_model_cpu.pt # Command line argument: model file
+  # 1. Check the model can be loaded from file and run in Fortran and that its
+  #   outputs meet expectations
+  add_test(
+    NAME multiionet_infer_fortran
+    COMMAND
+      multiionet_infer_fortran
+      ${PROJECT_BINARY_DIR}/saved_multiio_model_cpu.pt # Command line argument:
+                                                       # model file
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  set_tests_properties(multiionet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-    "MultiIO example ran successfully")
+  set_tests_properties(
+    multiionet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+                                        "MultiIO example ran successfully")
 endif()

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -34,8 +34,8 @@ if(CMAKE_BUILD_TESTS)
   add_test(
     NAME pt2ts
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
-                                  # the model
+            ${PROJECT_BINARY_DIR}
+    # Command line argument: filepath for saving the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 1. Check the model can be loaded from file and run in Python and that its
@@ -44,7 +44,8 @@ if(CMAKE_BUILD_TESTS)
     NAME multiionet_infer_python
     COMMAND
       ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet_infer_python.py
-      ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the model
+      ${PROJECT_BINARY_DIR}
+    # Command line argument: filepath to find the model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 1. Check the model can be loaded from file and run in Fortran and that its
@@ -53,8 +54,8 @@ if(CMAKE_BUILD_TESTS)
     NAME multiionet_infer_fortran
     COMMAND
       multiionet_infer_fortran
-      ${PROJECT_BINARY_DIR}/saved_multiio_model_cpu.pt # Command line argument:
-                                                       # model file
+      ${PROJECT_BINARY_DIR}/saved_multiio_model_cpu.pt
+      # Command line argument: model file
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(
     multiionet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION

--- a/examples/5_Looping/CMakeLists.txt
+++ b/examples/5_Looping/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-#policy CMP0076 - target_sources source files are relative to file where target_sources is run
-cmake_policy (SET CMP0076 NEW)
+# policy CMP0076 - target_sources source files are relative to file where
+# target_sources is run
+cmake_policy(SET CMP0076 NEW)
 
 set(PROJECT_NAME LoopingExample)
 
@@ -8,7 +9,9 @@ project(${PROJECT_NAME} LANGUAGES Fortran)
 
 # Build in Debug mode if not specified
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+  set(CMAKE_BUILD_TYPE
+      Debug
+      CACHE STRING "" FORCE)
 endif()
 
 find_package(FTorch)
@@ -17,9 +20,9 @@ message(STATUS "Building with Fortran PyTorch coupling")
 # Fortran example - bad
 add_executable(simplenet_infer_fortran_bad bad/simplenet_infer_fortran.f90)
 target_link_libraries(simplenet_infer_fortran_bad PRIVATE FTorch::ftorch)
-target_sources ( simplenet_infer_fortran_bad PRIVATE bad/fortran_ml_mod.f90 )
+target_sources(simplenet_infer_fortran_bad PRIVATE bad/fortran_ml_mod.f90)
 
 # Fortran example - good
 add_executable(simplenet_infer_fortran_good good/simplenet_infer_fortran.f90)
 target_link_libraries(simplenet_infer_fortran_good PRIVATE FTorch::ftorch)
-target_sources ( simplenet_infer_fortran_good PRIVATE good/fortran_ml_mod.f90 )
+target_sources(simplenet_infer_fortran_good PRIVATE good/fortran_ml_mod.f90)

--- a/examples/6_Autograd/CMakeLists.txt
+++ b/examples/6_Autograd/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-#policy CMP0076 - target_sources source files are relative to file where target_sources is run
-cmake_policy (SET CMP0076 NEW)
+# policy CMP0076 - target_sources source files are relative to file where
+# target_sources is run
+cmake_policy(SET CMP0076 NEW)
 
 set(PROJECT_NAME AutogradExample)
 
@@ -8,7 +9,9 @@ project(${PROJECT_NAME} LANGUAGES Fortran)
 
 # Build in Debug mode if not specified
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+  set(CMAKE_BUILD_TYPE
+      Debug
+      CACHE STRING "" FORCE)
 endif()
 
 find_package(FTorch)
@@ -23,13 +26,14 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the Python Autograd script runs successfully
-  add_test(NAME pyautograd
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/autograd.py)
+  add_test(NAME pyautograd COMMAND ${PYTHON_EXECUTABLE}
+                                   ${PROJECT_SOURCE_DIR}/autograd.py)
 
-  # 2. Check the Fortran Autograd script runs successfully
-  add_test(NAME fautograd
+  # 1. Check the Fortran Autograd script runs successfully
+  add_test(
+    NAME fautograd
     COMMAND autograd
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(fautograd PROPERTIES PASS_REGULAR_EXPRESSION
-    "Autograd example ran successfully")
+                                            "Autograd example ran successfully")
 endif()

--- a/examples/n_c_and_cpp/CMakeLists.txt
+++ b/examples/n_c_and_cpp/CMakeLists.txt
@@ -3,7 +3,10 @@ set(PROJECT_NAME FTorch)
 set(LIB_NAME ftorch)
 set(PACKAGE_VERSION 0.1)
 
-project(${PROJECT_NAME} VERSION ${PACKAGE_VERSION} LANGUAGES C CXX Fortran)
+project(
+  ${PROJECT_NAME}
+  VERSION ${PACKAGE_VERSION}
+  LANGUAGES C CXX Fortran)
 
 include(FortranCInterface)
 FortranCInterface_VERIFY(CXX QUIET)
@@ -16,19 +19,18 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_SKIP_RPATH FALSE)
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-# Embed absolute paths to external libraries that are not part of
-# the project, (they are expected to be at the same location on all
-# machines the project will be deployed to
+# Embed absolute paths to external libraries that are not part of the project,
+# (they are expected to be at the same location on all machines the project will
+# be deployed to
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Follow GNU conventions for installing directories
 include(GNUInstallDirs)
 
-# Define RPATH for executables via a relative expression to enable a
-# fully relocatable package
-file(RELATIVE_PATH relDir
- ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
- ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+# Define RPATH for executables via a relative expression to enable a fully
+# relocatable package
+file(RELATIVE_PATH relDir ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
+     ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(CMAKE_INSTALL_RPATH $ORIGIN/${relDir})
 
 # Dependencies
@@ -37,37 +39,35 @@ find_package(Torch REQUIRED)
 # Library with C and Fortran bindings
 add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.f90)
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
-set_target_properties(${LIB_NAME} PROPERTIES
-  PUBLIC_HEADER "ctorch.h"
-  Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/modules"
-  )
+set_target_properties(
+  ${LIB_NAME} PROPERTIES PUBLIC_HEADER "ctorch.h" Fortran_MODULE_DIRECTORY
+                                                  "${CMAKE_BINARY_DIR}/modules")
 target_link_libraries(${LIB_NAME} PRIVATE ${TORCH_LIBRARIES})
-target_include_directories(${LIB_NAME}
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/modules>
-#    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
+target_include_directories(
+  ${LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/modules>
+  # $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 # Install library, create target file
-install(TARGETS "${LIB_NAME}"
+install(
+  TARGETS "${LIB_NAME}"
   EXPORT ${PROJECT_NAME}
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PRIVATE_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
-  )
+  INCLUDES
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME})
 
 # Install target file
-install(EXPORT ${PROJECT_NAME}
+install(
+  EXPORT ${PROJECT_NAME}
   FILE ${PROJECT_NAME}Config.cmake
   NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
-  )
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 
 # Install Fortran module files
 install(FILES "${CMAKE_BINARY_DIR}/modules/ftorch.mod"
- DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}"
- )
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}")
 
 # C++ demo
 add_executable(ts_infer_cpp ts_inference.cpp)

--- a/examples/n_c_and_cpp/CMakeLists.txt
+++ b/examples/n_c_and_cpp/CMakeLists.txt
@@ -39,9 +39,11 @@ find_package(Torch REQUIRED)
 # Library with C and Fortran bindings
 add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.f90)
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
+# cmake-format: off
 set_target_properties(
-  ${LIB_NAME} PROPERTIES PUBLIC_HEADER "ctorch.h" Fortran_MODULE_DIRECTORY
-                                                  "${CMAKE_BINARY_DIR}/modules")
+  ${LIB_NAME} PROPERTIES PUBLIC_HEADER "ctorch.h"
+  Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/modules")
+# cmake-format: on
 target_link_libraries(${LIB_NAME} PRIVATE ${TORCH_LIBRARIES})
 target_include_directories(
   ${LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/modules>

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -106,6 +106,7 @@ The tools we use are as follows on a language-by-language basis:
 * C++: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
 * C: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
 * Python: [ruff](https://docs.astral.sh/ruff/)
+* CMake: [cmake-format](https://github.com/cheshirekow/cmake_format)
 
 Instructions on installing these tools can be found in their respective documentations.
 Contributors should run them over their code and ensure that it conforms before submitting

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ruff==0.7.3
 fortitude-lint
 clang-format==19.1.3
 clang-tidy==19.1.0
+cmakelang

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,10 @@ set(PROJECT_NAME FTorch)
 set(LIB_NAME ftorch)
 set(PACKAGE_VERSION 0.1)
 
-project(${PROJECT_NAME} VERSION ${PACKAGE_VERSION} LANGUAGES C CXX Fortran)
+project(
+  ${PROJECT_NAME}
+  VERSION ${PACKAGE_VERSION}
+  LANGUAGES C CXX Fortran)
 
 include(FortranCInterface)
 FortranCInterface_VERIFY(CXX QUIET)
@@ -26,19 +29,18 @@ endif()
 set(CMAKE_SKIP_RPATH FALSE)
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-# Embed absolute paths to external libraries that are not part of
-# the project, (they are expected to be at the same location on all
-# machines the project will be deployed to
+# Embed absolute paths to external libraries that are not part of the project,
+# (they are expected to be at the same location on all machines the project will
+# be deployed to
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Follow GNU conventions for installing directories
 include(GNUInstallDirs)
 
-# Define RPATH for executables via a relative expression to enable a
-# fully relocatable package
-file(RELATIVE_PATH relDir
- ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
- ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+# Define RPATH for executables via a relative expression to enable a fully
+# relocatable package
+file(RELATIVE_PATH relDir ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
+     ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(CMAKE_INSTALL_RPATH $ORIGIN/${relDir})
 
 # Dependencies
@@ -48,66 +50,56 @@ find_package(Torch REQUIRED)
 add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.f90 ftorch_test_utils.f90)
 # Add an alias FTorch::ftorch for the library
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
-set_target_properties(${LIB_NAME} PROPERTIES
-  PUBLIC_HEADER "ctorch.h"
-  Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/modules"
-  )
+set_target_properties(
+  ${LIB_NAME} PROPERTIES PUBLIC_HEADER "ctorch.h" Fortran_MODULE_DIRECTORY
+                                                  "${CMAKE_BINARY_DIR}/modules")
 # Link TorchScript
 target_link_libraries(${LIB_NAME} PRIVATE ${TORCH_LIBRARIES})
 # Include the Fortran mod files in the library
-target_include_directories(${LIB_NAME}
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/modules>
-#    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
+target_include_directories(
+  ${LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/modules>
+  # $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 # Install library, create target file
-install(TARGETS "${LIB_NAME}"
+install(
+  TARGETS "${LIB_NAME}"
   EXPORT ${PROJECT_NAME}
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PRIVATE_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
-  )
+  INCLUDES
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME})
 
 # Install target file
-install(EXPORT ${PROJECT_NAME}
+install(
+  EXPORT ${PROJECT_NAME}
   FILE ${PROJECT_NAME}Config.cmake
   NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-  )
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 # Install Fortran module files
 install(FILES "${CMAKE_BINARY_DIR}/modules/ftorch.mod"
- DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}"
- )
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}")
 install(FILES "${CMAKE_BINARY_DIR}/modules/ftorch_test_utils.mod"
- DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}"
- )
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}")
 
 # Build integration tests
 if(CMAKE_BUILD_TESTS)
   file(MAKE_DIRECTORY test/examples)
   file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/CMakeLists.txt
-    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples
-    )
+       DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples)
   file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/1_SimpleNet
-    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples
-    )
+       DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples)
   file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/2_ResNet18
-    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples
-    )
-  # file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/3_MultiGPU
-  #   DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples
-  #   )
+       DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples)
+  # file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/3_MultiGPU DESTINATION
+  # ${CMAKE_CURRENT_SOURCE_DIR}/test/examples )
   file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/4_MultiIO
-    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples
-    )
-  # file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/5_Looping
-  #   DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples
-  #   )
+       DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples)
+  # file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/5_Looping DESTINATION
+  # ${CMAKE_CURRENT_SOURCE_DIR}/test/examples )
   file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/6_Autograd
-    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples
-    )
+       DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/test/examples)
   add_subdirectory(test/examples)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,9 +50,11 @@ find_package(Torch REQUIRED)
 add_library(${LIB_NAME} SHARED ctorch.cpp ftorch.f90 ftorch_test_utils.f90)
 # Add an alias FTorch::ftorch for the library
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
+# cmake-format: off
 set_target_properties(
-  ${LIB_NAME} PROPERTIES PUBLIC_HEADER "ctorch.h" Fortran_MODULE_DIRECTORY
-                                                  "${CMAKE_BINARY_DIR}/modules")
+  ${LIB_NAME} PROPERTIES PUBLIC_HEADER "ctorch.h"
+  Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/modules")
+# cmake-format: on
 # Link TorchScript
 target_link_libraries(${LIB_NAME} PRIVATE ${TORCH_LIBRARIES})
 # Include the Fortran mod files in the library


### PR DESCRIPTION
Today I discovered a CMake formatter: https://github.com/cheshirekow/cmake_format.

Seems like a good idea to add to the static analysis workflow. I did need to disable the formatter in a couple of places with particularly long lines.

(Most of the changes in this PR are auto-formatting changes.)