### PR TITLE
Call from_blob inside from_array

### DIFF
--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -1249,46 +1249,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     integer(c_int64_t)        :: strides(1)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 1                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int8_1d
 
@@ -1306,46 +1279,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     integer(c_int64_t)        :: strides(2)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 2                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int8_2d
 
@@ -1363,46 +1309,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     integer(c_int64_t)        :: strides(3)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 3                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int8_3d
 
@@ -1420,46 +1339,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     integer(c_int64_t)        :: strides(4)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 4                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int8_4d
 
@@ -1477,46 +1369,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     integer(c_int64_t)        :: strides(5)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 5                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int8_5d
 
@@ -1534,46 +1399,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     integer(c_int64_t)        :: strides(1)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 1                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int16_1d
 
@@ -1591,46 +1429,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     integer(c_int64_t)        :: strides(2)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 2                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int16_2d
 
@@ -1648,46 +1459,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     integer(c_int64_t)        :: strides(3)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 3                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int16_3d
 
@@ -1705,46 +1489,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     integer(c_int64_t)        :: strides(4)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 4                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int16_4d
 
@@ -1762,46 +1519,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     integer(c_int64_t)        :: strides(5)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 5                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int16_5d
 
@@ -1819,46 +1549,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     integer(c_int64_t)        :: strides(1)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 1                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int32_1d
 
@@ -1876,46 +1579,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     integer(c_int64_t)        :: strides(2)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 2                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int32_2d
 
@@ -1933,46 +1609,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     integer(c_int64_t)        :: strides(3)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 3                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int32_3d
 
@@ -1990,46 +1639,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     integer(c_int64_t)        :: strides(4)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 4                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int32_4d
 
@@ -2047,46 +1669,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     integer(c_int64_t)        :: strides(5)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 5                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int32_5d
 
@@ -2104,46 +1699,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     integer(c_int64_t)        :: strides(1)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 1                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int64_1d
 
@@ -2161,46 +1729,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     integer(c_int64_t)        :: strides(2)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 2                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int64_2d
 
@@ -2218,46 +1759,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     integer(c_int64_t)        :: strides(3)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 3                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int64_3d
 
@@ -2275,46 +1789,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     integer(c_int64_t)        :: strides(4)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 4                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int64_4d
 
@@ -2332,46 +1819,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     integer(c_int64_t)        :: strides(5)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 5                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_int64_5d
 
@@ -2389,46 +1849,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     integer(c_int64_t)        :: strides(1)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 1                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real32_1d
 
@@ -2446,46 +1879,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     integer(c_int64_t)        :: strides(2)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 2                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real32_2d
 
@@ -2503,46 +1909,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     integer(c_int64_t)        :: strides(3)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 3                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real32_3d
 
@@ -2560,46 +1939,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     integer(c_int64_t)        :: strides(4)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 4                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real32_4d
 
@@ -2617,46 +1969,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     integer(c_int64_t)        :: strides(5)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 5                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real32_5d
 
@@ -2674,46 +1999,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     integer(c_int64_t)        :: strides(1)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 1                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real64_1d
 
@@ -2731,46 +2029,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     integer(c_int64_t)        :: strides(2)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 2                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real64_2d
 
@@ -2788,46 +2059,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     integer(c_int64_t)        :: strides(3)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 3                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real64_3d
 
@@ -2845,46 +2089,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     integer(c_int64_t)        :: strides(4)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 4                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real64_4d
 
@@ -2902,46 +2119,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     integer(c_int64_t)        :: strides(5)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = 5                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_real64_5d
 

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -220,7 +220,7 @@ contains
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value  !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
 
@@ -271,7 +271,7 @@ contains
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value   !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
 
@@ -322,7 +322,7 @@ contains
     integer(c_int), intent(in)      :: dtype        !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad   !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad   !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value    !! device index used
     logical(c_bool)                 :: requires_grad_value   !! Whether gradients need to be computed for the created tensor
 
@@ -378,7 +378,7 @@ contains
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer(c_int)                  :: i                    !! loop index
     integer(c_int64_t)              :: strides(ndims)       !! Strides for accessing data
