### PR TITLE
Unit tests for operator overloading; fix scalar bug

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -277,22 +277,24 @@ torch_tensor_t torch_tensor_multiply(const torch_tensor_t tensor1,
   return output;
 }
 
-torch_tensor_t torch_tensor_premultiply(const torch_data_t scalar,
+// FIXME: Don't cast to float. Now doesn't work for integers
+torch_tensor_t torch_tensor_premultiply(const float scalar,
                                         const torch_tensor_t tensor) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
-  std::cout << "DEBUG: scalar = " << scalar << std::endl;
+  std::cout << "DEBUG: pre-multiplier = " << scalar << std::endl;
   *output = scalar * *t;
   return output;
 }
 
+// FIXME: Don't cast to float. Now doesn't work for integers
 torch_tensor_t torch_tensor_postmultiply(const torch_tensor_t tensor,
-                                         const torch_data_t scalar) {
+                                         const float scalar) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
-  std::cout << "DEBUG: scalar = " << scalar << std::endl;
+  std::cout << "DEBUG: post-multiplier = " << scalar << std::endl;
   *output = *t * scalar;
   return output;
 }
@@ -307,18 +309,22 @@ torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
   return output;
 }
 
+// FIXME: Don't cast to float. Now doesn't work for integers
 torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
-                                       const torch_data_t scalar) {
+                                       const float scalar) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
-  std::cout << "DEBUG: scalar = " << scalar << std::endl;
-  *output = *t / scalar;
+  torch::Scalar *alpha = nullptr;
+  alpha = new torch::Scalar;
+  *alpha = scalar;
+  std::cout << "DEBUG: divisor = " << scalar << std::endl;
+  *output = *t / *alpha;
   return output;
 }
 
-torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
-                                  const torch_data_t exponent) {
+// FIXME: Don't cast to float. Now doesn't work for integers
+torch_tensor_t torch_tensor_power(const torch_tensor_t tensor, const float exponent) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -282,6 +282,7 @@ torch_tensor_t torch_tensor_premultiply(const torch_data_t scalar,
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
+  std::cout << "DEBUG: scalar = " << scalar << std::endl;
   *output = scalar * *t;
   return output;
 }
@@ -291,6 +292,7 @@ torch_tensor_t torch_tensor_postmultiply(const torch_tensor_t tensor,
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
+  std::cout << "DEBUG: scalar = " << scalar << std::endl;
   *output = *t * scalar;
   return output;
 }
@@ -310,6 +312,7 @@ torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
+  std::cout << "DEBUG: scalar = " << scalar << std::endl;
   *output = *t / scalar;
   return output;
 }
@@ -319,6 +322,7 @@ torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
+  std::cout << "DEBUG: exponent = " << exponent << std::endl;
   *output = pow(*t, exponent);
   return output;
 }

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -277,25 +277,27 @@ torch_tensor_t torch_tensor_multiply(const torch_tensor_t tensor1,
   return output;
 }
 
-// FIXME: Don't cast to float. Now doesn't work for integers
-torch_tensor_t torch_tensor_premultiply(const float scalar,
+torch_tensor_t torch_tensor_premultiply(const torch_scalar_t premultiplier,
                                         const torch_tensor_t tensor) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
+  // FIXME: Don't cast to float. Now doesn't work for integers
+  auto pm = reinterpret_cast<float *const>(premultiplier);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
-  std::cout << "DEBUG: pre-multiplier = " << scalar << std::endl;
-  *output = scalar * *t;
+  std::cout << "DEBUG: pre-multiplier = " << *pm << std::endl;
+  *output = *pm * *t;
   return output;
 }
 
-// FIXME: Don't cast to float. Now doesn't work for integers
 torch_tensor_t torch_tensor_postmultiply(const torch_tensor_t tensor,
-                                         const float scalar) {
+                                         const torch_scalar_t postmultiplier) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
+  // FIXME: Don't cast to float. Now doesn't work for integers
+  auto pm = reinterpret_cast<float *const>(postmultiplier);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
-  std::cout << "DEBUG: post-multiplier = " << scalar << std::endl;
-  *output = *t * scalar;
+  std::cout << "DEBUG: post-multiplier = " << *pm << std::endl;
+  *output = *t * *pm;
   return output;
 }
 
@@ -309,27 +311,30 @@ torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
   return output;
 }
 
-// FIXME: Don't cast to float. Now doesn't work for integers
 torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
-                                       const float scalar) {
+                                       const torch_scalar_t divisor) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
+  // FIXME: Don't cast to float. Now doesn't work for integers
+  auto div = reinterpret_cast<float *const>(divisor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
-  torch::Scalar *alpha = nullptr;
-  alpha = new torch::Scalar;
-  *alpha = scalar;
-  std::cout << "DEBUG: divisor = " << scalar << std::endl;
-  *output = *t / *alpha;
+  // torch::Scalar *alpha = nullptr;
+  // alpha = new torch::Scalar;
+  // *alpha = *scalar;
+  std::cout << "DEBUG: divisor = " << *div << std::endl;
+  *output = *t / *div;
   return output;
 }
 
-// FIXME: Don't cast to float. Now doesn't work for integers
-torch_tensor_t torch_tensor_power(const torch_tensor_t tensor, const float exponent) {
+torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
+                                  const torch_scalar_t exponent) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
+  // FIXME: Don't cast to float. Now doesn't work for integers
+  auto exp = reinterpret_cast<float *const>(exponent);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
-  std::cout << "DEBUG: exponent = " << exponent << std::endl;
-  *output = pow(*t, exponent);
+  std::cout << "DEBUG: exponent = " << *exp << std::endl;
+  *output = pow(*t, *exp);
   return output;
 }
 

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -290,7 +290,7 @@ torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
 torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
                                   const torch_scalar_t exponent) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
-  // FIXME: Don't cast to int. Now doesn't work for floats.
+  // NOTE: The following cast will only work for integer exponents
   auto exp = reinterpret_cast<int *const>(exponent);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -294,7 +294,6 @@ torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
   auto exp = reinterpret_cast<int *const>(exponent);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
-  std::cout << "DEBUG: exponent = " << *exp << std::endl;
   *output = pow(*t, *exp);
   return output;
 }

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -287,11 +287,22 @@ torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
   return output;
 }
 
-torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
-                                  const torch_scalar_t exponent) {
+torch_tensor_t torch_tensor_power_int(const torch_tensor_t tensor,
+                                      const torch_int_t exponent) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   // NOTE: The following cast will only work for integer exponents
   auto exp = reinterpret_cast<int *const>(exponent);
+  torch::Tensor *output = nullptr;
+  output = new torch::Tensor;
+  *output = pow(*t, *exp);
+  return output;
+}
+
+torch_tensor_t torch_tensor_power_float(const torch_tensor_t tensor,
+                                        const torch_float_t exponent) {
+  auto t = reinterpret_cast<torch::Tensor *const>(tensor);
+  // NOTE: The following cast will only work for floating point exponents
+  auto exp = reinterpret_cast<float *const>(exponent);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
   *output = pow(*t, *exp);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -277,30 +277,6 @@ torch_tensor_t torch_tensor_multiply(const torch_tensor_t tensor1,
   return output;
 }
 
-torch_tensor_t torch_tensor_premultiply(const torch_scalar_t premultiplier,
-                                        const torch_tensor_t tensor) {
-  auto t = reinterpret_cast<torch::Tensor *const>(tensor);
-  // FIXME: Don't cast to float. Now doesn't work for integers
-  auto pm = reinterpret_cast<float *const>(premultiplier);
-  torch::Tensor *output = nullptr;
-  output = new torch::Tensor;
-  std::cout << "DEBUG: pre-multiplier = " << *pm << std::endl;
-  *output = *pm * *t;
-  return output;
-}
-
-torch_tensor_t torch_tensor_postmultiply(const torch_tensor_t tensor,
-                                         const torch_scalar_t postmultiplier) {
-  auto t = reinterpret_cast<torch::Tensor *const>(tensor);
-  // FIXME: Don't cast to float. Now doesn't work for integers
-  auto pm = reinterpret_cast<float *const>(postmultiplier);
-  torch::Tensor *output = nullptr;
-  output = new torch::Tensor;
-  std::cout << "DEBUG: post-multiplier = " << *pm << std::endl;
-  *output = *t * *pm;
-  return output;
-}
-
 torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
                                    const torch_tensor_t tensor2) {
   auto t1 = reinterpret_cast<torch::Tensor *const>(tensor1);
@@ -311,26 +287,11 @@ torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
   return output;
 }
 
-torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
-                                       const torch_scalar_t divisor) {
-  auto t = reinterpret_cast<torch::Tensor *const>(tensor);
-  // FIXME: Don't cast to float. Now doesn't work for integers
-  auto div = reinterpret_cast<float *const>(divisor);
-  torch::Tensor *output = nullptr;
-  output = new torch::Tensor;
-  // torch::Scalar *alpha = nullptr;
-  // alpha = new torch::Scalar;
-  // *alpha = *scalar;
-  std::cout << "DEBUG: divisor = " << *div << std::endl;
-  *output = *t / *div;
-  return output;
-}
-
 torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
                                   const torch_scalar_t exponent) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
-  // FIXME: Don't cast to float. Now doesn't work for integers
-  auto exp = reinterpret_cast<float *const>(exponent);
+  // FIXME: Don't cast to int. Now doesn't work for floats.
+  auto exp = reinterpret_cast<int *const>(exponent);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;
   std::cout << "DEBUG: exponent = " << *exp << std::endl;

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -176,7 +176,7 @@ EXPORT_C torch_tensor_t torch_tensor_multiply(const torch_tensor_t tensor1,
  * @param Tensor to be multiplied
  * @return product of the scalar and Tensor
  */
-EXPORT_C torch_tensor_t torch_tensor_premultiply(const torch_data_t scalar,
+EXPORT_C torch_tensor_t torch_tensor_premultiply(const float scalar,
                                                  const torch_tensor_t tensor);
 
 /**
@@ -186,7 +186,7 @@ EXPORT_C torch_tensor_t torch_tensor_premultiply(const torch_data_t scalar,
  * @return product of the Tensor and scalar
  */
 EXPORT_C torch_tensor_t torch_tensor_postmultiply(const torch_tensor_t tensor,
-                                                  const torch_data_t scalar);
+                                                  const float scalar);
 
 /**
  * Overloads the division operator for two Torch Tensors
@@ -204,7 +204,7 @@ EXPORT_C torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
  * @return quotient of the Tensor and scalar
  */
 EXPORT_C torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
-                                                const torch_data_t scalar);
+                                                const float scalar);
 
 /**
  * Overloads the exponentiation operator for two Torch Tensors
@@ -213,7 +213,7 @@ EXPORT_C torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
  * @return power of the Tensor
  */
 EXPORT_C torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
