### PR TITLE
wip: debugging windows CI

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -70,12 +70,12 @@ jobs:
         run: |
           cd src
           rem find torch location
-          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set package_path=%%i
+          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set torch_path=%%i
           cmake ^
             -Bbuild ^
             -G "NMake Makefiles" ^
             -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" ^
-            -DCMAKE_PREFIX_PATH=%package_path% ^
+            -DCMAKE_PREFIX_PATH=%torch_path% ^
             -DCMAKE_BUILD_TYPE=Release ^
             -DCMAKE_Fortran_COMPILER=ifx ^
             -DCMAKE_C_COMPILER=icx ^
@@ -87,7 +87,7 @@ jobs:
       - name: Integration tests
         shell: cmd
         run: |
-          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set package_path=%%i
+          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set torch_path=%%i
           set PATH=C:\Program Files (x86)\FTorch\bin;%PATH%
-          set PATH=%package_path%\torch\lib;%PATH%
+          set PATH=%torch_path%\torch\lib;%PATH%
           run_integration_tests.bat

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -69,11 +69,13 @@ jobs:
         shell: cmd
         run: |
           cd src
+          rem find torch location
+          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set package_path=%%i
           cmake ^
             -Bbuild ^
             -G "NMake Makefiles" ^
             -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" ^
-            -DCMAKE_PREFIX_PATH="C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages" ^
+            -DCMAKE_PREFIX_PATH=%package_path% ^
             -DCMAKE_BUILD_TYPE=Release ^
             -DCMAKE_Fortran_COMPILER=ifx ^
             -DCMAKE_C_COMPILER=icx ^
@@ -85,7 +87,7 @@ jobs:
       - name: Integration tests
         shell: cmd
         run: |
-          set PATH=C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages;%PATH%
+          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set package_path=%%i
           set PATH=C:\Program Files (x86)\FTorch\bin;%PATH%
-          set PATH=C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages\torch\lib;%PATH%
+          set PATH=%package_path%\torch\lib;%PATH%
           run_integration_tests.bat


### PR DESCRIPTION
Previously I hard-coded the path to `libtorch` i.e., 
`-DCMAKE_PREFIX_PATH="C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages"`. 

This commit replaces the hard-code path using `pip show` to get the updated location and store it in a variable `%torch_path%` for later use i.e.,  `-DCMAKE_PREFIX_PATH=%torch_path%`