@@ -1249,7 +1249,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
@@ -1279,7 +1279,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
@@ -1309,7 +1309,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
@@ -1339,7 +1339,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
@@ -1369,7 +1369,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
@@ -1399,7 +1399,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
@@ -1429,7 +1429,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
@@ -1459,7 +1459,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
@@ -1489,7 +1489,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
@@ -1519,7 +1519,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
@@ -1549,7 +1549,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
@@ -1579,7 +1579,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
@@ -1609,7 +1609,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
@@ -1639,7 +1639,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
@@ -1669,7 +1669,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
@@ -1699,7 +1699,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
@@ -1729,7 +1729,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
@@ -1759,7 +1759,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
@@ -1789,7 +1789,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
@@ -1819,7 +1819,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
@@ -1849,7 +1849,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
@@ -1879,7 +1879,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
@@ -1909,7 +1909,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
@@ -1939,7 +1939,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
@@ -1969,7 +1969,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor
@@ -1999,7 +1999,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(1)            !! Shape of the tensor
@@ -2029,7 +2029,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(2)            !! Shape of the tensor
@@ -2059,7 +2059,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(3)            !! Shape of the tensor
@@ -2089,7 +2089,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(4)            !! Shape of the tensor
@@ -2119,7 +2119,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(5)            !! Shape of the tensor

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -173,7 +173,7 @@ contains
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value  !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
 
@@ -224,7 +224,7 @@ contains
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value   !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
 
@@ -275,7 +275,7 @@ contains
     integer(c_int), intent(in)      :: dtype        !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad   !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad   !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value    !! device index used
     logical(c_bool)                 :: requires_grad_value   !! Whether gradients need to be computed for the created tensor
 
@@ -331,7 +331,7 @@ contains
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer(c_int)                  :: i                    !! loop index
     integer(c_int64_t)              :: strides(ndims)       !! Strides for accessing data
@@ -812,7 +812,7 @@ contains
     integer(ftorch_int), intent(in)      :: layout(${RANK}$)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(${RANK}$)            !! Shape of the tensor

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -812,46 +812,19 @@ contains
     integer(ftorch_int), intent(in)      :: layout(${RANK}$)  !! Control order of indices
     integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in)        :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical(c_bool), optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(${RANK}$)            !! Shape of the tensor
     integer(c_int), parameter :: dtype = ${enum_from_prec(PREC)}$  !! Data type
     integer(c_int64_t)        :: strides(${RANK}$)                 !! Strides for accessing data
     integer(c_int), parameter :: ndims = ${RANK}$                  !! Number of dimension of input data
-    integer(ftorch_int)       :: i
-    integer(c_int)            :: device_index_value
-    logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    ! Process optional arguments
-    if (present(device_index)) then
-      device_index_value = device_index
-    else if (device_type == torch_kCPU) then
-      device_index_value = -1
-    else
-      device_index_value = 0
-    endif
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = .false.
-    else
-      requires_grad_value = requires_grad
-    end if
 
     tensor_shape = shape(data_in)
 
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
-
-    tensor%p = torch_from_blob_c(c_loc(data_in), ndims, tensor_shape,          &
-                                 strides, dtype, device_type,                  &
-                                 device_index_value,                           &
-                                 logical(requires_grad_value, c_bool))
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
 
   end subroutine torch_tensor_from_array_${PREC}$_${RANK}$d
 

--- a/src/test/unit/test_constructors.pf
+++ b/src/test/unit/test_constructors.pf
@@ -20,6 +20,7 @@ subroutine test_torch_tensor_empty()
   integer, parameter :: dtype = torch_kFloat32
   integer, parameter :: device_type = torch_kCPU
   integer, parameter :: device_index = -1
+  logical, parameter :: requires_grad = .false.
   logical :: test_pass
 
   tensor_shape = [2, 3]
@@ -28,7 +29,8 @@ subroutine test_torch_tensor_empty()
   @assertFalse(c_associated(tensor%p))
 
   ! Create a tensor of zeros
-  call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index)
+  call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index, &
+                          requires_grad)
 
   ! Check the tensor pointer is associated
   @assertTrue(c_associated(tensor%p))
@@ -57,6 +59,7 @@ subroutine test_torch_tensor_zeros()
   integer, parameter :: dtype = torch_kFloat32
   integer, parameter :: device_type = torch_kCPU
   integer, parameter :: device_index = -1
+  logical, parameter :: requires_grad = .false.
   real(wp), dimension(:,:), pointer :: out_data
   real(wp), dimension(2,3) :: expected
   logical :: test_pass