-                                           const torch_data_t exponent);
+                                           const float exponent);
 
 // =====================================================================================
 // Module API

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -15,8 +15,11 @@ typedef void *torch_jit_script_module_t;
 // Opaque pointer type alias for at::Tensor
 typedef void *torch_tensor_t;
 
-// Opaque pointer type alias for at::Scalar
-typedef void *torch_scalar_t;
+// Opaque pointer type alias for integer scalars
+typedef void *torch_int_t;
+
+// Opaque pointer type alias for float scalars
+typedef void *torch_float_t;
 
 // Data types
 typedef enum {
@@ -185,11 +188,21 @@ EXPORT_C torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
 /**
  * Overloads the exponentiation operator for a Torch Tensor and an integer exponent
  * @param Tensor to take the power of
- * @param scalar exponent
+ * @param integer exponent
  * @return power of the Tensor
  */
-EXPORT_C torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
-                                           const torch_scalar_t exponent);
+EXPORT_C torch_tensor_t torch_tensor_power_int(const torch_tensor_t tensor,
+                                               const torch_int_t exponent);
+
+/**
+ * Overloads the exponentiation operator for a Torch Tensor and a floating point
+ * exponent
+ * @param Tensor to take the power of
+ * @param floating point exponent
+ * @return power of the Tensor
+ */
+EXPORT_C torch_tensor_t torch_tensor_power_float(const torch_tensor_t tensor,
+                                                 const torch_float_t exponent);
 
 // =====================================================================================
 // Module API

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -15,6 +15,9 @@ typedef void *torch_jit_script_module_t;
 // Opaque pointer type alias for at::Tensor
 typedef void *torch_tensor_t;
 
+// Opaque pointer type alias for at::Scalar
+typedef void *torch_scalar_t;
+
 // Data types
 typedef enum {
   torch_kUInt8,
@@ -176,7 +179,7 @@ EXPORT_C torch_tensor_t torch_tensor_multiply(const torch_tensor_t tensor1,
  * @param Tensor to be multiplied
  * @return product of the scalar and Tensor
  */
-EXPORT_C torch_tensor_t torch_tensor_premultiply(const float scalar,
+EXPORT_C torch_tensor_t torch_tensor_premultiply(const torch_scalar_t scalar,
                                                  const torch_tensor_t tensor);
 
 /**
@@ -186,7 +189,7 @@ EXPORT_C torch_tensor_t torch_tensor_premultiply(const float scalar,
  * @return product of the Tensor and scalar
  */
 EXPORT_C torch_tensor_t torch_tensor_postmultiply(const torch_tensor_t tensor,
-                                                  const float scalar);
+                                                  const torch_scalar_t scalar);
 
 /**
  * Overloads the division operator for two Torch Tensors
@@ -204,7 +207,7 @@ EXPORT_C torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
  * @return quotient of the Tensor and scalar
  */
 EXPORT_C torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
-                                                const float scalar);
+                                                const torch_scalar_t scalar);
 
 /**
  * Overloads the exponentiation operator for two Torch Tensors
@@ -213,7 +216,7 @@ EXPORT_C torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
  * @return power of the Tensor
  */
 EXPORT_C torch_tensor_t torch_tensor_power(const torch_tensor_t tensor,
-                                           const float exponent);
+                                           const torch_scalar_t exponent);
 
 // =====================================================================================
 // Module API

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -174,7 +174,7 @@ EXPORT_C torch_tensor_t torch_tensor_multiply(const torch_tensor_t tensor1,
                                               const torch_tensor_t tensor2);
 
 /**
- * Overloads the division operator for two Torch Tensors
+ * Overloads the division operator for two Torch Tensors.
  * @param first Tensor to be divided
  * @param second Tensor to be divided
  * @return quotient of the Tensors
@@ -183,7 +183,7 @@ EXPORT_C torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
                                             const torch_tensor_t tensor2);
 
 /**
- * Overloads the exponentiation operator for two Torch Tensors
+ * Overloads the exponentiation operator for a Torch Tensor and an integer exponent
  * @param Tensor to take the power of
  * @param scalar exponent
  * @return power of the Tensor

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -174,24 +174,6 @@ EXPORT_C torch_tensor_t torch_tensor_multiply(const torch_tensor_t tensor1,
                                               const torch_tensor_t tensor2);
 
 /**
- * Overloads the premultiplication operator for a scalar and a Torch Tensor
- * @param scalar to multiply by
- * @param Tensor to be multiplied
- * @return product of the scalar and Tensor
- */
-EXPORT_C torch_tensor_t torch_tensor_premultiply(const torch_scalar_t scalar,
-                                                 const torch_tensor_t tensor);
-
-/**
- * Overloads the postmultiplication operator for a Torch Tensor and a scalar
- * @param Tensor to be multiplied
- * @param scalar to multiply by
- * @return product of the Tensor and scalar
- */
-EXPORT_C torch_tensor_t torch_tensor_postmultiply(const torch_tensor_t tensor,
-                                                  const torch_scalar_t scalar);
-
-/**
  * Overloads the division operator for two Torch Tensors
  * @param first Tensor to be divided
  * @param second Tensor to be divided
@@ -199,15 +181,6 @@ EXPORT_C torch_tensor_t torch_tensor_postmultiply(const torch_tensor_t tensor,
  */
 EXPORT_C torch_tensor_t torch_tensor_divide(const torch_tensor_t tensor1,
                                             const torch_tensor_t tensor2);
