### PR TITLE
Reorganise main mod

### DIFF
--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -219,7 +219,7 @@ contains
     integer(c_int64_t), intent(in)  :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value  !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
@@ -270,7 +270,7 @@ contains
     integer(c_int64_t), intent(in)  :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value   !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
@@ -321,8 +321,8 @@ contains
     integer(c_int64_t), intent(in)  :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)      :: dtype        !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in) :: requires_grad   !! Whether gradients need to be computed for the created tensor
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value    !! device index used
     logical(c_bool)                 :: requires_grad_value   !! Whether gradients need to be computed for the created tensor
 
@@ -377,7 +377,7 @@ contains
     integer(c_int), intent(in)      :: layout(*)  !! Layout for strides for accessing data
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer(c_int)                  :: i                    !! loop index
@@ -1246,9 +1246,9 @@ contains
 
     ! inputs
     integer(kind=int8), intent(in), target :: data_in(:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(1)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1276,9 +1276,9 @@ contains
 
     ! inputs
     integer(kind=int8), intent(in), target :: data_in(:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(2)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1306,9 +1306,9 @@ contains
 
     ! inputs
     integer(kind=int8), intent(in), target :: data_in(:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(3)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1336,9 +1336,9 @@ contains
 
     ! inputs
     integer(kind=int8), intent(in), target :: data_in(:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(4)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1366,9 +1366,9 @@ contains
 
     ! inputs
     integer(kind=int8), intent(in), target :: data_in(:,:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(5)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1396,9 +1396,9 @@ contains
 
     ! inputs
     integer(kind=int16), intent(in), target :: data_in(:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(1)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1426,9 +1426,9 @@ contains
 
     ! inputs
     integer(kind=int16), intent(in), target :: data_in(:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(2)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1456,9 +1456,9 @@ contains
 
     ! inputs
     integer(kind=int16), intent(in), target :: data_in(:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(3)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1486,9 +1486,9 @@ contains
 
     ! inputs
     integer(kind=int16), intent(in), target :: data_in(:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(4)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1516,9 +1516,9 @@ contains
 
     ! inputs
     integer(kind=int16), intent(in), target :: data_in(:,:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(5)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1546,9 +1546,9 @@ contains
 
     ! inputs
     integer(kind=int32), intent(in), target :: data_in(:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(1)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1576,9 +1576,9 @@ contains
 
     ! inputs
     integer(kind=int32), intent(in), target :: data_in(:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(2)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1606,9 +1606,9 @@ contains
 
     ! inputs
     integer(kind=int32), intent(in), target :: data_in(:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(3)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1636,9 +1636,9 @@ contains
 
     ! inputs
     integer(kind=int32), intent(in), target :: data_in(:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(4)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1666,9 +1666,9 @@ contains
 
     ! inputs
     integer(kind=int32), intent(in), target :: data_in(:,:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(5)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1696,9 +1696,9 @@ contains
 
     ! inputs
     integer(kind=int64), intent(in), target :: data_in(:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(1)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1726,9 +1726,9 @@ contains
 
     ! inputs
     integer(kind=int64), intent(in), target :: data_in(:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(2)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1756,9 +1756,9 @@ contains
 
     ! inputs
     integer(kind=int64), intent(in), target :: data_in(:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(3)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1786,9 +1786,9 @@ contains
 
     ! inputs
     integer(kind=int64), intent(in), target :: data_in(:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(4)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1816,9 +1816,9 @@ contains
 
     ! inputs
     integer(kind=int64), intent(in), target :: data_in(:,:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(5)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1846,9 +1846,9 @@ contains
 
     ! inputs
     real(kind=real32), intent(in), target :: data_in(:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(1)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1876,9 +1876,9 @@ contains
 
     ! inputs
     real(kind=real32), intent(in), target :: data_in(:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(2)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1906,9 +1906,9 @@ contains
 
     ! inputs
     real(kind=real32), intent(in), target :: data_in(:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(3)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1936,9 +1936,9 @@ contains
 
     ! inputs
     real(kind=real32), intent(in), target :: data_in(:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(4)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1966,9 +1966,9 @@ contains
 
     ! inputs
     real(kind=real32), intent(in), target :: data_in(:,:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(5)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -1996,9 +1996,9 @@ contains
 
     ! inputs
     real(kind=real64), intent(in), target :: data_in(:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(1)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(1)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -2026,9 +2026,9 @@ contains
 
     ! inputs
     real(kind=real64), intent(in), target :: data_in(:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(2)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(2)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -2056,9 +2056,9 @@ contains
 
     ! inputs
     real(kind=real64), intent(in), target :: data_in(:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(3)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(3)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -2086,9 +2086,9 @@ contains
 
     ! inputs
     real(kind=real64), intent(in), target :: data_in(:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(4)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(4)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data
@@ -2116,9 +2116,9 @@ contains
 
     ! inputs
     real(kind=real64), intent(in), target :: data_in(:,:,:,:,:)  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(5)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(5)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -8,13 +8,10 @@
 
 module ftorch
 
-  use, intrinsic :: iso_c_binding, only: c_int, c_int8_t, c_int16_t, c_int32_t, c_int64_t, &
-                                         c_float, c_double, c_char, c_ptr, c_null_ptr, c_f_pointer
-  use, intrinsic :: iso_fortran_env, only: int8, int16, int32, int64, real32, real64
+  use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
+  use, intrinsic :: iso_fortran_env, only: ftorch_int => int32 ! set integer size for FTorch library
 
   implicit none
-
-  integer, parameter :: ftorch_int = int32  ! set integer size for FTorch library
 
   !> Type for holding a torch neural net (nn.Module).
   type torch_model
@@ -420,7 +417,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int8`
   subroutine torch_tensor_from_array_int8_1d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! output tensor
@@ -450,7 +447,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int8`
   subroutine torch_tensor_from_array_int8_2d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! output tensor
@@ -480,7 +477,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int8`
   subroutine torch_tensor_from_array_int8_3d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! output tensor
@@ -510,7 +507,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int8`
   subroutine torch_tensor_from_array_int8_4d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! output tensor
@@ -540,7 +537,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 5 containing data of type `int8`
   subroutine torch_tensor_from_array_int8_5d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int8
 
     ! output tensor
@@ -570,7 +567,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int16`
   subroutine torch_tensor_from_array_int16_1d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! output tensor
@@ -600,7 +597,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int16`
   subroutine torch_tensor_from_array_int16_2d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! output tensor
@@ -630,7 +627,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int16`
   subroutine torch_tensor_from_array_int16_3d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! output tensor
@@ -660,7 +657,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int16`
   subroutine torch_tensor_from_array_int16_4d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! output tensor
@@ -690,7 +687,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 5 containing data of type `int16`
   subroutine torch_tensor_from_array_int16_5d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int16
 
     ! output tensor
@@ -720,7 +717,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int32`
   subroutine torch_tensor_from_array_int32_1d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! output tensor
@@ -750,7 +747,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int32`
   subroutine torch_tensor_from_array_int32_2d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! output tensor
@@ -780,7 +777,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int32`
   subroutine torch_tensor_from_array_int32_3d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! output tensor
@@ -810,7 +807,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int32`
   subroutine torch_tensor_from_array_int32_4d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! output tensor
@@ -840,7 +837,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 5 containing data of type `int32`
   subroutine torch_tensor_from_array_int32_5d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int32
 
     ! output tensor
@@ -870,7 +867,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int64`
   subroutine torch_tensor_from_array_int64_1d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! output tensor
@@ -900,7 +897,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `int64`
   subroutine torch_tensor_from_array_int64_2d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! output tensor
@@ -930,7 +927,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `int64`
   subroutine torch_tensor_from_array_int64_3d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! output tensor
@@ -960,7 +957,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `int64`
   subroutine torch_tensor_from_array_int64_4d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! output tensor
@@ -990,7 +987,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 5 containing data of type `int64`
   subroutine torch_tensor_from_array_int64_5d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : int64
 
     ! output tensor
@@ -1020,7 +1017,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `real32`
   subroutine torch_tensor_from_array_real32_1d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! output tensor
@@ -1050,7 +1047,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `real32`
   subroutine torch_tensor_from_array_real32_2d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! output tensor
@@ -1080,7 +1077,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `real32`
   subroutine torch_tensor_from_array_real32_3d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! output tensor
@@ -1110,7 +1107,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `real32`
   subroutine torch_tensor_from_array_real32_4d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! output tensor
@@ -1140,7 +1137,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 5 containing data of type `real32`
   subroutine torch_tensor_from_array_real32_5d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real32
 
     ! output tensor
@@ -1170,7 +1167,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `real64`
   subroutine torch_tensor_from_array_real64_1d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! output tensor
@@ -1200,7 +1197,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 2 containing data of type `real64`
   subroutine torch_tensor_from_array_real64_2d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! output tensor
@@ -1230,7 +1227,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 3 containing data of type `real64`
   subroutine torch_tensor_from_array_real64_3d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! output tensor
@@ -1260,7 +1257,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 4 containing data of type `real64`
   subroutine torch_tensor_from_array_real64_4d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! output tensor
@@ -1290,7 +1287,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank 5 containing data of type `real64`
   subroutine torch_tensor_from_array_real64_5d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : real64
 
     ! output tensor
@@ -1322,7 +1319,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int8`
   subroutine torch_tensor_to_array_int8_1d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:)  !! Pointer to tensor data
@@ -1352,7 +1349,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `int8`
   subroutine torch_tensor_to_array_int8_2d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:)  !! Pointer to tensor data
@@ -1382,7 +1379,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `int8`
   subroutine torch_tensor_to_array_int8_3d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:,:)  !! Pointer to tensor data
@@ -1412,7 +1409,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `int8`
   subroutine torch_tensor_to_array_int8_4d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:,:,:)  !! Pointer to tensor data
@@ -1442,7 +1439,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 5 and data type `int8`
   subroutine torch_tensor_to_array_int8_5d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int8, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int8), pointer, intent(out) :: data_out(:,:,:,:,:)  !! Pointer to tensor data
@@ -1472,7 +1469,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int16`
   subroutine torch_tensor_to_array_int16_1d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:)  !! Pointer to tensor data
@@ -1502,7 +1499,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `int16`
   subroutine torch_tensor_to_array_int16_2d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:)  !! Pointer to tensor data
@@ -1532,7 +1529,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `int16`
   subroutine torch_tensor_to_array_int16_3d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:,:)  !! Pointer to tensor data
@@ -1562,7 +1559,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `int16`
   subroutine torch_tensor_to_array_int16_4d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:,:,:)  !! Pointer to tensor data
@@ -1592,7 +1589,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 5 and data type `int16`
   subroutine torch_tensor_to_array_int16_5d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int16, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int16), pointer, intent(out) :: data_out(:,:,:,:,:)  !! Pointer to tensor data
@@ -1622,7 +1619,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int32`
   subroutine torch_tensor_to_array_int32_1d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:)  !! Pointer to tensor data
@@ -1652,7 +1649,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `int32`
   subroutine torch_tensor_to_array_int32_2d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:)  !! Pointer to tensor data
@@ -1682,7 +1679,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `int32`
   subroutine torch_tensor_to_array_int32_3d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:,:)  !! Pointer to tensor data
@@ -1712,7 +1709,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `int32`
   subroutine torch_tensor_to_array_int32_4d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:,:,:)  !! Pointer to tensor data
@@ -1742,7 +1739,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 5 and data type `int32`
   subroutine torch_tensor_to_array_int32_5d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int32), pointer, intent(out) :: data_out(:,:,:,:,:)  !! Pointer to tensor data
@@ -1772,7 +1769,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int64`
   subroutine torch_tensor_to_array_int64_1d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:)  !! Pointer to tensor data
@@ -1802,7 +1799,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `int64`
   subroutine torch_tensor_to_array_int64_2d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:)  !! Pointer to tensor data
@@ -1832,7 +1829,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `int64`
   subroutine torch_tensor_to_array_int64_3d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:,:)  !! Pointer to tensor data
@@ -1862,7 +1859,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `int64`
   subroutine torch_tensor_to_array_int64_4d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:,:,:)  !! Pointer to tensor data
@@ -1892,7 +1889,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 5 and data type `int64`
   subroutine torch_tensor_to_array_int64_5d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : int64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     integer(kind=int64), pointer, intent(out) :: data_out(:,:,:,:,:)  !! Pointer to tensor data
@@ -1922,7 +1919,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `real32`
   subroutine torch_tensor_to_array_real32_1d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:)  !! Pointer to tensor data
@@ -1952,7 +1949,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `real32`
   subroutine torch_tensor_to_array_real32_2d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:)  !! Pointer to tensor data
@@ -1982,7 +1979,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `real32`
   subroutine torch_tensor_to_array_real32_3d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:,:)  !! Pointer to tensor data
@@ -2012,7 +2009,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `real32`
   subroutine torch_tensor_to_array_real32_4d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:,:,:)  !! Pointer to tensor data
@@ -2042,7 +2039,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 5 and data type `real32`
   subroutine torch_tensor_to_array_real32_5d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real32, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real32), pointer, intent(out) :: data_out(:,:,:,:,:)  !! Pointer to tensor data
@@ -2072,7 +2069,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `real64`
   subroutine torch_tensor_to_array_real64_1d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:)  !! Pointer to tensor data
@@ -2102,7 +2099,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 2 and data type `real64`
   subroutine torch_tensor_to_array_real64_2d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:)  !! Pointer to tensor data
@@ -2132,7 +2129,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 3 and data type `real64`
   subroutine torch_tensor_to_array_real64_3d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:,:)  !! Pointer to tensor data
@@ -2162,7 +2159,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 4 and data type `real64`
   subroutine torch_tensor_to_array_real64_4d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:,:,:)  !! Pointer to tensor data
@@ -2192,7 +2189,7 @@ contains
 
   !> Return the array data associated with a Torch tensor of rank 5 and data type `real64`
   subroutine torch_tensor_to_array_real64_5d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : real64, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     real(kind=real64), pointer, intent(out) :: data_out(:,:,:,:,:)  !! Pointer to tensor data
@@ -2259,7 +2256,7 @@ contains
   !> Determines the rank of a tensor.
   function get_rank(self) result(rank)
     class(torch_tensor), intent(in) :: self
-    integer(kind=int32) :: rank  !! rank of tensor
+    integer(kind=ftorch_int) :: rank  !! rank of tensor
 
     interface
       function torch_tensor_get_rank_c(tensor) result(rank) &
@@ -2276,14 +2273,14 @@ contains
 
   !> Determines the shape of a tensor.
   function get_shape(self) result(sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_long, c_long_long, c_ptr
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_long, c_long_long, c_ptr
     class(torch_tensor), intent(in) :: self
 #ifdef UNIX
     integer(kind=c_long), pointer :: sizes(:)  !! Pointer to tensor data
 #else
     integer(kind=c_long_long), pointer :: sizes(:)  !! Pointer to tensor data
 #endif
-    integer(kind=int32) :: ndims(1)
+    integer(kind=ftorch_int) :: ndims(1)
     type(c_ptr) :: cptr
 
     interface
@@ -2412,7 +2409,8 @@ contains
 
   !> Overloads multiplication operator for a scalar of type int8 and a tensor.
   function torch_tensor_premultiply_int8(scalar, tensor) result(output)
-    integer(kind=int8), intent(in) :: scalar
+    use, intrinsic :: iso_fortran_env, only : int8
+    integer(int8), intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2432,7 +2430,8 @@ contains
 
   !> Overloads multiplication operator for a scalar of type int16 and a tensor.
   function torch_tensor_premultiply_int16(scalar, tensor) result(output)
-    integer(kind=int16), intent(in) :: scalar
+    use, intrinsic :: iso_fortran_env, only : int16
+    integer(int16), intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2452,7 +2451,8 @@ contains
 
   !> Overloads multiplication operator for a scalar of type int32 and a tensor.
   function torch_tensor_premultiply_int32(scalar, tensor) result(output)
-    integer(kind=int32), intent(in) :: scalar
+    use, intrinsic :: iso_fortran_env, only : int32
+    integer(int32), intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2472,7 +2472,8 @@ contains
 
   !> Overloads multiplication operator for a scalar of type int64 and a tensor.
   function torch_tensor_premultiply_int64(scalar, tensor) result(output)
-    integer(kind=int64), intent(in) :: scalar
+    use, intrinsic :: iso_fortran_env, only : int64
+    integer(int64), intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2492,7 +2493,8 @@ contains
 
   !> Overloads multiplication operator for a scalar of type real32 and a tensor.
   function torch_tensor_premultiply_real32(scalar, tensor) result(output)
-    real(kind=real32), intent(in) :: scalar
+    use, intrinsic :: iso_fortran_env, only : real32
+    real(real32), intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2512,7 +2514,8 @@ contains
 
   !> Overloads multiplication operator for a scalar of type real64 and a tensor.
   function torch_tensor_premultiply_real64(scalar, tensor) result(output)
-    real(kind=real64), intent(in) :: scalar
+    use, intrinsic :: iso_fortran_env, only : real64
+    real(real64), intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2533,8 +2536,9 @@ contains
 
   !> Overloads multiplication operator for a tensor and a scalar of type int8.
   function torch_tensor_postmultiply_int8(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int8), intent(in) :: scalar
+    integer(int8), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2553,8 +2557,9 @@ contains
 
   !> Overloads multiplication operator for a tensor and a scalar of type int16.
   function torch_tensor_postmultiply_int16(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int16), intent(in) :: scalar
+    integer(int16), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2573,8 +2578,9 @@ contains
 
   !> Overloads multiplication operator for a tensor and a scalar of type int32.
   function torch_tensor_postmultiply_int32(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int32), intent(in) :: scalar
+    integer(int32), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2593,8 +2599,9 @@ contains
 
   !> Overloads multiplication operator for a tensor and a scalar of type int64.
   function torch_tensor_postmultiply_int64(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int64), intent(in) :: scalar
+    integer(int64), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2613,8 +2620,9 @@ contains
 
   !> Overloads multiplication operator for a tensor and a scalar of type real32.
   function torch_tensor_postmultiply_real32(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor
-    real(kind=real32), intent(in) :: scalar
+    real(real32), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2633,8 +2641,9 @@ contains
 
   !> Overloads multiplication operator for a tensor and a scalar of type real64.
   function torch_tensor_postmultiply_real64(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor
-    real(kind=real64), intent(in) :: scalar
+    real(real64), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2673,8 +2682,9 @@ contains
 
   !> Overloads division operator for a tensor and a scalar of type int8.
   function torch_tensor_postdivide_int8(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int8), intent(in) :: scalar
+    integer(int8), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2693,8 +2703,9 @@ contains
 
   !> Overloads division operator for a tensor and a scalar of type int16.
   function torch_tensor_postdivide_int16(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int16), intent(in) :: scalar
+    integer(int16), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2713,8 +2724,9 @@ contains
 
   !> Overloads division operator for a tensor and a scalar of type int32.
   function torch_tensor_postdivide_int32(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int32), intent(in) :: scalar
+    integer(int32), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2733,8 +2745,9 @@ contains
 
   !> Overloads division operator for a tensor and a scalar of type int64.
   function torch_tensor_postdivide_int64(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int64), intent(in) :: scalar
+    integer(int64), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2753,8 +2766,9 @@ contains
 
   !> Overloads division operator for a tensor and a scalar of type real32.
   function torch_tensor_postdivide_real32(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor
-    real(kind=real32), intent(in) :: scalar
+    real(real32), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2773,8 +2787,9 @@ contains
 
   !> Overloads division operator for a tensor and a scalar of type real64.
   function torch_tensor_postdivide_real64(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor
-    real(kind=real64), intent(in) :: scalar
+    real(real64), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2794,8 +2809,9 @@ contains
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `int8`
   function torch_tensor_power_int8(tensor, power) result(output)
+    use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int8), intent(in) :: power
+    integer(int8), intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2814,8 +2830,9 @@ contains
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `int16`
   function torch_tensor_power_int16(tensor, power) result(output)
+    use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int16), intent(in) :: power
+    integer(int16), intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2834,8 +2851,9 @@ contains
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `int32`
   function torch_tensor_power_int32(tensor, power) result(output)
+    use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int32), intent(in) :: power
+    integer(int32), intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2854,8 +2872,9 @@ contains
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `int64`
   function torch_tensor_power_int64(tensor, power) result(output)
+    use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor
-    integer(kind=int64), intent(in) :: power
+    integer(int64), intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2874,8 +2893,9 @@ contains
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `real32`
   function torch_tensor_power_real32(tensor, power) result(output)
+    use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor
-    real(kind=real32), intent(in) :: power
+    real(real32), intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2894,8 +2914,9 @@ contains
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `real64`
   function torch_tensor_power_real64(tensor, power) result(output)
+    use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor
-    real(kind=real64), intent(in) :: power
+    real(real64), intent(in) :: power
     type(torch_tensor) :: output
 
     interface

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -13,6 +13,8 @@ module ftorch
 
   implicit none
 
+  ! --- Derived types and enums
+
   !> Type for holding a torch neural net (nn.Module).
   type torch_model
     type(c_ptr) :: p = c_null_ptr  !! pointer to the neural net in memory

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -8,8 +8,10 @@
 
 module ftorch
 
-  use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
-  use, intrinsic :: iso_fortran_env, only: ftorch_int => int32 ! set integer size for FTorch library
+  use, intrinsic :: iso_c_binding, only: c_null_ptr, c_ptr
+
+  ! Set integer size for FTorch library
+  use, intrinsic :: iso_fortran_env, only: ftorch_int => int32
 
   implicit none
 

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -9,11 +9,12 @@
 module ftorch
 
   use, intrinsic :: iso_c_binding, only: c_null_ptr, c_ptr
-
-  ! Set integer size for FTorch library
-  use, intrinsic :: iso_fortran_env, only: ftorch_int => int32
+  use, intrinsic :: iso_fortran_env, only: int32
 
   implicit none
+
+  ! Set integer size for FTorch library
+  integer, parameter :: ftorch_int = int32
 
   ! --- Derived types and enums
 
@@ -2260,7 +2261,7 @@ contains
   !> Determines the rank of a tensor.
   function get_rank(self) result(rank)
     class(torch_tensor), intent(in) :: self
-    integer(kind=ftorch_int) :: rank  !! rank of tensor
+    integer(kind=int32) :: rank  !! rank of tensor
 
     interface
       function torch_tensor_get_rank_c(tensor) result(rank) &
@@ -2284,7 +2285,7 @@ contains
 #else
     integer(kind=c_long_long), pointer :: sizes(:)  !! Pointer to tensor data
 #endif
-    integer(kind=ftorch_int) :: ndims(1)
+    integer(kind=int32) :: ndims(1)
     type(c_ptr) :: cptr
 
     interface

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -16,7 +16,9 @@ module ftorch
   ! Set integer size for FTorch library
   integer, parameter :: ftorch_int = int32
 
+  ! ============================================================================
   ! --- Derived types and enums
+  ! ============================================================================
 
   !> Type for holding a torch neural net (nn.Module).
   type torch_model
@@ -52,7 +54,9 @@ module ftorch
     enumerator :: torch_kCUDA = 1
   end enum
 
+  ! ============================================================================
   ! --- Interfaces for core FTorch procedures
+  ! ============================================================================
 
   !> Interface for directing `torch_tensor_from_array` to possible input types and ranks
   interface torch_tensor_from_array
@@ -164,7 +168,9 @@ module ftorch
     end function torch_to_blob_c
   end interface
 
+  ! ============================================================================
   ! --- Interfaces for overloaded operators acting on tensors
+  ! ============================================================================
 
   interface assignment (=)
     module procedure torch_tensor_assign
@@ -215,7 +221,9 @@ module ftorch
 
 contains
 
+  ! ============================================================================
   ! --- Procedures for constructing tensors
+  ! ============================================================================
 
   !> Returns a tensor with uninitialised values.
   subroutine torch_tensor_empty(tensor, ndims, tensor_shape, dtype, &
@@ -1320,7 +1328,9 @@ contains
   end subroutine torch_tensor_from_array_real64_5d
 
 
+  ! ============================================================================
   ! --- Procedures for interrogating tensors
+  ! ============================================================================
 
   !> Return the array data associated with a Torch tensor of rank 1 and data type `int8`
   subroutine torch_tensor_to_array_int8_1d(tensor, data_out, sizes)
@@ -2303,7 +2313,9 @@ contains
     call c_f_pointer(cptr, sizes, ndims)
   end function get_shape
 
+  ! ============================================================================
   ! --- Procedures for deallocating tensors
+  ! ============================================================================
 
   !> Deallocates an array of tensors.
   subroutine torch_tensor_array_delete(tensor_array)
@@ -2332,7 +2344,9 @@ contains
     call torch_tensor_delete_c(tensor%p)
   end subroutine torch_tensor_delete
 
+  ! ============================================================================
   ! --- Overloaded operators acting on tensors
+  ! ============================================================================
 
   !> Overloads assignment operator for tensors.
   subroutine torch_tensor_assign(output, input)
@@ -2939,7 +2953,9 @@ contains
   end function torch_tensor_power_real64
 
 
+  ! ============================================================================
   ! --- Torch Model API
+  ! ============================================================================
 
   !> Loads a TorchScript nn.module (pre-trained PyTorch model saved with TorchScript)
   subroutine torch_model_load(model, filename, device_type, device_index, &

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -26,11 +26,12 @@ $:'integer' if PRECISION[:3] == 'int' else 'real'
 module ftorch
 
   use, intrinsic :: iso_c_binding, only: c_null_ptr, c_ptr
-
-  ! Set integer size for FTorch library
-  use, intrinsic :: iso_fortran_env, only: ftorch_int => int32
+  use, intrinsic :: iso_fortran_env, only: int32
 
   implicit none
+
+  ! Set integer size for FTorch library
+  integer, parameter :: ftorch_int = int32
 
   ! --- Derived types and enums
 
@@ -481,7 +482,7 @@ contains
   !> Determines the rank of a tensor.
   function get_rank(self) result(rank)
     class(torch_tensor), intent(in) :: self
-    integer(kind=ftorch_int) :: rank  !! rank of tensor
+    integer(kind=int32) :: rank  !! rank of tensor
 
     interface
       function torch_tensor_get_rank_c(tensor) result(rank) &
@@ -505,7 +506,7 @@ contains
 #else
     integer(kind=c_long_long), pointer :: sizes(:)  !! Pointer to tensor data
 #endif
-    integer(kind=ftorch_int) :: ndims(1)
+    integer(kind=int32) :: ndims(1)
     type(c_ptr) :: cptr
 
     interface

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -25,13 +25,10 @@ $:'integer' if PRECISION[:3] == 'int' else 'real'
 
 module ftorch
 
-  use, intrinsic :: iso_c_binding, only: c_int, c_int8_t, c_int16_t, c_int32_t, c_int64_t, &
-                                         c_float, c_double, c_char, c_ptr, c_null_ptr, c_f_pointer
-  use, intrinsic :: iso_fortran_env, only: int8, int16, int32, int64, real32, real64
+  use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
+  use, intrinsic :: iso_fortran_env, only: ftorch_int => int32 ! set integer size for FTorch library
 
   implicit none
-
-  integer, parameter :: ftorch_int = int32  ! set integer size for FTorch library
 
   !> Type for holding a torch neural net (nn.Module).
   type torch_model
@@ -375,7 +372,7 @@ contains
   !> Return a Torch tensor pointing to data_in array of rank ${RANK}$ containing data of type `${PREC}$`
   subroutine torch_tensor_from_array_${PREC}$_${RANK}$d(tensor, data_in, layout, &
                                                         device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : ${PREC}$
 
     ! output tensor
@@ -411,7 +408,7 @@ contains
   #:for RANK in RANKS
   !> Return the array data associated with a Torch tensor of rank ${RANK}$ and data type `${PREC}$`
   subroutine torch_tensor_to_array_${PREC}$_${RANK}$d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_loc
     use, intrinsic :: iso_fortran_env, only : ${PREC}$, int64
     type(torch_tensor), intent(in) :: tensor  !! Returned tensor
     ${f_type(PREC)}$(kind=${PREC}$), pointer, intent(out) :: data_out${ranksuffix(RANK)}$  !! Pointer to tensor data
@@ -480,7 +477,7 @@ contains
   !> Determines the rank of a tensor.
   function get_rank(self) result(rank)
     class(torch_tensor), intent(in) :: self
-    integer(kind=int32) :: rank  !! rank of tensor
+    integer(kind=ftorch_int) :: rank  !! rank of tensor
 
     interface
       function torch_tensor_get_rank_c(tensor) result(rank) &
@@ -497,14 +494,14 @@ contains
 
   !> Determines the shape of a tensor.
   function get_shape(self) result(sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_long, c_long_long, c_ptr
+    use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_long, c_long_long, c_ptr
     class(torch_tensor), intent(in) :: self
 #ifdef UNIX
     integer(kind=c_long), pointer :: sizes(:)  !! Pointer to tensor data
 #else
     integer(kind=c_long_long), pointer :: sizes(:)  !! Pointer to tensor data
 #endif
-    integer(kind=int32) :: ndims(1)
+    integer(kind=ftorch_int) :: ndims(1)
     type(c_ptr) :: cptr
 
     interface
@@ -634,7 +631,8 @@ contains
   #:for PREC in PRECISIONS
   !> Overloads multiplication operator for a scalar of type ${PREC}$ and a tensor.
   function torch_tensor_premultiply_${PREC}$(scalar, tensor) result(output)
-    ${f_type(PREC)}$(kind=${PREC}$), intent(in) :: scalar
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
+    ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -657,8 +655,9 @@ contains
   #:for PREC in PRECISIONS
   !> Overloads multiplication operator for a tensor and a scalar of type ${PREC}$.
   function torch_tensor_postmultiply_${PREC}$(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
     type(torch_tensor), intent(in) :: tensor
-    ${f_type(PREC)}$(kind=${PREC}$), intent(in) :: scalar
+    ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -699,8 +698,9 @@ contains
   #:for PREC in PRECISIONS
   !> Overloads division operator for a tensor and a scalar of type ${PREC}$.
   function torch_tensor_postdivide_${PREC}$(tensor, scalar) result(output)
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
     type(torch_tensor), intent(in) :: tensor
-    ${f_type(PREC)}$(kind=${PREC}$), intent(in) :: scalar
+    ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -722,8 +722,9 @@ contains
   #:for PREC in PRECISIONS
   !> Overloads exponentiation operator for a tensor and a scalar of type `${PREC}$`
   function torch_tensor_power_${PREC}$(tensor, power) result(output)
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
     type(torch_tensor), intent(in) :: tensor
-    ${f_type(PREC)}$(kind=${PREC}$), intent(in) :: power
+    ${f_type(PREC)}$(${PREC}$), intent(in) :: power
     type(torch_tensor) :: output
 
     interface

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -172,7 +172,7 @@ contains
     integer(c_int64_t), intent(in)  :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value  !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
@@ -223,7 +223,7 @@ contains
     integer(c_int64_t), intent(in)  :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value   !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
@@ -274,8 +274,8 @@ contains
     integer(c_int64_t), intent(in)  :: tensor_shape(*)   !! Shape of the tensor
     integer(c_int), intent(in)      :: dtype        !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index     !! device index to use for `torch_kCUDA` case
-    logical, optional, intent(in) :: requires_grad   !! Whether gradients need to be computed for the created tensor
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
     integer(c_int)                  :: device_index_value    !! device index used
     logical(c_bool)                 :: requires_grad_value   !! Whether gradients need to be computed for the created tensor
 
@@ -330,7 +330,7 @@ contains
     integer(c_int), intent(in)      :: layout(*)  !! Layout for strides for accessing data
     integer(c_int), intent(in)      :: dtype      !! Data type of the tensor
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index    !! device index to use for `torch_kCUDA` case
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     integer(c_int)                  :: i                    !! loop index
@@ -809,9 +809,9 @@ contains
 
     ! inputs
     ${f_type(PREC)}$(kind=${PREC}$), intent(in), target :: data_in${ranksuffix(RANK)}$  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in)      :: layout(${RANK}$)  !! Control order of indices
-    integer(c_int), intent(in)           :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer(c_int), optional, intent(in) :: device_index   !! device index to use for `torch_kCUDA` case
+    integer(ftorch_int), intent(in) :: layout(${RANK}$)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
 
     ! local data

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -30,6 +30,8 @@ module ftorch
 
   implicit none
 
+  ! --- Derived types and enums
+
   !> Type for holding a torch neural net (nn.Module).
   type torch_model
     type(c_ptr) :: p = c_null_ptr  !! pointer to the neural net in memory

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -60,13 +60,14 @@ module ftorch
     enumerator :: torch_kFloat64 = 7
   end enum
 
-
   !| Enumerator for Torch devices
   !  From c_torch.h (torch_device_t)
   enum, bind(c)
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
   end enum
+
+  ! --- Interfaces for core FTorch procedures
 
   !> Interface for directing `torch_tensor_from_array` to possible input types and ranks
   interface torch_tensor_from_array
@@ -115,6 +116,21 @@ module ftorch
     end function torch_from_blob_c
   end interface
 
+  interface
+    function torch_to_blob_c(tensor, dtype) result(data) &
+        bind(c, name = 'torch_to_blob')
+      use, intrinsic :: iso_c_binding, only : c_int, c_ptr
+
+      implicit none
+
+      type(c_ptr), value, intent(in)    :: tensor
+      integer(c_int), value, intent(in) :: dtype
+      type(c_ptr)                       :: data
+    end function torch_to_blob_c
+  end interface
+
+  ! --- Interfaces for overloaded operators acting on tensors
+
   interface assignment (=)
     module procedure torch_tensor_assign
   end interface
@@ -148,20 +164,9 @@ module ftorch
     #:endfor
   end interface
 
-  interface
-    function torch_to_blob_c(tensor, dtype) result(data) &
-        bind(c, name = 'torch_to_blob')
-      use, intrinsic :: iso_c_binding, only : c_int, c_ptr
-
-      implicit none
-
-      type(c_ptr), value, intent(in)    :: tensor
-      integer(c_int), value, intent(in) :: dtype
-      type(c_ptr)                       :: data
-    end function torch_to_blob_c
-  end interface
-
 contains
+
+  ! --- Procedures for constructing tensors
 
   !> Returns a tensor with uninitialised values.
   subroutine torch_tensor_empty(tensor, ndims, tensor_shape, dtype, &
@@ -316,7 +321,6 @@ contains
                             device_index_value, requires_grad_value)
   end subroutine torch_tensor_ones
 
-  ! Torch Tensor API
   !| Exposes the given data as a tensor without taking ownership of the original data.
   !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
   subroutine torch_tensor_from_blob(tensor, data, ndims, tensor_shape, layout, dtype, &
@@ -365,6 +369,78 @@ contains
                                  device_type, device_index_value,              &
                                  requires_grad_value)
   end subroutine torch_tensor_from_blob
+
+  #:for PREC in PRECISIONS
+  #:for RANK in RANKS
+  !> Return a Torch tensor pointing to data_in array of rank ${RANK}$ containing data of type `${PREC}$`
+  subroutine torch_tensor_from_array_${PREC}$_${RANK}$d(tensor, data_in, layout, &
+                                                        device_type, device_index, requires_grad)
+    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
+
+    ! output tensor
+    type(torch_tensor), intent(out) :: tensor  !! Returned tensor
+
+    ! inputs
+    ${f_type(PREC)}$(kind=${PREC}$), intent(in), target :: data_in${ranksuffix(RANK)}$  !! Input data that tensor will point at
+    integer(ftorch_int), intent(in) :: layout(${RANK}$)  !! Control order of indices
+    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
+    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
+    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+
+    ! local data
+    integer(c_int64_t)        :: tensor_shape(${RANK}$)            !! Shape of the tensor
+    integer(c_int), parameter :: dtype = ${enum_from_prec(PREC)}$  !! Data type
+    integer(c_int64_t)        :: strides(${RANK}$)                 !! Strides for accessing data
+    integer(c_int), parameter :: ndims = ${RANK}$                  !! Number of dimension of input data
+
+    tensor_shape = shape(data_in)
+
+    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
+                                layout, dtype, device_type, device_index, &
+                                requires_grad)
+
+  end subroutine torch_tensor_from_array_${PREC}$_${RANK}$d
+
+  #:endfor
+  #:endfor
+
+  ! --- Procedures for interrogating tensors
+
+  #:for PREC in PRECISIONS
+  #:for RANK in RANKS
+  !> Return the array data associated with a Torch tensor of rank ${RANK}$ and data type `${PREC}$`
+  subroutine torch_tensor_to_array_${PREC}$_${RANK}$d(tensor, data_out, sizes)
+    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$, int64
+    type(torch_tensor), intent(in) :: tensor  !! Returned tensor
+    ${f_type(PREC)}$(kind=${PREC}$), pointer, intent(out) :: data_out${ranksuffix(RANK)}$  !! Pointer to tensor data
+    integer, optional, intent(in) :: sizes(${RANK}$)  !! Number of entries for each rank
+    integer(kind=int64), allocatable :: my_shape(:)  !! Number of entries for each rank
+
+    ! Local data
+    integer(c_int), parameter :: dtype = ${enum_from_prec(PREC)}$  !! Data type
+    type(c_ptr) :: cptr
+
+    my_shape = tensor%get_shape()
+
+    if (present(sizes)) then
+      if (.not. all(my_shape == sizes)) then
+        write(*,*) 'Error :: sizes argument does not match shape of tensor'
+        write(*,'(A, ${RANK}$(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
+        write(*,'(A, ${RANK}$(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
+        stop 1
+      end if
+    end if
+
+    ! Have the data_out array point to the Tensor data
+    cptr = torch_to_blob_c(tensor%p, dtype)
+    call c_f_pointer(cptr, data_out, my_shape)
+
+  end subroutine torch_tensor_to_array_${PREC}$_${RANK}$d
+
+  #:endfor
+  #:endfor
 
   !> Prints the contents of a tensor.
   subroutine torch_tensor_print(tensor)
@@ -446,6 +522,8 @@ contains
     call c_f_pointer(cptr, sizes, ndims)
   end function get_shape
 
+  ! --- Procedures for deallocating tensors
+
   !> Deallocates an array of tensors.
   subroutine torch_tensor_array_delete(tensor_array)
     type(torch_tensor), dimension(:), intent(inout) :: tensor_array
@@ -472,6 +550,8 @@ contains
 
     call torch_tensor_delete_c(tensor%p)
   end subroutine torch_tensor_delete
+
+  ! --- Overloaded operators acting on tensors
 
   !> Overloads assignment operator for tensors.
   subroutine torch_tensor_assign(output, input)
@@ -662,7 +742,8 @@ contains
 
   #:endfor
 
-  ! Torch Model API
+  ! --- Torch Model API
+
   !> Loads a TorchScript nn.module (pre-trained PyTorch model saved with TorchScript)
   subroutine torch_model_load(model, filename, device_type, device_index, &
                               requires_grad, is_training)
@@ -795,75 +876,5 @@ contains
 
     call torch_jit_model_delete_c(model%p)
   end subroutine torch_model_delete
-
-  #:for PREC in PRECISIONS
-  #:for RANK in RANKS
-  !> Return a Torch tensor pointing to data_in array of rank ${RANK}$ containing data of type `${PREC}$`
-  subroutine torch_tensor_from_array_${PREC}$_${RANK}$d(tensor, data_in, layout, &
-                                                        device_type, device_index, requires_grad)
-    use, intrinsic :: iso_c_binding, only : c_bool, c_float, c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : ${PREC}$
-
-    ! output tensor
-    type(torch_tensor), intent(out) :: tensor  !! Returned tensor
-
-    ! inputs
-    ${f_type(PREC)}$(kind=${PREC}$), intent(in), target :: data_in${ranksuffix(RANK)}$  !! Input data that tensor will point at
-    integer(ftorch_int), intent(in) :: layout(${RANK}$)  !! Control order of indices
-    integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
-    integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
-    logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
-
-    ! local data
-    integer(c_int64_t)        :: tensor_shape(${RANK}$)            !! Shape of the tensor
-    integer(c_int), parameter :: dtype = ${enum_from_prec(PREC)}$  !! Data type
-    integer(c_int64_t)        :: strides(${RANK}$)                 !! Strides for accessing data
-    integer(c_int), parameter :: ndims = ${RANK}$                  !! Number of dimension of input data
-
-    tensor_shape = shape(data_in)
-
-    call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
-                                layout, dtype, device_type, device_index, &
-                                requires_grad)
-
-  end subroutine torch_tensor_from_array_${PREC}$_${RANK}$d
-
-  #:endfor
-  #:endfor
-
-  #:for PREC in PRECISIONS
-  #:for RANK in RANKS
-  !> Return the array data associated with a Torch tensor of rank ${RANK}$ and data type `${PREC}$`
-  subroutine torch_tensor_to_array_${PREC}$_${RANK}$d(tensor, data_out, sizes)
-    use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_loc
-    use, intrinsic :: iso_fortran_env, only : ${PREC}$, int64
-    type(torch_tensor), intent(in) :: tensor  !! Returned tensor
-    ${f_type(PREC)}$(kind=${PREC}$), pointer, intent(out) :: data_out${ranksuffix(RANK)}$  !! Pointer to tensor data
-    integer, optional, intent(in) :: sizes(${RANK}$)  !! Number of entries for each rank
-    integer(kind=int64), allocatable :: my_shape(:)  !! Number of entries for each rank
-
-    ! Local data
-    integer(c_int), parameter :: dtype = ${enum_from_prec(PREC)}$  !! Data type
-    type(c_ptr) :: cptr
-
-    my_shape = tensor%get_shape()
-
-    if (present(sizes)) then
-      if (.not. all(my_shape == sizes)) then
-        write(*,*) 'Error :: sizes argument does not match shape of tensor'
-        write(*,'(A, ${RANK}$(I0, " "), A)') 'sizes        :: [ ', sizes(:), ']'
-        write(*,'(A, ${RANK}$(I0, " "), A)') 'tensor shape :: [ ', my_shape(:), ']'
-        stop 1
-      end if
-    end if
-
-    ! Have the data_out array point to the Tensor data
-    cptr = torch_to_blob_c(tensor%p, dtype)
-    call c_f_pointer(cptr, data_out, my_shape)
-
-  end subroutine torch_tensor_to_array_${PREC}$_${RANK}$d
-
-  #:endfor
-  #:endfor
 
 end module ftorch

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -25,8 +25,10 @@ $:'integer' if PRECISION[:3] == 'int' else 'real'
 
 module ftorch
 
-  use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
-  use, intrinsic :: iso_fortran_env, only: ftorch_int => int32 ! set integer size for FTorch library
+  use, intrinsic :: iso_c_binding, only: c_null_ptr, c_ptr
+
+  ! Set integer size for FTorch library
+  use, intrinsic :: iso_fortran_env, only: ftorch_int => int32
 
   implicit none
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -33,7 +33,9 @@ module ftorch
   ! Set integer size for FTorch library
   integer, parameter :: ftorch_int = int32
 
+  ! ============================================================================
   ! --- Derived types and enums
+  ! ============================================================================
 
   !> Type for holding a torch neural net (nn.Module).
   type torch_model
@@ -69,7 +71,9 @@ module ftorch
     enumerator :: torch_kCUDA = 1
   end enum
 
+  ! ============================================================================
   ! --- Interfaces for core FTorch procedures
+  ! ============================================================================
 
   !> Interface for directing `torch_tensor_from_array` to possible input types and ranks
   interface torch_tensor_from_array
@@ -131,7 +135,9 @@ module ftorch
     end function torch_to_blob_c
   end interface
 
+  ! ============================================================================
   ! --- Interfaces for overloaded operators acting on tensors
+  ! ============================================================================
 
   interface assignment (=)
     module procedure torch_tensor_assign
@@ -168,7 +174,9 @@ module ftorch
 
 contains
 
+  ! ============================================================================
   ! --- Procedures for constructing tensors
+  ! ============================================================================
 
   !> Returns a tensor with uninitialised values.
   subroutine torch_tensor_empty(tensor, ndims, tensor_shape, dtype, &
@@ -407,7 +415,9 @@ contains
   #:endfor
   #:endfor
 
+  ! ============================================================================
   ! --- Procedures for interrogating tensors
+  ! ============================================================================
 
   #:for PREC in PRECISIONS
   #:for RANK in RANKS
@@ -524,7 +534,9 @@ contains
     call c_f_pointer(cptr, sizes, ndims)
   end function get_shape
 
+  ! ============================================================================
   ! --- Procedures for deallocating tensors
+  ! ============================================================================
 
   !> Deallocates an array of tensors.
   subroutine torch_tensor_array_delete(tensor_array)
@@ -553,7 +565,9 @@ contains
     call torch_tensor_delete_c(tensor%p)
   end subroutine torch_tensor_delete
 
+  ! ============================================================================
   ! --- Overloaded operators acting on tensors
+  ! ============================================================================
 
   !> Overloads assignment operator for tensors.
   subroutine torch_tensor_assign(output, input)
@@ -748,7 +762,9 @@ contains
 
   #:endfor
 
+  ! ============================================================================
   ! --- Torch Model API
+  ! ============================================================================
 
   !> Loads a TorchScript nn.module (pre-trained PyTorch model saved with TorchScript)
   subroutine torch_model_load(model, filename, device_type, device_index, &


### PR DESCRIPTION
To follow #76.

This PR reorganises the main FTorch module to group things more logically:
1. Datatypes
2. Interfaces for core FTorch functionality
3. Interfaces for operator overloading of tensors
4. Procedures for constructing tensors
5. Procedures for interrogating tensors
6. Procedures for deallocating tensors
7. Overloaded operators for tensors
8. Torch model API

This PR also drops unnecessary imports and makes it so that the `device_index` argument can be passed as a Fortran `integer` rather than a `c_int`.