@@ -67,7 +70,8 @@ subroutine test_torch_tensor_zeros()
   @assertFalse(c_associated(tensor%p))
 
   ! Create a tensor of zeros
-  call torch_tensor_zeros(tensor, ndims, tensor_shape, dtype, device_type, device_index)
+  call torch_tensor_zeros(tensor, ndims, tensor_shape, dtype, device_type, device_index, &
+                          requires_grad)
 
   ! Check the tensor pointer is associated
   @assertTrue(c_associated(tensor%p))
@@ -105,6 +109,7 @@ subroutine test_torch_tensor_ones()
   integer, parameter :: dtype = torch_kFloat32
   integer, parameter :: device_type = torch_kCPU
   integer, parameter :: device_index = -1
+  logical, parameter :: requires_grad = .false.
   real(wp), dimension(:,:), pointer :: out_data
   real(wp), dimension(2,3) :: expected
   logical :: test_pass
@@ -115,7 +120,8 @@ subroutine test_torch_tensor_ones()
   @assertFalse(c_associated(tensor%p))
 
   ! Create tensor of ones
-  call torch_tensor_ones(tensor, ndims, tensor_shape, dtype, device_type, device_index)
+  call torch_tensor_ones(tensor, ndims, tensor_shape, dtype, device_type, device_index, &
+                         requires_grad)
 
   ! Check the tensor pointer is associated
   @assertTrue(c_associated(tensor%p))
@@ -152,6 +158,7 @@ subroutine test_torch_from_array_1d()
   integer(ftorch_int), parameter :: tensor_layout(ndims) = [1]
   integer, parameter :: device_type = torch_kCPU
   integer, parameter :: device_index = -1
+  logical, parameter :: requires_grad = .false.
   real(wp), dimension(6), target :: in_data
   real(wp), dimension(:), pointer :: out_data
   real(wp), dimension(6) :: expected
@@ -164,7 +171,8 @@ subroutine test_torch_from_array_1d()
   @assertFalse(c_associated(tensor%p))
 
   ! Create a tensor based off an input array
-  call torch_tensor_from_array(tensor, in_data, tensor_layout, device_type, device_index)
+  call torch_tensor_from_array(tensor, in_data, tensor_layout, device_type, device_index, &
+                               requires_grad)
 
   ! Check the tensor pointer is associated
   @assertTrue(c_associated(tensor%p))
@@ -201,6 +209,7 @@ subroutine test_torch_from_array_2d()
   integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 1]
   integer, parameter :: device_type = torch_kCPU
   integer, parameter :: device_index = -1
+  logical, parameter :: requires_grad = .false.
   real(wp), dimension(2,3), target :: in_data
   real(wp), dimension(:,:), pointer :: out_data
   real(wp), dimension(2,3) :: expected
@@ -213,7 +222,8 @@ subroutine test_torch_from_array_2d()
   @assertFalse(c_associated(tensor%p))
 
   ! Create a tensor based off an input array
-  call torch_tensor_from_array(tensor, in_data, tensor_layout, device_type, device_index)
+  call torch_tensor_from_array(tensor, in_data, tensor_layout, device_type, device_index, &
+                               requires_grad)
 
   ! Check the tensor pointer is associated
   @assertTrue(c_associated(tensor%p))
@@ -252,6 +262,7 @@ subroutine test_torch_from_blob()
   integer, parameter :: dtype = torch_kFloat32
   integer, parameter :: device_type = torch_kCPU
   integer, parameter :: device_index = -1
+  logical, parameter :: requires_grad = .false.
   real(wp), dimension(2,3), target :: in_data
   real(wp), dimension(:,:), pointer :: out_data
   real(wp), dimension(2,3) :: expected
@@ -264,7 +275,8 @@ subroutine test_torch_from_blob()
   @assertFalse(c_associated(tensor%p))
 
   ! Create a tensor based off an input array
-  call torch_tensor_from_blob(tensor, c_loc(in_data), ndims, tensor_layout, layout, dtype, device_type, device_index)
+  call torch_tensor_from_blob(tensor, c_loc(in_data), ndims, tensor_layout, layout, dtype, &
+                              device_type, device_index, requires_grad)
 
   ! Check the tensor pointer is associated
   @assertTrue(c_associated(tensor%p))