-
-/**
- * Overloads the post-division operator for a Torch Tensor and a scalar
- * @param Tensor to be divided
- * @param scalar to divide by
- * @return quotient of the Tensor and scalar
- */
-EXPORT_C torch_tensor_t torch_tensor_postdivide(const torch_tensor_t tensor,
-                                                const torch_scalar_t scalar);
 
 /**
  * Overloads the exponentiation operator for two Torch Tensors

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2428,8 +2428,8 @@ contains
 
   !> Overloads multiplication operator for a scalar of type int8 and a tensor.
   function torch_tensor_premultiply_int8(scalar, tensor) result(output)
-    use, intrinsic :: iso_fortran_env, only : int8
-    integer(int8), intent(in) :: scalar
+    use, intrinsic :: iso_c_binding, only : c_loc
+    integer(int8), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2438,19 +2438,19 @@ contains
           bind(c, name = 'torch_tensor_premultiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
         implicit none
-        integer(kind=c_int8_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(scalar, tensor%p)
+    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
   end function torch_tensor_premultiply_int8
 
   !> Overloads multiplication operator for a scalar of type int16 and a tensor.
   function torch_tensor_premultiply_int16(scalar, tensor) result(output)
-    use, intrinsic :: iso_fortran_env, only : int16
-    integer(int16), intent(in) :: scalar
+    use, intrinsic :: iso_c_binding, only : c_loc
+    integer(int16), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2459,19 +2459,19 @@ contains
           bind(c, name = 'torch_tensor_premultiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
         implicit none
-        integer(kind=c_int16_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(scalar, tensor%p)
+    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
   end function torch_tensor_premultiply_int16
 
   !> Overloads multiplication operator for a scalar of type int32 and a tensor.
   function torch_tensor_premultiply_int32(scalar, tensor) result(output)
-    use, intrinsic :: iso_fortran_env, only : int32
-    integer(int32), intent(in) :: scalar
+    use, intrinsic :: iso_c_binding, only : c_loc
+    integer(int32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2480,19 +2480,19 @@ contains
           bind(c, name = 'torch_tensor_premultiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
         implicit none
-        integer(kind=c_int32_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(scalar, tensor%p)
+    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
   end function torch_tensor_premultiply_int32
 
   !> Overloads multiplication operator for a scalar of type int64 and a tensor.
   function torch_tensor_premultiply_int64(scalar, tensor) result(output)
-    use, intrinsic :: iso_fortran_env, only : int64
-    integer(int64), intent(in) :: scalar
+    use, intrinsic :: iso_c_binding, only : c_loc
+    integer(int64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2501,19 +2501,19 @@ contains
           bind(c, name = 'torch_tensor_premultiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
         implicit none
-        integer(kind=c_int64_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(scalar, tensor%p)
+    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
   end function torch_tensor_premultiply_int64
 
   !> Overloads multiplication operator for a scalar of type real32 and a tensor.
   function torch_tensor_premultiply_real32(scalar, tensor) result(output)
-    use, intrinsic :: iso_fortran_env, only : real32
-    real(real32), intent(in) :: scalar
+    use, intrinsic :: iso_c_binding, only : c_loc
+    real(real32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2522,19 +2522,19 @@ contains
           bind(c, name = 'torch_tensor_premultiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_float
         implicit none
-        real(kind=c_float), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(scalar, tensor%p)
+    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
   end function torch_tensor_premultiply_real32
 
   !> Overloads multiplication operator for a scalar of type real64 and a tensor.
   function torch_tensor_premultiply_real64(scalar, tensor) result(output)
-    use, intrinsic :: iso_fortran_env, only : real64
-    real(real64), intent(in) :: scalar
+    use, intrinsic :: iso_c_binding, only : c_loc
+    real(real64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -2543,21 +2543,21 @@ contains
           bind(c, name = 'torch_tensor_premultiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_double
         implicit none
-        real(kind=c_double), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(scalar, tensor%p)
+    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
   end function torch_tensor_premultiply_real64
 
 
   !> Overloads multiplication operator for a tensor and a scalar of type int8.
   function torch_tensor_postmultiply_int8(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : int8
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int8), intent(in) :: scalar
+    integer(int8), target, intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2566,19 +2566,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(kind=c_int8_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr) :: output_c
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, scalar)
+    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
   end function torch_tensor_postmultiply_int8
 
   !> Overloads multiplication operator for a tensor and a scalar of type int16.
   function torch_tensor_postmultiply_int16(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : int16
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int16), intent(in) :: scalar
+    integer(int16), target, intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2587,19 +2587,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(kind=c_int16_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr) :: output_c
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, scalar)
+    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
   end function torch_tensor_postmultiply_int16
 
   !> Overloads multiplication operator for a tensor and a scalar of type int32.
   function torch_tensor_postmultiply_int32(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : int32
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int32), intent(in) :: scalar
+    integer(int32), target, intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2608,19 +2608,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(kind=c_int32_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr) :: output_c
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, scalar)
+    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
   end function torch_tensor_postmultiply_int32
 
   !> Overloads multiplication operator for a tensor and a scalar of type int64.
   function torch_tensor_postmultiply_int64(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : int64
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int64), intent(in) :: scalar
+    integer(int64), target, intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2629,19 +2629,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(kind=c_int64_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr) :: output_c
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, scalar)
+    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
   end function torch_tensor_postmultiply_int64
 
   !> Overloads multiplication operator for a tensor and a scalar of type real32.
   function torch_tensor_postmultiply_real32(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : real32
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real32), intent(in) :: scalar
+    real(real32), target, intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2650,19 +2650,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_float
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        real(kind=c_float), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr) :: output_c
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, scalar)
+    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
   end function torch_tensor_postmultiply_real32
 
   !> Overloads multiplication operator for a tensor and a scalar of type real64.
   function torch_tensor_postmultiply_real64(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : real64
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real64), intent(in) :: scalar
+    real(real64), target, intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -2671,12 +2671,12 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_double
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        real(kind=c_double), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr) :: output_c
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, scalar)
+    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
   end function torch_tensor_postmultiply_real64
 
   !> Overloads division operator for two tensors.
@@ -2700,137 +2700,137 @@ contains
   end function torch_tensor_divide
 
   !> Overloads division operator for a tensor and a scalar of type int8.
-  function torch_tensor_postdivide_int8(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : int8
+  function torch_tensor_postdivide_int8(tensor, divisor) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int8), intent(in) :: scalar
+    integer(int8), target, intent(in) :: divisor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_postdivide_c(tensor_c, scalar_c)                 &
+      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
           result(output_c) bind(c, name = 'torch_tensor_postdivide')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
+        use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(kind=c_int8_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: divisor_c
         type(c_ptr) :: output_c
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, scalar)
+    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
   end function torch_tensor_postdivide_int8
 
   !> Overloads division operator for a tensor and a scalar of type int16.
-  function torch_tensor_postdivide_int16(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : int16
+  function torch_tensor_postdivide_int16(tensor, divisor) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int16), intent(in) :: scalar
+    integer(int16), target, intent(in) :: divisor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_postdivide_c(tensor_c, scalar_c)                 &
+      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
           result(output_c) bind(c, name = 'torch_tensor_postdivide')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
+        use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(kind=c_int16_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: divisor_c
         type(c_ptr) :: output_c
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, scalar)
+    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
   end function torch_tensor_postdivide_int16
 
   !> Overloads division operator for a tensor and a scalar of type int32.
-  function torch_tensor_postdivide_int32(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : int32
+  function torch_tensor_postdivide_int32(tensor, divisor) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int32), intent(in) :: scalar
+    integer(int32), target, intent(in) :: divisor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_postdivide_c(tensor_c, scalar_c)                 &
+      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
           result(output_c) bind(c, name = 'torch_tensor_postdivide')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
+        use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(kind=c_int32_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: divisor_c
         type(c_ptr) :: output_c
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, scalar)
+    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
   end function torch_tensor_postdivide_int32
 
   !> Overloads division operator for a tensor and a scalar of type int64.
-  function torch_tensor_postdivide_int64(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : int64
+  function torch_tensor_postdivide_int64(tensor, divisor) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int64), intent(in) :: scalar
+    integer(int64), target, intent(in) :: divisor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_postdivide_c(tensor_c, scalar_c)                 &
+      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
           result(output_c) bind(c, name = 'torch_tensor_postdivide')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
+        use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(kind=c_int64_t), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: divisor_c
         type(c_ptr) :: output_c
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, scalar)
+    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
   end function torch_tensor_postdivide_int64
 
   !> Overloads division operator for a tensor and a scalar of type real32.
-  function torch_tensor_postdivide_real32(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : real32
+  function torch_tensor_postdivide_real32(tensor, divisor) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real32), intent(in) :: scalar
+    real(real32), target, intent(in) :: divisor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_postdivide_c(tensor_c, scalar_c)                 &
+      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
           result(output_c) bind(c, name = 'torch_tensor_postdivide')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_float
+        use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        real(kind=c_float), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: divisor_c
         type(c_ptr) :: output_c
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, scalar)
+    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
   end function torch_tensor_postdivide_real32
 
   !> Overloads division operator for a tensor and a scalar of type real64.
-  function torch_tensor_postdivide_real64(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : real64
+  function torch_tensor_postdivide_real64(tensor, divisor) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real64), intent(in) :: scalar
+    real(real64), target, intent(in) :: divisor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_postdivide_c(tensor_c, scalar_c)                 &
+      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
           result(output_c) bind(c, name = 'torch_tensor_postdivide')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_double
+        use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        real(kind=c_double), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: divisor_c
         type(c_ptr) :: output_c
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, scalar)
+    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
   end function torch_tensor_postdivide_real64
 
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `int8`
   function torch_tensor_power_int8(tensor, power) result(output)
-    use, intrinsic :: iso_fortran_env, only : int8
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int8), intent(in) :: power
+    integer(int8), target, intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2839,19 +2839,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(c_int8_t), value, intent(in) :: power_c
+        type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
       end function torch_tensor_power_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, power)
+    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int8
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `int16`
   function torch_tensor_power_int16(tensor, power) result(output)
-    use, intrinsic :: iso_fortran_env, only : int16
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int16), intent(in) :: power
+    integer(int16), target, intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2860,19 +2860,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(c_int16_t), value, intent(in) :: power_c
+        type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
       end function torch_tensor_power_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, power)
+    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int16
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `int32`
   function torch_tensor_power_int32(tensor, power) result(output)
-    use, intrinsic :: iso_fortran_env, only : int32
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int32), intent(in) :: power
+    integer(int32), target, intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2881,19 +2881,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(c_int32_t), value, intent(in) :: power_c
+        type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
       end function torch_tensor_power_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, power)
+    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int32
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `int64`
   function torch_tensor_power_int64(tensor, power) result(output)
-    use, intrinsic :: iso_fortran_env, only : int64
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int64), intent(in) :: power
+    integer(int64), target, intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2902,19 +2902,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        integer(c_int64_t), value, intent(in) :: power_c
+        type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
       end function torch_tensor_power_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, power)
+    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int64
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `real32`
   function torch_tensor_power_real32(tensor, power) result(output)
-    use, intrinsic :: iso_fortran_env, only : real32
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real32), intent(in) :: power
+    real(real32), target, intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2923,19 +2923,19 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_float
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        real(c_float), value, intent(in) :: power_c
+        type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
       end function torch_tensor_power_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, power)
+    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_real32
 
   !> Overloads exponentiation operator for a tensor and a scalar of type `real64`
   function torch_tensor_power_real64(tensor, power) result(output)
-    use, intrinsic :: iso_fortran_env, only : real64
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real64), intent(in) :: power
+    real(real64), target, intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -2944,12 +2944,12 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, c_double
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        real(c_double), value, intent(in) :: power_c
+        type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
       end function torch_tensor_power_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, power)
+    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_real64
 
 

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -205,6 +205,17 @@ module ftorch
     module procedure torch_tensor_postmultiply_real64
   end interface
 
+  interface
+    function torch_tensor_multiply_c(tensor1_c, tensor2_c) result(output_c)  &
+        bind(c, name = 'torch_tensor_multiply')
+      use, intrinsic :: iso_c_binding, only : c_ptr
+      implicit none
+      type(c_ptr), value, intent(in) :: tensor1_c
+      type(c_ptr), value, intent(in) :: tensor2_c
+      type(c_ptr) :: output_c
+    end function torch_tensor_multiply_c
+  end interface
+
   interface operator (/)
     module procedure torch_tensor_divide
     module procedure torch_tensor_postdivide_int8
@@ -213,6 +224,17 @@ module ftorch
     module procedure torch_tensor_postdivide_int64
     module procedure torch_tensor_postdivide_real32
     module procedure torch_tensor_postdivide_real64
+  end interface
+
+  interface
+    function torch_tensor_divide_c(tensor1_c, tensor2_c) result(output_c)  &
+        bind(c, name = 'torch_tensor_divide')
+      use, intrinsic :: iso_c_binding, only : c_ptr
+      implicit none
+      type(c_ptr), value, intent(in) :: tensor1_c
+      type(c_ptr), value, intent(in) :: tensor2_c
+      type(c_ptr) :: output_c
+    end function torch_tensor_divide_c
   end interface
 
   interface operator (**)
@@ -2415,17 +2437,6 @@ contains
     type(torch_tensor), intent(in) :: tensor2
     type(torch_tensor) :: output
 
-    interface
-      function torch_tensor_multiply_c(tensor1_c, tensor2_c) result(output_c)  &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor1_c
-        type(c_ptr), value, intent(in) :: tensor2_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_multiply_c
-    end interface
-
     output%p = torch_tensor_multiply_c(tensor1%p, tensor2%p)
   end function torch_tensor_multiply
 
@@ -2436,19 +2447,9 @@ contains
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
-        implicit none
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_premultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar pre-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
+    output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int8
 
   !> Overloads multiplication operator for a scalar of type int16 and a tensor.
@@ -2458,19 +2459,9 @@ contains
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
-        implicit none
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_premultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar pre-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
+    output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int16
 
   !> Overloads multiplication operator for a scalar of type int32 and a tensor.
@@ -2480,19 +2471,9 @@ contains
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
-        implicit none
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_premultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar pre-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
+    output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int32
 
   !> Overloads multiplication operator for a scalar of type int64 and a tensor.
@@ -2502,19 +2483,9 @@ contains
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
-        implicit none
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_premultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar pre-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
+    output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int64
 
   !> Overloads multiplication operator for a scalar of type real32 and a tensor.
@@ -2524,19 +2495,9 @@ contains
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_float
-        implicit none
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_premultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar pre-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
+    output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real32
 
   !> Overloads multiplication operator for a scalar of type real64 and a tensor.
@@ -2546,19 +2507,9 @@ contains
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_double
-        implicit none
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_premultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar pre-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
+    output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real64
 
 
@@ -2569,19 +2520,9 @@ contains
     integer(int8), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postmultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
+    output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int8
 
   !> Overloads multiplication operator for a tensor and a scalar of type int16.
@@ -2591,19 +2532,9 @@ contains
     integer(int16), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postmultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
+    output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int16
 
   !> Overloads multiplication operator for a tensor and a scalar of type int32.
@@ -2613,19 +2544,9 @@ contains
     integer(int32), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postmultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
+    output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int32
 
   !> Overloads multiplication operator for a tensor and a scalar of type int64.
@@ -2635,19 +2556,9 @@ contains
     integer(int64), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postmultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
+    output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int64
 
   !> Overloads multiplication operator for a tensor and a scalar of type real32.
@@ -2657,19 +2568,9 @@ contains
     real(real32), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_float
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postmultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
+    output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real32
 
   !> Overloads multiplication operator for a tensor and a scalar of type real64.
@@ -2679,19 +2580,9 @@ contains
     real(real64), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_double
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postmultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
+    output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real64
 
   !> Overloads division operator for two tensors.
@@ -2699,17 +2590,6 @@ contains
     type(torch_tensor), intent(in) :: tensor1
     type(torch_tensor), intent(in) :: tensor2
     type(torch_tensor) :: output
-
-    interface
-      function torch_tensor_divide_c(tensor1_c, tensor2_c) result(output_c)  &
-          bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor1_c
-        type(c_ptr), value, intent(in) :: tensor2_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_divide_c
-    end interface
 
     output%p = torch_tensor_divide_c(tensor1%p, tensor2%p)
   end function torch_tensor_divide
@@ -2721,19 +2601,9 @@ contains
     integer(int8), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: divisor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postdivide_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-divisor
     call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
-    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
+    output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int8
 
   !> Overloads division operator for a tensor and a scalar of type int16.
@@ -2743,19 +2613,9 @@ contains
     integer(int16), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: divisor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postdivide_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-divisor
     call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
-    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
+    output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int16
 
   !> Overloads division operator for a tensor and a scalar of type int32.
@@ -2765,19 +2625,9 @@ contains
     integer(int32), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: divisor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postdivide_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-divisor
     call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
-    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
+    output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int32
 
   !> Overloads division operator for a tensor and a scalar of type int64.
@@ -2787,19 +2637,9 @@ contains
     integer(int64), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: divisor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postdivide_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-divisor
     call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
-    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
+    output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int64
 
   !> Overloads division operator for a tensor and a scalar of type real32.
@@ -2809,19 +2649,9 @@ contains
     real(real32), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: divisor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postdivide_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-divisor
     call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
-    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
+    output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real32
 
   !> Overloads division operator for a tensor and a scalar of type real64.
@@ -2831,19 +2661,9 @@ contains
     real(real64), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: divisor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postdivide_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-divisor
     call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
-    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
+    output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real64
 
 

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -33,11 +33,6 @@ module ftorch
     procedure :: get_shape
   end type torch_tensor
 
-  !> Type for holding a Torch scalar.
-  type torch_scalar
-    type(c_ptr) :: p = c_null_ptr  !! pointer to the scalar in memory
-  end type torch_scalar
-
   !| Enumerator for Torch data types
   !  From c_torch.h (torch_data_t)
   !  Note that 0 `torch_kUInt8` and 5 `torch_kFloat16` are not sypported in Fortran
@@ -2445,6 +2440,7 @@ contains
   !> Overloads multiplication operator for a scalar of type int8 and a tensor.
   function torch_tensor_premultiply_int8(scalar, tensor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int8
     integer(int8), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
@@ -2457,6 +2453,7 @@ contains
   !> Overloads multiplication operator for a scalar of type int16 and a tensor.
   function torch_tensor_premultiply_int16(scalar, tensor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int16
     integer(int16), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
@@ -2469,6 +2466,7 @@ contains
   !> Overloads multiplication operator for a scalar of type int32 and a tensor.
   function torch_tensor_premultiply_int32(scalar, tensor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int32
     integer(int32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
@@ -2481,6 +2479,7 @@ contains
   !> Overloads multiplication operator for a scalar of type int64 and a tensor.
   function torch_tensor_premultiply_int64(scalar, tensor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int64
     integer(int64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
@@ -2493,6 +2492,7 @@ contains
   !> Overloads multiplication operator for a scalar of type real32 and a tensor.
   function torch_tensor_premultiply_real32(scalar, tensor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : real32
     real(real32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
@@ -2505,6 +2505,7 @@ contains
   !> Overloads multiplication operator for a scalar of type real64 and a tensor.
   function torch_tensor_premultiply_real64(scalar, tensor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : real64
     real(real64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
@@ -2518,6 +2519,7 @@ contains
   !> Overloads multiplication operator for a tensor and a scalar of type int8.
   function torch_tensor_postmultiply_int8(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor
     integer(int8), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
@@ -2530,6 +2532,7 @@ contains
   !> Overloads multiplication operator for a tensor and a scalar of type int16.
   function torch_tensor_postmultiply_int16(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor
     integer(int16), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
@@ -2542,6 +2545,7 @@ contains
   !> Overloads multiplication operator for a tensor and a scalar of type int32.
   function torch_tensor_postmultiply_int32(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor
     integer(int32), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
@@ -2554,6 +2558,7 @@ contains
   !> Overloads multiplication operator for a tensor and a scalar of type int64.
   function torch_tensor_postmultiply_int64(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor
     integer(int64), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
@@ -2566,6 +2571,7 @@ contains
   !> Overloads multiplication operator for a tensor and a scalar of type real32.
   function torch_tensor_postmultiply_real32(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor
     real(real32), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
@@ -2578,6 +2584,7 @@ contains
   !> Overloads multiplication operator for a tensor and a scalar of type real64.
   function torch_tensor_postmultiply_real64(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor
     real(real64), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
@@ -2599,6 +2606,7 @@ contains
   !> Overloads division operator for a tensor and a scalar of type int8.
   function torch_tensor_postdivide_int8(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor
     integer(int8), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
@@ -2611,6 +2619,7 @@ contains
   !> Overloads division operator for a tensor and a scalar of type int16.
   function torch_tensor_postdivide_int16(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor
     integer(int16), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
@@ -2623,6 +2632,7 @@ contains
   !> Overloads division operator for a tensor and a scalar of type int32.
   function torch_tensor_postdivide_int32(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor
     integer(int32), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
@@ -2635,6 +2645,7 @@ contains
   !> Overloads division operator for a tensor and a scalar of type int64.
   function torch_tensor_postdivide_int64(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor
     integer(int64), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
@@ -2647,6 +2658,7 @@ contains
   !> Overloads division operator for a tensor and a scalar of type real32.
   function torch_tensor_postdivide_real32(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor
     real(real32), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
@@ -2659,6 +2671,7 @@ contains
   !> Overloads division operator for a tensor and a scalar of type real64.
   function torch_tensor_postdivide_real64(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor
     real(real64), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
@@ -2672,6 +2685,7 @@ contains
   !> Overloads exponentiation operator for a tensor and a scalar of type `int8`
   function torch_tensor_power_int8(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int8
     type(torch_tensor), intent(in) :: tensor
     integer(int8), target, intent(in) :: power
     type(torch_tensor) :: output
@@ -2693,6 +2707,7 @@ contains
   !> Overloads exponentiation operator for a tensor and a scalar of type `int16`
   function torch_tensor_power_int16(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int16
     type(torch_tensor), intent(in) :: tensor
     integer(int16), target, intent(in) :: power
     type(torch_tensor) :: output
@@ -2714,6 +2729,7 @@ contains
   !> Overloads exponentiation operator for a tensor and a scalar of type `int32`
   function torch_tensor_power_int32(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int32
     type(torch_tensor), intent(in) :: tensor
     integer(int32), target, intent(in) :: power
     type(torch_tensor) :: output
@@ -2735,6 +2751,7 @@ contains
   !> Overloads exponentiation operator for a tensor and a scalar of type `int64`
   function torch_tensor_power_int64(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : int64
     type(torch_tensor), intent(in) :: tensor
     integer(int64), target, intent(in) :: power
     type(torch_tensor) :: output
@@ -2757,6 +2774,7 @@ contains
   !> Overloads exponentiation operator for a tensor and a scalar of type `real32`
   function torch_tensor_power_real32(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : real32
     type(torch_tensor), intent(in) :: tensor
     real(kind=real32), target, intent(in) :: power
     type(torch_tensor) :: output
@@ -2778,6 +2796,7 @@ contains
   !> Overloads exponentiation operator for a tensor and a scalar of type `real64`
   function torch_tensor_power_real64(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : real64
     type(torch_tensor), intent(in) :: tensor
     real(kind=real64), target, intent(in) :: power
     type(torch_tensor) :: output

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -242,6 +242,8 @@ module ftorch
     module procedure torch_tensor_power_int16
     module procedure torch_tensor_power_int32
     module procedure torch_tensor_power_int64
+    module procedure torch_tensor_power_real32
+    module procedure torch_tensor_power_real64
   end interface
 
 contains
@@ -2667,7 +2669,7 @@ contains
   end function torch_tensor_postdivide_real64
 
 
-  !> Overloads exponentiation operator for a tensor and an integer of type `int8`
+  !> Overloads exponentiation operator for a tensor and a scalar of type `int8`
   function torch_tensor_power_int8(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -2675,20 +2677,20 @@ contains
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_power_c(tensor_c, power_c) result(output_c)        &
-          bind(c, name = 'torch_tensor_power')
+      function torch_tensor_power_int_c(tensor_c, power_c) result(output_c)        &
+          bind(c, name = 'torch_tensor_power_int')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
-      end function torch_tensor_power_c
+      end function torch_tensor_power_int_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
+    output%p = torch_tensor_power_int_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int8
 
-  !> Overloads exponentiation operator for a tensor and an integer of type `int16`
+  !> Overloads exponentiation operator for a tensor and a scalar of type `int16`
   function torch_tensor_power_int16(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -2696,20 +2698,20 @@ contains
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_power_c(tensor_c, power_c) result(output_c)        &
-          bind(c, name = 'torch_tensor_power')
+      function torch_tensor_power_int_c(tensor_c, power_c) result(output_c)        &
+          bind(c, name = 'torch_tensor_power_int')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
-      end function torch_tensor_power_c
+      end function torch_tensor_power_int_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
+    output%p = torch_tensor_power_int_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int16
 
-  !> Overloads exponentiation operator for a tensor and an integer of type `int32`
+  !> Overloads exponentiation operator for a tensor and a scalar of type `int32`
   function torch_tensor_power_int32(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -2717,20 +2719,20 @@ contains
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_power_c(tensor_c, power_c) result(output_c)        &
-          bind(c, name = 'torch_tensor_power')
+      function torch_tensor_power_int_c(tensor_c, power_c) result(output_c)        &
+          bind(c, name = 'torch_tensor_power_int')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
-      end function torch_tensor_power_c
+      end function torch_tensor_power_int_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
+    output%p = torch_tensor_power_int_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int32
 
-  !> Overloads exponentiation operator for a tensor and an integer of type `int64`
+  !> Overloads exponentiation operator for a tensor and a scalar of type `int64`
   function torch_tensor_power_int64(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -2738,18 +2740,61 @@ contains
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_power_c(tensor_c, power_c) result(output_c)        &
-          bind(c, name = 'torch_tensor_power')
+      function torch_tensor_power_int_c(tensor_c, power_c) result(output_c)        &
+          bind(c, name = 'torch_tensor_power_int')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
-      end function torch_tensor_power_c
+      end function torch_tensor_power_int_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
+    output%p = torch_tensor_power_int_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int64
+
+
+  !> Overloads exponentiation operator for a tensor and a scalar of type `real32`
+  function torch_tensor_power_real32(tensor, power) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
+    type(torch_tensor), intent(in) :: tensor
+    real(kind=real32), target, intent(in) :: power
+    type(torch_tensor) :: output
+
+    interface
+      function torch_tensor_power_float_c(tensor_c, power_c) result(output_c)        &
+          bind(c, name = 'torch_tensor_power_float')
+        use, intrinsic :: iso_c_binding, only : c_ptr, c_float
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor_c
+        type(c_ptr), value, intent(in) :: power_c
+        type(c_ptr) :: output_c
+      end function torch_tensor_power_float_c
+    end interface
+
+    output%p = torch_tensor_power_float_c(tensor%p, c_loc(power))
+  end function torch_tensor_power_real32
+
+  !> Overloads exponentiation operator for a tensor and a scalar of type `real64`
+  function torch_tensor_power_real64(tensor, power) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
+    type(torch_tensor), intent(in) :: tensor
+    real(kind=real64), target, intent(in) :: power
+    type(torch_tensor) :: output
+
+    interface
+      function torch_tensor_power_float_c(tensor_c, power_c) result(output_c)        &
+          bind(c, name = 'torch_tensor_power_float')
+        use, intrinsic :: iso_c_binding, only : c_ptr, c_double
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor_c
+        type(c_ptr), value, intent(in) :: power_c
+        type(c_ptr) :: output_c
+      end function torch_tensor_power_float_c
+    end interface
+
+    output%p = torch_tensor_power_float_c(tensor%p, c_loc(power))
+  end function torch_tensor_power_real64
 
 
   ! ============================================================================

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -220,8 +220,6 @@ module ftorch
     module procedure torch_tensor_power_int16
     module procedure torch_tensor_power_int32
     module procedure torch_tensor_power_int64
-    module procedure torch_tensor_power_real32
-    module procedure torch_tensor_power_real64
   end interface
 
 contains
@@ -2849,7 +2847,7 @@ contains
   end function torch_tensor_postdivide_real64
 
 
-  !> Overloads exponentiation operator for a tensor and a scalar of type `int8`
+  !> Overloads exponentiation operator for a tensor and an integer of type `int8`
   function torch_tensor_power_int8(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -2870,7 +2868,7 @@ contains
     output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int8
 
-  !> Overloads exponentiation operator for a tensor and a scalar of type `int16`
+  !> Overloads exponentiation operator for a tensor and an integer of type `int16`
   function torch_tensor_power_int16(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -2891,7 +2889,7 @@ contains
     output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int16
 
-  !> Overloads exponentiation operator for a tensor and a scalar of type `int32`
+  !> Overloads exponentiation operator for a tensor and an integer of type `int32`
   function torch_tensor_power_int32(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -2912,7 +2910,7 @@ contains
     output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int32
 
-  !> Overloads exponentiation operator for a tensor and a scalar of type `int64`
+  !> Overloads exponentiation operator for a tensor and an integer of type `int64`
   function torch_tensor_power_int64(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -2932,48 +2930,6 @@ contains
 
     output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_int64
-
-  !> Overloads exponentiation operator for a tensor and a scalar of type `real32`
-  function torch_tensor_power_real32(tensor, power) result(output)
-    use, intrinsic :: iso_c_binding, only : c_loc
-    type(torch_tensor), intent(in) :: tensor
-    real(real32), target, intent(in) :: power
-    type(torch_tensor) :: output
-
-    interface
-      function torch_tensor_power_c(tensor_c, power_c) result(output_c)        &
-          bind(c, name = 'torch_tensor_power')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_float
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: power_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_power_c
-    end interface
-
-    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
-  end function torch_tensor_power_real32
-
-  !> Overloads exponentiation operator for a tensor and a scalar of type `real64`
-  function torch_tensor_power_real64(tensor, power) result(output)
-    use, intrinsic :: iso_c_binding, only : c_loc
-    type(torch_tensor), intent(in) :: tensor
-    real(real64), target, intent(in) :: power
-    type(torch_tensor) :: output
-
-    interface
-      function torch_tensor_power_c(tensor_c, power_c) result(output_c)        &
-          bind(c, name = 'torch_tensor_power')
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_double
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: power_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_power_c
-    end interface
-
-    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
-  end function torch_tensor_power_real64
 
 
   ! ============================================================================

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -33,6 +33,11 @@ module ftorch
     procedure :: get_shape
   end type torch_tensor
 
+  !> Type for holding a Torch scalar.
+  type torch_scalar
+    type(c_ptr) :: p = c_null_ptr  !! pointer to the scalar in memory
+  end type torch_scalar
+
   !| Enumerator for Torch data types
   !  From c_torch.h (torch_data_t)
   !  Note that 0 `torch_kUInt8` and 5 `torch_kFloat16` are not sypported in Fortran
@@ -2431,11 +2436,11 @@ contains
     use, intrinsic :: iso_c_binding, only : c_loc
     integer(int8), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
-    type(torch_tensor) :: output
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_premultiply')
+          bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
         implicit none
         type(c_ptr), value, intent(in) :: scalar_c
@@ -2444,7 +2449,8 @@ contains
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int8
 
   !> Overloads multiplication operator for a scalar of type int16 and a tensor.
@@ -2452,11 +2458,11 @@ contains
     use, intrinsic :: iso_c_binding, only : c_loc
     integer(int16), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
-    type(torch_tensor) :: output
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_premultiply')
+          bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
         implicit none
         type(c_ptr), value, intent(in) :: scalar_c
@@ -2465,7 +2471,8 @@ contains
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int16
 
   !> Overloads multiplication operator for a scalar of type int32 and a tensor.
@@ -2473,11 +2480,11 @@ contains
     use, intrinsic :: iso_c_binding, only : c_loc
     integer(int32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
-    type(torch_tensor) :: output
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_premultiply')
+          bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
         implicit none
         type(c_ptr), value, intent(in) :: scalar_c
@@ -2486,7 +2493,8 @@ contains
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int32
 
   !> Overloads multiplication operator for a scalar of type int64 and a tensor.
@@ -2494,11 +2502,11 @@ contains
     use, intrinsic :: iso_c_binding, only : c_loc
     integer(int64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
-    type(torch_tensor) :: output
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_premultiply')
+          bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
         implicit none
         type(c_ptr), value, intent(in) :: scalar_c
@@ -2507,7 +2515,8 @@ contains
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int64
 
   !> Overloads multiplication operator for a scalar of type real32 and a tensor.
@@ -2515,11 +2524,11 @@ contains
     use, intrinsic :: iso_c_binding, only : c_loc
     real(real32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
-    type(torch_tensor) :: output
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_premultiply')
+          bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_float
         implicit none
         type(c_ptr), value, intent(in) :: scalar_c
@@ -2528,7 +2537,8 @@ contains
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real32
 
   !> Overloads multiplication operator for a scalar of type real64 and a tensor.
@@ -2536,11 +2546,11 @@ contains
     use, intrinsic :: iso_c_binding, only : c_loc
     real(real64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
-    type(torch_tensor) :: output
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_premultiply')
+          bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_double
         implicit none
         type(c_ptr), value, intent(in) :: scalar_c
@@ -2549,7 +2559,8 @@ contains
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real64
 
 
@@ -2557,12 +2568,12 @@ contains
   function torch_tensor_postmultiply_int8(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int8), target, intent(in) :: scalar
-    type(torch_tensor) :: output
+    integer(int8), intent(in) :: scalar
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_postmultiply')
+          result(output_c) bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int8_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2571,19 +2582,20 @@ contains
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int8
 
   !> Overloads multiplication operator for a tensor and a scalar of type int16.
   function torch_tensor_postmultiply_int16(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int16), target, intent(in) :: scalar
-    type(torch_tensor) :: output
+    integer(int16), intent(in) :: scalar
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_postmultiply')
+          result(output_c) bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int16_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2592,19 +2604,20 @@ contains
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int16
 
   !> Overloads multiplication operator for a tensor and a scalar of type int32.
   function torch_tensor_postmultiply_int32(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int32), target, intent(in) :: scalar
-    type(torch_tensor) :: output
+    integer(int32), intent(in) :: scalar
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_postmultiply')
+          result(output_c) bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int32_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2613,19 +2626,20 @@ contains
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int32
 
   !> Overloads multiplication operator for a tensor and a scalar of type int64.
   function torch_tensor_postmultiply_int64(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int64), target, intent(in) :: scalar
-    type(torch_tensor) :: output
+    integer(int64), intent(in) :: scalar
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_postmultiply')
+          result(output_c) bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_int64_t
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2634,19 +2648,20 @@ contains
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int64
 
   !> Overloads multiplication operator for a tensor and a scalar of type real32.
   function torch_tensor_postmultiply_real32(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real32), target, intent(in) :: scalar
-    type(torch_tensor) :: output
+    real(real32), intent(in) :: scalar
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_postmultiply')
+          result(output_c) bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_float
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2655,19 +2670,20 @@ contains
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real32
 
   !> Overloads multiplication operator for a tensor and a scalar of type real64.
   function torch_tensor_postmultiply_real64(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real64), target, intent(in) :: scalar
-    type(torch_tensor) :: output
+    real(real64), intent(in) :: scalar
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_postmultiply')
+          result(output_c) bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, c_double
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2676,7 +2692,8 @@ contains
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real64
 
   !> Overloads division operator for two tensors.
@@ -2703,12 +2720,12 @@ contains
   function torch_tensor_postdivide_int8(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int8), target, intent(in) :: divisor
-    type(torch_tensor) :: output
+    integer(int8), intent(in) :: divisor
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_postdivide')
+          result(output_c) bind(c, name = 'torch_tensor_divide')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2717,19 +2734,20 @@ contains
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
+    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int8
 
   !> Overloads division operator for a tensor and a scalar of type int16.
   function torch_tensor_postdivide_int16(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int16), target, intent(in) :: divisor
-    type(torch_tensor) :: output
+    integer(int16), intent(in) :: divisor
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_postdivide')
+          result(output_c) bind(c, name = 'torch_tensor_divide')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2738,19 +2756,20 @@ contains
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
+    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int16
 
   !> Overloads division operator for a tensor and a scalar of type int32.
   function torch_tensor_postdivide_int32(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int32), target, intent(in) :: divisor
-    type(torch_tensor) :: output
+    integer(int32), intent(in) :: divisor
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_postdivide')
+          result(output_c) bind(c, name = 'torch_tensor_divide')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2759,19 +2778,20 @@ contains
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
+    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int32
 
   !> Overloads division operator for a tensor and a scalar of type int64.
   function torch_tensor_postdivide_int64(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    integer(int64), target, intent(in) :: divisor
-    type(torch_tensor) :: output
+    integer(int64), intent(in) :: divisor
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_postdivide')
+          result(output_c) bind(c, name = 'torch_tensor_divide')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2780,19 +2800,20 @@ contains
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
+    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int64
 
   !> Overloads division operator for a tensor and a scalar of type real32.
   function torch_tensor_postdivide_real32(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real32), target, intent(in) :: divisor
-    type(torch_tensor) :: output
+    real(real32), intent(in) :: divisor
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_postdivide')
+          result(output_c) bind(c, name = 'torch_tensor_divide')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2801,19 +2822,20 @@ contains
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
+    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real32
 
   !> Overloads division operator for a tensor and a scalar of type real64.
   function torch_tensor_postdivide_real64(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    real(real64), target, intent(in) :: divisor
-    type(torch_tensor) :: output
+    real(real64), intent(in) :: divisor
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_postdivide')
+          result(output_c) bind(c, name = 'torch_tensor_divide')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -2822,7 +2844,8 @@ contains
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
+    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real64
 
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -1,6 +1,7 @@
 #:def ranksuffix(RANK)
 $:'' if RANK == 0 else '(' + ':' + ',:' * (RANK - 1) + ')'
 #:enddef ranksuffix
+#:set INT_PRECISIONS = ['int8', 'int16', 'int32', 'int64']
 #:set PRECISIONS = ['int8', 'int16', 'int32', 'int64', 'real32', 'real64']
 #:set C_PRECISIONS = ['c_int8_t', 'c_int16_t', 'c_int32_t', 'c_int64_t', 'c_float', 'c_double']
 #:set C_PRECISIONS = dict(zip(PRECISIONS, C_PRECISIONS))
@@ -172,7 +173,7 @@ module ftorch
   end interface
 
   interface operator (**)
-    #:for PREC in PRECISIONS
+    #:for PREC in INT_PRECISIONS
     module procedure torch_tensor_power_${PREC}$
     #:endfor
   end interface
@@ -746,8 +747,8 @@ contains
 
   #:endfor
 
-  #:for PREC in PRECISIONS
-  !> Overloads exponentiation operator for a tensor and a scalar of type `${PREC}$`
+  #:for PREC in INT_PRECISIONS
+  !> Overloads exponentiation operator for a tensor and an integer of type `${PREC}$`
   function torch_tensor_power_${PREC}$(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -650,8 +650,8 @@ contains
   #:for PREC in PRECISIONS
   !> Overloads multiplication operator for a scalar of type ${PREC}$ and a tensor.
   function torch_tensor_premultiply_${PREC}$(scalar, tensor) result(output)
-    use, intrinsic :: iso_fortran_env, only : ${PREC}$
-    ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
+    use, intrinsic :: iso_c_binding, only : c_loc
+    ${f_type(PREC)}$(${PREC}$), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
@@ -660,13 +660,13 @@ contains
           bind(c, name = 'torch_tensor_premultiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
         implicit none
-        ${f_type(PREC)}$(kind=${c_prec(PREC)}$), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(scalar, tensor%p)
+    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
   end function torch_tensor_premultiply_${PREC}$
 
   #:endfor
@@ -674,9 +674,9 @@ contains
   #:for PREC in PRECISIONS
   !> Overloads multiplication operator for a tensor and a scalar of type ${PREC}$.
   function torch_tensor_postmultiply_${PREC}$(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : ${PREC}$
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
+    ${f_type(PREC)}$(${PREC}$), target, intent(in) :: scalar
     type(torch_tensor) :: output
 
     interface
@@ -685,12 +685,12 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        ${f_type(PREC)}$(kind=${c_prec(PREC)}$), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: scalar_c
         type(c_ptr) :: output_c
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, scalar)
+    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
   end function torch_tensor_postmultiply_${PREC}$
 
   #:endfor
@@ -716,24 +716,24 @@ contains
 
   #:for PREC in PRECISIONS
   !> Overloads division operator for a tensor and a scalar of type ${PREC}$.
-  function torch_tensor_postdivide_${PREC}$(tensor, scalar) result(output)
-    use, intrinsic :: iso_fortran_env, only : ${PREC}$
+  function torch_tensor_postdivide_${PREC}$(tensor, divisor) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
+    ${f_type(PREC)}$(${PREC}$), target, intent(in) :: divisor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_postdivide_c(tensor_c, scalar_c)                 &
+      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
           result(output_c) bind(c, name = 'torch_tensor_postdivide')
-        use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
+        use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        ${f_type(PREC)}$(kind=${c_prec(PREC)}$), value, intent(in) :: scalar_c
+        type(c_ptr), value, intent(in) :: divisor_c
         type(c_ptr) :: output_c
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, scalar)
+    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
   end function torch_tensor_postdivide_${PREC}$
 
   #:endfor
@@ -741,9 +741,9 @@ contains
   #:for PREC in PRECISIONS
   !> Overloads exponentiation operator for a tensor and a scalar of type `${PREC}$`
   function torch_tensor_power_${PREC}$(tensor, power) result(output)
-    use, intrinsic :: iso_fortran_env, only : ${PREC}$
+    use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    ${f_type(PREC)}$(${PREC}$), intent(in) :: power
+    ${f_type(PREC)}$(${PREC}$), target, intent(in) :: power
     type(torch_tensor) :: output
 
     interface
@@ -752,12 +752,12 @@ contains
         use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
-        ${f_type(PREC)}$(${c_prec(PREC)}$), value, intent(in) :: power_c
+        type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
       end function torch_tensor_power_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, power)
+    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
   end function torch_tensor_power_${PREC}$
 
   #:endfor

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -2,7 +2,8 @@
 $:'' if RANK == 0 else '(' + ':' + ',:' * (RANK - 1) + ')'
 #:enddef ranksuffix
 #:set INT_PRECISIONS = ['int8', 'int16', 'int32', 'int64']
-#:set PRECISIONS = ['int8', 'int16', 'int32', 'int64', 'real32', 'real64']
+#:set FLOAT_PRECISIONS = ['real32', 'real64']
+#:set PRECISIONS = INT_PRECISIONS + FLOAT_PRECISIONS
 #:set C_PRECISIONS = ['c_int8_t', 'c_int16_t', 'c_int32_t', 'c_int64_t', 'c_float', 'c_double']
 #:set C_PRECISIONS = dict(zip(PRECISIONS, C_PRECISIONS))
 #:set ENUMS = dict(zip(PRECISIONS, ['torch_kInt8', 'torch_kInt16', 'torch_kInt32', 'torch_kInt64', 'torch_kFloat32', 'torch_kFloat64']))
@@ -195,7 +196,7 @@ module ftorch
   end interface
 
   interface operator (**)
-    #:for PREC in INT_PRECISIONS
+    #:for PREC in PRECISIONS
     module procedure torch_tensor_power_${PREC}$
     #:endfor
   end interface
@@ -718,7 +719,7 @@ contains
   #:endfor
 
   #:for PREC in INT_PRECISIONS
-  !> Overloads exponentiation operator for a tensor and an integer of type `${PREC}$`
+  !> Overloads exponentiation operator for a tensor and a scalar of type `${PREC}$`
   function torch_tensor_power_${PREC}$(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
@@ -726,17 +727,41 @@ contains
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_power_c(tensor_c, power_c) result(output_c)        &
-          bind(c, name = 'torch_tensor_power')
+      function torch_tensor_power_int_c(tensor_c, power_c) result(output_c)        &
+          bind(c, name = 'torch_tensor_power_int')
         use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: power_c
         type(c_ptr) :: output_c
-      end function torch_tensor_power_c
+      end function torch_tensor_power_int_c
     end interface
 
-    output%p = torch_tensor_power_c(tensor%p, c_loc(power))
+    output%p = torch_tensor_power_int_c(tensor%p, c_loc(power))
+  end function torch_tensor_power_${PREC}$
+
+  #:endfor
+
+  #:for PREC in FLOAT_PRECISIONS
+  !> Overloads exponentiation operator for a tensor and a scalar of type `${PREC}$`
+  function torch_tensor_power_${PREC}$(tensor, power) result(output)
+    use, intrinsic :: iso_c_binding, only : c_loc
+    type(torch_tensor), intent(in) :: tensor
+    ${f_type(PREC)}$(kind=${PREC}$), target, intent(in) :: power
+    type(torch_tensor) :: output
+
+    interface
+      function torch_tensor_power_float_c(tensor_c, power_c) result(output_c)        &
+          bind(c, name = 'torch_tensor_power_float')
+        use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor_c
+        type(c_ptr), value, intent(in) :: power_c
+        type(c_ptr) :: output_c
+      end function torch_tensor_power_float_c
+    end interface
+
+    output%p = torch_tensor_power_float_c(tensor%p, c_loc(power))
   end function torch_tensor_power_${PREC}$
 
   #:endfor

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -165,11 +165,33 @@ module ftorch
     #:endfor
   end interface
 
+  interface
+    function torch_tensor_multiply_c(tensor1_c, tensor2_c) result(output_c)  &
+        bind(c, name = 'torch_tensor_multiply')
+      use, intrinsic :: iso_c_binding, only : c_ptr
+      implicit none
+      type(c_ptr), value, intent(in) :: tensor1_c
+      type(c_ptr), value, intent(in) :: tensor2_c
+      type(c_ptr) :: output_c
+    end function torch_tensor_multiply_c
+  end interface
+
   interface operator (/)
     module procedure torch_tensor_divide
     #:for PREC in PRECISIONS
     module procedure torch_tensor_postdivide_${PREC}$
     #:endfor
+  end interface
+
+  interface
+    function torch_tensor_divide_c(tensor1_c, tensor2_c) result(output_c)  &
+        bind(c, name = 'torch_tensor_divide')
+      use, intrinsic :: iso_c_binding, only : c_ptr
+      implicit none
+      type(c_ptr), value, intent(in) :: tensor1_c
+      type(c_ptr), value, intent(in) :: tensor2_c
+      type(c_ptr) :: output_c
+    end function torch_tensor_divide_c
   end interface
 
   interface operator (**)
@@ -639,17 +661,6 @@ contains
     type(torch_tensor), intent(in) :: tensor2
     type(torch_tensor) :: output
 
-    interface
-      function torch_tensor_multiply_c(tensor1_c, tensor2_c) result(output_c)  &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor1_c
-        type(c_ptr), value, intent(in) :: tensor2_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_multiply_c
-    end interface
-
     output%p = torch_tensor_multiply_c(tensor1%p, tensor2%p)
   end function torch_tensor_multiply
 
@@ -661,19 +672,9 @@ contains
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
-        implicit none
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_premultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar pre-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
+    output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_${PREC}$
 
   #:endfor
@@ -686,19 +687,9 @@ contains
     ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_multiply')
-        use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: scalar_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postmultiply_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-multiplier
     call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
-    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
+    output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_${PREC}$
 
   #:endfor
@@ -707,17 +698,6 @@ contains
     type(torch_tensor), intent(in) :: tensor1
     type(torch_tensor), intent(in) :: tensor2
     type(torch_tensor) :: output
-
-    interface
-      function torch_tensor_divide_c(tensor1_c, tensor2_c) result(output_c)  &
-          bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor1_c
-        type(c_ptr), value, intent(in) :: tensor2_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_divide_c
-    end interface
 
     output%p = torch_tensor_divide_c(tensor1%p, tensor2%p)
   end function torch_tensor_divide
@@ -730,19 +710,9 @@ contains
     ${f_type(PREC)}$(${PREC}$), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
 
-    interface
-      function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_divide')
-        use, intrinsic :: iso_c_binding, only : c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor_c
-        type(c_ptr), value, intent(in) :: divisor_c
-        type(c_ptr) :: output_c
-      end function torch_tensor_postdivide_c
-    end interface
-
+    ! Create a tensor with a single entry, the scalar post-divisor
     call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
-    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
+    output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_${PREC}$
 
   #:endfor

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -50,6 +50,11 @@ module ftorch
     procedure :: get_shape
   end type torch_tensor
 
+  !> Type for holding a Torch scalar.
+  type torch_scalar
+    type(c_ptr) :: p = c_null_ptr  !! pointer to the scalar in memory
+  end type torch_scalar
+
   !| Enumerator for Torch data types
   !  From c_torch.h (torch_data_t)
   !  Note that 0 `torch_kUInt8` and 5 `torch_kFloat16` are not sypported in Fortran
@@ -653,11 +658,11 @@ contains
     use, intrinsic :: iso_c_binding, only : c_loc
     ${f_type(PREC)}$(${PREC}$), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
-    type(torch_tensor) :: output
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_premultiply_c(scalar_c, tensor_c) result(output_c) &
-          bind(c, name = 'torch_tensor_premultiply')
+          bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
         implicit none
         type(c_ptr), value, intent(in) :: scalar_c
@@ -666,7 +671,8 @@ contains
       end function torch_tensor_premultiply_c
     end interface
 
-    output%p = torch_tensor_premultiply_c(c_loc(scalar), tensor%p)
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_premultiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_${PREC}$
 
   #:endfor
@@ -676,12 +682,12 @@ contains
   function torch_tensor_postmultiply_${PREC}$(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    ${f_type(PREC)}$(${PREC}$), target, intent(in) :: scalar
-    type(torch_tensor) :: output
+    ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postmultiply_c(tensor_c, scalar_c)                 &
-          result(output_c) bind(c, name = 'torch_tensor_postmultiply')
+          result(output_c) bind(c, name = 'torch_tensor_multiply')
         use, intrinsic :: iso_c_binding, only : c_ptr, ${c_prec(PREC)}$
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -690,7 +696,8 @@ contains
       end function torch_tensor_postmultiply_c
     end interface
 
-    output%p = torch_tensor_postmultiply_c(tensor%p, c_loc(scalar))
+    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    output%p = torch_tensor_postmultiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_${PREC}$
 
   #:endfor
@@ -719,12 +726,12 @@ contains
   function torch_tensor_postdivide_${PREC}$(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
     type(torch_tensor), intent(in) :: tensor
-    ${f_type(PREC)}$(${PREC}$), target, intent(in) :: divisor
-    type(torch_tensor) :: output
+    ${f_type(PREC)}$(${PREC}$), intent(in) :: divisor
+    type(torch_tensor) :: wrk, output
 
     interface
       function torch_tensor_postdivide_c(tensor_c, divisor_c) &
-          result(output_c) bind(c, name = 'torch_tensor_postdivide')
+          result(output_c) bind(c, name = 'torch_tensor_divide')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
@@ -733,7 +740,8 @@ contains
       end function torch_tensor_postdivide_c
     end interface
 
-    output%p = torch_tensor_postdivide_c(tensor%p, c_loc(divisor))
+    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    output%p = torch_tensor_postdivide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_${PREC}$
 
   #:endfor

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -52,11 +52,6 @@ module ftorch
     procedure :: get_shape
   end type torch_tensor
 
-  !> Type for holding a Torch scalar.
-  type torch_scalar
-    type(c_ptr) :: p = c_null_ptr  !! pointer to the scalar in memory
-  end type torch_scalar
-
   !| Enumerator for Torch data types
   !  From c_torch.h (torch_data_t)
   !  Note that 0 `torch_kUInt8` and 5 `torch_kFloat16` are not sypported in Fortran
@@ -669,6 +664,7 @@ contains
   !> Overloads multiplication operator for a scalar of type ${PREC}$ and a tensor.
   function torch_tensor_premultiply_${PREC}$(scalar, tensor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
     ${f_type(PREC)}$(${PREC}$), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
@@ -684,6 +680,7 @@ contains
   !> Overloads multiplication operator for a tensor and a scalar of type ${PREC}$.
   function torch_tensor_postmultiply_${PREC}$(tensor, scalar) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
     type(torch_tensor), intent(in) :: tensor
     ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
@@ -707,6 +704,7 @@ contains
   !> Overloads division operator for a tensor and a scalar of type ${PREC}$.
   function torch_tensor_postdivide_${PREC}$(tensor, divisor) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
     type(torch_tensor), intent(in) :: tensor
     ${f_type(PREC)}$(${PREC}$), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
@@ -722,6 +720,7 @@ contains
   !> Overloads exponentiation operator for a tensor and a scalar of type `${PREC}$`
   function torch_tensor_power_${PREC}$(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
     type(torch_tensor), intent(in) :: tensor
     ${f_type(PREC)}$(${PREC}$), target, intent(in) :: power
     type(torch_tensor) :: output
@@ -746,6 +745,7 @@ contains
   !> Overloads exponentiation operator for a tensor and a scalar of type `${PREC}$`
   function torch_tensor_power_${PREC}$(tensor, power) result(output)
     use, intrinsic :: iso_c_binding, only : c_loc
+    use, intrinsic :: iso_fortran_env, only : ${PREC}$
     type(torch_tensor), intent(in) :: tensor
     ${f_type(PREC)}$(kind=${PREC}$), target, intent(in) :: power
     type(torch_tensor) :: output

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -10,3 +10,5 @@ find_package(PFUNIT REQUIRED)
 
 add_pfunit_ctest(test_constructors
   TEST_SOURCES test_constructors.pf LINK_LIBRARIES FTorch::ftorch)
+add_pfunit_ctest(test_operator_overloads
+  TEST_SOURCES test_tensor_operator_overloads.pf LINK_LIBRARIES FTorch::ftorch)

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -457,3 +457,56 @@ subroutine test_torch_tensor_square()
   call torch_tensor_delete(tensor3)
 
 end subroutine test_torch_tensor_square
+
+@test
+subroutine test_torch_tensor_sqrt()
+  use FUnit
+  use ftorch, only: assignment(=), operator(**), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  real(wp), dimension(2,3), target :: in_data
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create an arbitrary input array
+  in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+  ! Create a tensor based off the input array
+  call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
+
+  ! Create another empty tensors and assign it to the first tensor to the power of 0.5 using the
+  ! overloaded exponentiation operator
+  call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
+  tensor2 = tensor1 ** 0.5
+
+  ! Extract Fortran arrays from the assigned tensors
+  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+
+  ! Compare the data in the tensors to the input data
+  expected(:,:) = in_data ** 0.5
+  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_sqrt")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data))
+
+  ! Cleanup
+  nullify(out_data)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+
+end subroutine test_torch_tensor_sqrt

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -226,6 +226,70 @@ subroutine test_torch_tensor_multiply()
 end subroutine test_torch_tensor_multiply
 
 @test
+subroutine test_torch_tensor_scalar_multiply()
+  use FUnit
+  use ftorch, only: assignment(=), operator(*), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2, tensor3
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  ! real(wp), parameter :: scalar = 3.14 ! FIXME: Segfault
+  ! real(wp), parameter :: scalar = 3 ! FIXME: Segfault
+  integer, parameter :: scalar = 3
+  real(wp), dimension(2,3), target :: in_data
+  real(wp), dimension(:,:), pointer :: out_data2, out_data3
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create an arbitrary input array
+  in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+  ! Create a tensor based off the input array
+  call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
+
+  ! Create another two empty tensors and assign them to the products of a scalar constant and the
+  ! first tensor using the overloaded multiplication operator (in each order)
+  call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
+  call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+  tensor2 = scalar * tensor1
+  tensor3 = tensor1 * scalar
+
+  ! Extract Fortran arrays from the assigned tensors
+  call torch_tensor_to_array(tensor2, out_data2, shape(in_data))
+  call torch_tensor_to_array(tensor3, out_data3, shape(in_data))
+
+  ! Compare the data in the tensors to the input data
+  expected(:,:) = scalar * in_data
+  test_pass = assert_allclose(out_data2, expected, test_name="test_torch_tensor_premultiply")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data2))
+  test_pass = assert_allclose(out_data3, expected, test_name="test_torch_tensor_postmultiply")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data3))
+
+  ! Cleanup
+  nullify(out_data2)
+  nullify(out_data3)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+  call torch_tensor_delete(tensor3)
+
+end subroutine test_torch_tensor_scalar_multiply
+
+@test
 subroutine test_torch_tensor_divide()
   use FUnit
   use ftorch, only: assignment(=), operator(/), ftorch_int, torch_kCPU, torch_kFloat32, &

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -168,3 +168,59 @@ subroutine test_torch_tensor_subtract()
   call torch_tensor_delete(tensor3)
 
 end subroutine test_torch_tensor_subtract
+
+@test
+subroutine test_torch_tensor_multiply()
+  use FUnit
+  use ftorch, only: assignment(=), operator(*), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2, tensor3
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  real(wp), dimension(2,3), target :: in_data1, in_data2
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create two arbitrary input arrays
+  in_data1(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  in_data2(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
+
+  ! Create tensors based off the two input arrays
+  call torch_tensor_from_array(tensor1, in_data1, tensor_layout, device_type)
+  call torch_tensor_from_array(tensor2, in_data2, tensor_layout, device_type)
+
+  ! Create another empty tensor and assign it to the product of the first two using the overloaded
+  ! multiplication operator
+  call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+  tensor3 = tensor1 * tensor2
+
+  ! Extract Fortran array from the assigned tensor
+  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
+
+  ! Compare the data in the tensor to the input data
+  expected(:,:) = in_data1 * in_data2
+  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_multiply")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data))
+
+  ! Cleanup
+  nullify(out_data)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+  call torch_tensor_delete(tensor3)
+
+end subroutine test_torch_tensor_multiply

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -46,8 +46,6 @@ subroutine test_torch_tensor_assign()
 
   ! Compare the data in the tensor to the input data
   expected(:,:) = in_data
-  print *, expected
-  print *, out_data
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_assign")
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data))
@@ -58,3 +56,59 @@ subroutine test_torch_tensor_assign()
   call torch_tensor_delete(tensor2)
 
 end subroutine test_torch_tensor_assign
+
+@test
+subroutine test_torch_tensor_add()
+  use FUnit
+  use ftorch, only: assignment(=), operator(+), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2, tensor3
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  real(wp), dimension(2,3), target :: in_data1, in_data2
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create two arbitrary input arrays
+  in_data1(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  in_data2(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
+
+  ! Create tensors based off the two input arrays
+  call torch_tensor_from_array(tensor1, in_data1, tensor_layout, device_type)
+  call torch_tensor_from_array(tensor2, in_data2, tensor_layout, device_type)
+
+  ! Create another empty tensor and assign it to the sum of the first two using the overloaded
+  ! addition operator
+  call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+  tensor3 = tensor1 + tensor2
+
+  ! Extract Fortran array from the assigned tensor
+  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
+
+  ! Compare the data in the tensor to the input data
+  expected(:,:) = in_data1 + in_data2
+  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_add")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data))
+
+  ! Cleanup
+  nullify(out_data)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+  call torch_tensor_delete(tensor3)
+
+end subroutine test_torch_tensor_add

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -112,3 +112,59 @@ subroutine test_torch_tensor_add()
   call torch_tensor_delete(tensor3)
 
 end subroutine test_torch_tensor_add
+
+@test
+subroutine test_torch_tensor_subtract()
+  use FUnit
+  use ftorch, only: assignment(=), operator(-), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2, tensor3
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  real(wp), dimension(2,3), target :: in_data1, in_data2
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create two arbitrary input arrays
+  in_data1(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  in_data2(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
+
+  ! Create tensors based off the two input arrays
+  call torch_tensor_from_array(tensor1, in_data1, tensor_layout, device_type)
+  call torch_tensor_from_array(tensor2, in_data2, tensor_layout, device_type)
+
+  ! Create another empty tensor and assign it to the difference of the first two using the
+  ! overloaded subtraction operator
+  call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+  tensor3 = tensor1 - tensor2
+
+  ! Extract Fortran array from the assigned tensor
+  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
+
+  ! Compare the data in the tensor to the input data
+  expected(:,:) = in_data1 - in_data2
+  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_subtract")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data))
+
+  ! Cleanup
+  nullify(out_data)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+  call torch_tensor_delete(tensor3)
+
+end subroutine test_torch_tensor_subtract

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -224,3 +224,59 @@ subroutine test_torch_tensor_multiply()
   call torch_tensor_delete(tensor3)
 
 end subroutine test_torch_tensor_multiply
+
+@test
+subroutine test_torch_tensor_divide()
+  use FUnit
+  use ftorch, only: assignment(=), operator(/), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2, tensor3
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  real(wp), dimension(2,3), target :: in_data1, in_data2
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create two arbitrary input arrays
+  in_data1(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  in_data2(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
+
+  ! Create tensors based off the two input arrays
+  call torch_tensor_from_array(tensor1, in_data1, tensor_layout, device_type)
+  call torch_tensor_from_array(tensor2, in_data2, tensor_layout, device_type)
+
+  ! Create another empty tensor and assign it to the quotient of the first two using the overloaded
+  ! division operator
+  call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+  tensor3 = tensor1 / tensor2
+
+  ! Extract Fortran array from the assigned tensor
+  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
+
+  ! Compare the data in the tensor to the input data
+  expected(:,:) = in_data1 / in_data2
+  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_divide")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data))
+
+  ! Cleanup
+  nullify(out_data)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+  call torch_tensor_delete(tensor3)
+
+end subroutine test_torch_tensor_divide

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -246,9 +246,7 @@ subroutine test_torch_tensor_scalar_multiply()
   integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
   integer, parameter :: dtype = torch_kFloat32
   integer, parameter :: device_type = torch_kCPU
-  ! real(wp), parameter :: scalar = 3.14 ! FIXME: Segfault
-  ! real(wp), parameter :: scalar = 3 ! FIXME: Segfault
-  integer, parameter :: scalar = 3
+  real(wp), parameter :: scalar = 3.14
   real(wp), dimension(2,3), target :: in_data
   real(wp), dimension(:,:), pointer :: out_data2, out_data3
   real(wp), dimension(2,3) :: expected
@@ -366,9 +364,7 @@ subroutine test_torch_tensor_scalar_divide()
   integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
   integer, parameter :: dtype = torch_kFloat32
   integer, parameter :: device_type = torch_kCPU
-  ! real(wp), parameter :: scalar = 3.14 ! FIXME: Segfault
-  ! real(wp), parameter :: scalar = 3 ! FIXME: Gives zeros
-  integer, parameter :: scalar = 3
+  real(wp), parameter :: scalar = 3.14
   real(wp), dimension(2,3), target :: in_data
   real(wp), dimension(:,:), pointer :: out_data
   real(wp), dimension(2,3) :: expected

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -398,7 +398,7 @@ subroutine test_torch_tensor_scalar_divide()
 end subroutine test_torch_tensor_scalar_divide
 
 @test
-subroutine test_torch_tensor_power()
+subroutine test_torch_tensor_square()
   use FUnit
   use ftorch, only: assignment(=), operator(**), ftorch_int, torch_kCPU, torch_kFloat32, &
                     torch_tensor, torch_tensor_delete, torch_tensor_empty, &
@@ -412,15 +412,14 @@ subroutine test_torch_tensor_power()
   ! Set working precision for reals
   integer, parameter :: wp = sp
 
-  type(torch_tensor) :: tensor1, tensor2
+  type(torch_tensor) :: tensor1, tensor2, tensor3
   integer, parameter :: ndims = 2
   integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
   integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
   integer, parameter :: dtype = torch_kFloat32
   integer, parameter :: device_type = torch_kCPU
-  integer, parameter :: power = 2
   real(wp), dimension(2,3), target :: in_data
-  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(:,:), pointer :: out_data2, out_data3
   real(wp), dimension(2,3) :: expected
   logical :: test_pass
 
@@ -430,23 +429,31 @@ subroutine test_torch_tensor_power()
   ! Create a tensor based off the input array
   call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
 
-  ! Create another empty tensor and assign it to the first tensor to the power of an integer
-  ! exponent using the overloaded exponentiation operator
+  ! Create another two empty tensors and assign them to the first tensor to the power of an integer
+  ! exponent and float exponent, respectively, using the overloaded exponentiation operator
   call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
-  tensor2 = tensor1 ** power
+  call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+  tensor2 = tensor1 ** 2
+  tensor3 = tensor1 ** 2.0
 
-  ! Extract Fortran array from the assigned tensor
-  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+  ! Extract Fortran arrays from the assigned tensors
+  call torch_tensor_to_array(tensor2, out_data2, shape(in_data))
+  call torch_tensor_to_array(tensor3, out_data3, shape(in_data))
 
-  ! Compare the data in the tensor to the input data
-  expected(:,:) = in_data ** power
-  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_power")
+  ! Compare the data in the tensors to the input data
+  expected(:,:) = in_data ** 2
+  test_pass = assert_allclose(out_data2, expected, test_name="test_torch_tensor_square_int")
   @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data))
+  @assertEqual(shape(expected), shape(out_data2))
+  test_pass = assert_allclose(out_data3, expected, test_name="test_torch_tensor_square_float")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data3))
 
   ! Cleanup
-  nullify(out_data)
+  nullify(out_data2)
+  nullify(out_data3)
   call torch_tensor_delete(tensor1)
   call torch_tensor_delete(tensor2)
+  call torch_tensor_delete(tensor3)
 
-end subroutine test_torch_tensor_power
+end subroutine test_torch_tensor_square

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -396,3 +396,57 @@ subroutine test_torch_tensor_scalar_divide()
   call torch_tensor_delete(tensor2)
 
 end subroutine test_torch_tensor_scalar_divide
+
+@test
+subroutine test_torch_tensor_power()
+  use FUnit
+  use ftorch, only: assignment(=), operator(**), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  integer, parameter :: power = 2
+  real(wp), dimension(2,3), target :: in_data
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create an arbitrary input array
+  in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+  ! Create a tensor based off the input array
+  call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
+
+  ! Create another empty tensor and assign it to the first tensor to the power of an integer
+  ! exponent using the overloaded exponentiation operator
+  call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
+  tensor2 = tensor1 ** power
+
+  ! Extract Fortran array from the assigned tensor
+  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+
+  ! Compare the data in the tensor to the input data
+  expected(:,:) = in_data ** power
+  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_power")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data))
+
+  ! Cleanup
+  nullify(out_data)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+
+end subroutine test_torch_tensor_power

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -1,0 +1,60 @@
+!| Unit tests for FTorch's overloaded operators involving tensors.
+!
+!  * License  
+!    FTorch is released under an MIT license.
+!    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
+!    file for details.
+
+@test
+subroutine test_torch_tensor_assign()
+  use FUnit
+  use ftorch, only: assignment(=), ftorch_int, torch_kCPU, torch_kFloat32, torch_tensor, &
+                    torch_tensor_delete, torch_tensor_empty, torch_tensor_from_array, &
+                    torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  real(wp), dimension(2,3), target :: in_data
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create an arbitrary input array
+  in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+  ! Create a tensor based off an input array
+  call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
+
+  ! Create another empty tensor and assign it to the first using the overloaded assignment operator
+  call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
+  tensor2 = tensor1
+
+  ! Extract Fortran array from the assigned tensor
+  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+
+  ! Compare the data in the tensor to the input data
+  expected(:,:) = in_data
+  print *, expected
+  print *, out_data
+  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_assign")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data))
+
+  ! Cleanup
+  nullify(out_data)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+
+end subroutine test_torch_tensor_assign

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -344,3 +344,59 @@ subroutine test_torch_tensor_divide()
   call torch_tensor_delete(tensor3)
 
 end subroutine test_torch_tensor_divide
+
+@test
+subroutine test_torch_tensor_scalar_divide()
+  use FUnit
+  use ftorch, only: assignment(=), operator(/), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  ! real(wp), parameter :: scalar = 3.14 ! FIXME: Segfault
+  ! real(wp), parameter :: scalar = 3 ! FIXME: Gives zeros
+  integer, parameter :: scalar = 3
+  real(wp), dimension(2,3), target :: in_data
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create an arbitrary input array
+  in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+  ! Create a tensor based off the input array
+  call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
+
+  ! Create another empty tensor and assign it to the quotient of the first tensor and a scalar
+  ! constant using the overloaded division operator
+  call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
+  tensor2 = tensor1 / scalar
+
+  ! Extract Fortran array from the assigned tensor
+  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+
+  ! Compare the data in the tensor to the input data
+  expected(:,:) = in_data / scalar
+  test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_postdivide")
+  @assertTrue(test_pass)
+  @assertEqual(shape(expected), shape(out_data))
+
+  ! Cleanup
+  nullify(out_data)
+  call torch_tensor_delete(tensor1)
+  call torch_tensor_delete(tensor2)
+
+end subroutine test_torch_tensor_scalar_divide


### PR DESCRIPTION
Closes #221.
Closes #224.

This PR implements unit tests for the overloaded operators acting on tensors using funit.

While implementing these tests, I discovered that pre/post multiplication by scalar, post-division by scalar, and scalar exponent don't work if the scalar is non-integer. This was an oversight by me, which is fixed in this PR. It turns out you can multiply/divide any tensor by a [1] tensor and torch treats it as a scalar, so that's what I do here.

In the case of exponentiation, it doesn't seem to be valid to have a tensor exponent. I revised the implementation to use a `torch_scalar_t` type and restricted attention to the integer case for now.