### PR TITLE
Set upper CMake minimum version in CMakeLists across codebase.

### DIFF
--- a/examples/1_SimpleNet/CMakeLists.txt
+++ b/examples/1_SimpleNet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/2_ResNet18/CMakeLists.txt
+++ b/examples/2_ResNet18/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/5_Looping/CMakeLists.txt
+++ b/examples/5_Looping/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/6_Autograd/CMakeLists.txt
+++ b/examples/6_Autograd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/n_c_and_cpp/CMakeLists.txt
+++ b/examples/n_c_and_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 set(PROJECT_NAME FTorch)
 set(LIB_NAME ftorch)
 set(PACKAGE_VERSION 0.1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 set(PROJECT_NAME FTorch)
 set(LIB_NAME ftorch)
 set(PACKAGE_VERSION 0.1)

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
 cmake_policy (SET CMP0076 NEW)
 
 project("FTorch unit tests" VERSION 1.0.0 LANGUAGES Fortran)


### PR DESCRIPTION
This should close #226 by setting an upper bound on the minimum required version to the most recent version of CMake (`3.31`).

See issue #226 and https://cliutils.gitlab.io/modern-cmake/chapters/basics.html#minimum-version for more explanation on why this is advised.