### PR DESCRIPTION
This PR merges into #76.

I hit a weird bug because all tests passed in debug mode but the new unit test for `torch_tensor_from_array` failed for me locally in release mode, with the following traceback:
```
test 1
    Start 1: test_constructors

1: Test command: /home/joe/software/FTorch/src/build/test/unit/test_constructors "--verbose"
1: Test timeout computed to be: 10000000
1:  
1: 
1:  Start: <test_constructors_suite.test_torch_tensor_empty>
1: .   end: <test_constructors_suite.test_torch_tensor_empty>
1:  
1: 
1:  Start: <test_constructors_suite.test_torch_tensor_zeros>
1: .PASSED :: [test_torch_tensor_zeros] relative tolerance =  0.1000E-04
1:    end: <test_constructors_suite.test_torch_tensor_zeros>
1:  
1: 
1:  Start: <test_constructors_suite.test_torch_tensor_ones>
1: .PASSED :: [test_torch_tensor_ones] relative tolerance =  0.1000E-04
1:    end: <test_constructors_suite.test_torch_tensor_ones>
1:  
1: 
1:  Start: <test_constructors_suite.test_torch_from_array_1d>
1: .PASSED :: [test_torch_tensor_from_array] relative tolerance =  0.1000E-04
1:    end: <test_constructors_suite.test_torch_from_array_1d>
1:  
1: 
1:  Start: <test_constructors_suite.test_torch_from_array_2d>
1: .terminate called after throwing an instance of 'c10::Error'
1:   what():  Storage size calculation overflowed with sizes=[2, 3] and strides=[2, -3]
1: Exception raised from computeStorageNbytes at ../aten/src/ATen/EmptyTensor.cpp:89 (most recent call first):
1: frame #0: c10::Error::Error(c10::SourceLocation, std::string) + 0x57 (0x73f810b6b817 in /home/joe/.virtualenvs/ftorch/lib/python3.10/site-packages/torch/lib/libc10.so)
1: frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::string const&) + 0x64 (0x73f810b1c03f in /home/joe/.virtualenvs/ftorch/lib/python3.10/site-packages/torch/lib/libc10.so)
1: frame #2: at::detail::computeStorageNbytes(c10::ArrayRef<long>, c10::ArrayRef<long>, unsigned long, unsigned long) + 0x35e (0x73f7faa4752e in /home/joe/.virtualenvs/ftorch/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so)
1: frame #3: at::TensorMaker::computeStorageSize() const + 0xab (0x73f7fb6650eb in /home/joe/.virtualenvs/ftorch/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so)
1: frame #4: at::TensorMaker::make_tensor() + 0x438 (0x73f7fb665578 in /home/joe/.virtualenvs/ftorch/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so)
1: frame #5: torch_from_blob + 0x1bf (0x73f810c65c7f in /home/joe/software/FTorch/src/build/libftorch.so)
1: frame #6: __ftorch_MOD_torch_tensor_from_array_real32_2d + 0x1a3 (0x73f810c752e3 in /home/joe/software/FTorch/src/build/libftorch.so)
1: frame #7: <unknown function> + 0xd235 (0x5ee944ff0235 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #8: <unknown function> + 0x1cbdb (0x5ee944fffbdb in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #9: <unknown function> + 0x5047d (0x5ee94503347d in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #10: <unknown function> + 0x50432 (0x5ee945033432 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #11: <unknown function> + 0x70b96 (0x5ee945053b96 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #12: <unknown function> + 0x5061b (0x5ee94503361b in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #13: <unknown function> + 0x506e3 (0x5ee9450336e3 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #14: <unknown function> + 0x1f928 (0x5ee945002928 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #15: <unknown function> + 0x1f928 (0x5ee945002928 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #16: <unknown function> + 0x73e7e (0x5ee945056e7e in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #17: <unknown function> + 0x77a72 (0x5ee94505aa72 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #18: <unknown function> + 0x2c187 (0x5ee94500f187 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #19: <unknown function> + 0x334e7 (0x5ee9450164e7 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #20: <unknown function> + 0x33548 (0x5ee945016548 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #21: <unknown function> + 0xc4cc (0x5ee944fef4cc in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: frame #22: <unknown function> + 0x29d90 (0x73f810429d90 in /lib/x86_64-linux-gnu/libc.so.6)
1: frame #23: __libc_start_main + 0x80 (0x73f810429e40 in /lib/x86_64-linux-gnu/libc.so.6)
1: frame #24: <unknown function> + 0xc505 (0x5ee944fef505 in /home/joe/software/FTorch/src/build/test/unit/test_constructors)
1: 
1: 
1: Program received signal SIGABRT: Process abort signal.
1: 
1: Backtrace for this error:
1: #0  0x73f810823960 in ???
1: #1  0x73f810822ac5 in ???
1: #2  0x73f81044251f in ???
1: 	at ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
1: #3  0x73f8104969fc in __pthread_kill_implementation
1: 	at ./nptl/pthread_kill.c:44
1: #4  0x73f8104969fc in __pthread_kill_internal
1: 	at ./nptl/pthread_kill.c:78
1: #5  0x73f8104969fc in __GI___pthread_kill
1: 	at ./nptl/pthread_kill.c:89
1: #6  0x73f810442475 in __GI_raise
1: 	at ../sysdeps/posix/raise.c:26
1: #7  0x73f8104287f2 in __GI_abort
1: 	at ./stdlib/abort.c:79
1: #8  0x73f7f8ea2b9d in ???
1: #9  0x73f7f8eae20b in ???
1: #10  0x73f7f8ead1e8 in ???
1: #11  0x73f7f8ead958 in ???
1: #12  0x73f810bed883 in ???
1: #13  0x73f810bee2dc in ???
1: #14  0x73f7fa330b3c in ???
1: #15  0x73f7fb6650ea in ???
1: #16  0x73f7fb665577 in ???
1: #17  0x73f810c65c7e in ???
1: #18  0x73f810c752e2 in ???
1: #19  0x5ee944ff0234 in ???
1: #20  0x5ee944fffbda in __pf_testmethod_MOD_runmethod
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestMethod.F90:89
1: #21  0x5ee94503347c in __pf_testcase_MOD_runbare
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestCase.F90:136
1: #22  0x5ee945033431 in __pf_testcase_MOD_runbare_surrogate
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestCase.F90:146
1: #23  0x5ee945053b95 in __pf_testresult_MOD_run
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestResult.F90:237
1: #24  0x5ee94503361a in inner_run
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestCase.F90:121
1: #25  0x5ee9450336e2 in __pf_testcase_MOD_run
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestCase.F90:108
1: #26  0x5ee945002927 in __pf_testsuite_MOD_run
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestSuite.F90:108
1: #27  0x5ee945002927 in __pf_testsuite_MOD_run
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestSuite.F90:108
1: #28  0x5ee945056e7d in __pf_testrunner_MOD_runwithresult
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestRunner.F90:139
1: #29  0x5ee94505aa71 in __pf_testrunner_MOD_run
1: 	at /home/joe/software/tools/pFUnit/src/funit/core/TestRunner.F90:117
1: #30  0x5ee94500f186 in __funit_MOD_generic_run
1: 	at /home/joe/software/tools/pFUnit/src/funit/FUnit.F90:118
1: #31  0x5ee9450164e6 in __funit_MOD_run
1: 	at /home/joe/software/tools/pFUnit/src/funit/FUnit.F90:33
1: #32  0x5ee945016547 in funit_main_
1: 	at /home/joe/software/tools/pFUnit/src/funit/funit_main.F90:16
1: #33  0x5ee944fef4cb in ???
1: #34  0x73f810429d8f in __libc_start_call_main
1: 	at ../sysdeps/nptl/libc_start_call_main.h:58
1: #35  0x73f810429e3f in __libc_start_main_impl
1: 	at ../csu/libc-start.c:392
1: #36  0x5ee944fef504 in ???
1: #37  0xffffffffffffffff in ???
1/1 Test #1: test_constructors ................Subprocess aborted***Exception:   0.42 sec

0% tests passed, 1 tests failed out of 1
```

The other tests, including the new `torch_tensor_from_blob` unit test passed. Given that both `torch_tensor_from_array` and `torch_tensor_from_blob` call the same C function under the hood, I figured something was wrong with the former. Looking closer, it turned out pretty much all the logic in `torch_tensor_from_array` is duplicated from `torch_tensor_from_blob` anyway. So in this PR I make it so that the former just calls the latter.