### PR TITLE
Move input array checks out of autograd example

### DIFF
--- a/examples/6_Autograd/autograd.f90
+++ b/examples/6_Autograd/autograd.f90
@@ -67,39 +67,13 @@ program example
     stop 999
   end if
 
-  ! Check first input array is unchanged by the arithmetic operations
-  expected(:,1) = [2.0_wp, 3.0_wp]
-  test_pass = assert_allclose(in_data1, expected, test_name="torch_tensor_to_array", rtol=1e-5)
-  if (.not. test_pass) then
-    call clean_up()
-    print *, "Error :: in_data1 was changed during arithmetic operations"
-    stop 999
-  end if
-
-  ! Check second input array is unchanged by the arithmetic operations
-  expected(:,1) = [6.0_wp, 4.0_wp]
-  test_pass = assert_allclose(in_data2, expected, test_name="torch_tensor_to_array", rtol=1e-5)
-  if (.not. test_pass) then
-    call clean_up()
-    print *, "Error :: in_data2 was changed during arithmetic operations"
-    stop 999
-  end if
-
   ! Back-propagation
   ! TODO: Requires API extension
 
-  ! Cleanup
-  call clean_up()
+  nullify(out_data)
+  call torch_tensor_delete(a)
+  call torch_tensor_delete(b)
+  call torch_tensor_delete(Q)
   write (*,*) "Autograd example ran successfully"
-
-  contains
-
-    ! Subroutine for freeing memory and nullifying pointers used in the example
-    subroutine clean_up()
-      nullify(out_data)
-      call torch_tensor_delete(a)
-      call torch_tensor_delete(b)
-      call torch_tensor_delete(Q)
-    end subroutine clean_up
 
 end program example

--- a/examples/6_Autograd/autograd.f90
+++ b/examples/6_Autograd/autograd.f90
@@ -70,10 +70,17 @@ program example
   ! Back-propagation
   ! TODO: Requires API extension
 
-  nullify(out_data)
-  call torch_tensor_delete(a)
-  call torch_tensor_delete(b)
-  call torch_tensor_delete(Q)
+  call clean_up()
   write (*,*) "Autograd example ran successfully"
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the example
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(a)
+      call torch_tensor_delete(b)
+      call torch_tensor_delete(Q)
+    end subroutine clean_up
 
 end program example

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,11 @@ This directory contains a number of examples of how to use the library:
       This example demonstrates how to structure code in these cases, separating reading
       in of a net from the call to the forward pass.
 
+6. Autograd
+    - **This example is currently under development.** Eventually, it will
+      demonstrate automatic differentation in FTorch by leveraging PyTorch's
+      Autograd module.
+
 To run select examples as integration tests, use the CMake argument
 ```
 -DCMAKE_BUILD_TESTS=TRUE

--- a/src/test/unit/test_constructors.pf
+++ b/src/test/unit/test_constructors.pf
@@ -81,12 +81,21 @@ subroutine test_torch_tensor_zeros()
   ! Check that the tensor values are all zero
   expected(:,:) = 0.0
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_zeros")
-  @assertTrue(test_pass)
-  @assertEqual(shape(out_data), shape(expected))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from torch_tensor_zeros subroutine"
+    stop 999
+  end if
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_zeros
 
@@ -132,12 +141,21 @@ subroutine test_torch_tensor_ones()
   ! Check that the tensor values are all one
   expected(:,:) = 1.0
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_ones")
-  @assertTrue(test_pass)
-  @assertEqual(shape(out_data), shape(expected))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from torch_tensor_ones subroutine"
+    stop 999
+  end if
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_ones
 
@@ -184,12 +202,21 @@ subroutine test_torch_from_array_1d()
   ! Compare the data in the tensor to the input data
   expected(:) = in_data
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_from_array")
-  @assertTrue(test_pass)
-  @assertEqual(shape(out_data), shape(expected))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
+    stop 999
+  end if
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor)
+    end subroutine clean_up
 
 end subroutine test_torch_from_array_1d
 
@@ -236,12 +263,21 @@ subroutine test_torch_from_array_2d()
   ! Compare the data in the tensor to the input data
   expected(:,:) = in_data
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_from_array")
-  @assertTrue(test_pass)
-  @assertEqual(shape(out_data), shape(expected))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
+    stop 999
+  end if
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor)
+    end subroutine clean_up
 
 end subroutine test_torch_from_array_2d
 
@@ -286,12 +322,21 @@ subroutine test_torch_from_array_3d()
   ! Compare the data in the tensor to the input data
   expected(:,:,:) = in_data
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_from_array")
-  @assertTrue(test_pass)
-  @assertEqual(shape(out_data), shape(expected))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
+    stop 999
+  end if
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor)
+    end subroutine clean_up
 
 end subroutine test_torch_from_array_3d
 
@@ -340,11 +385,20 @@ subroutine test_torch_from_blob()
   ! Compare the data in the tensor to the input data 
   expected(:,:) = in_data
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_from_blob")
-  @assertTrue(test_pass)
-  @assertEqual(shape(out_data), shape(expected))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
+    stop 999
+  end if
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor)
+    end subroutine clean_up
 
 end subroutine test_torch_from_blob

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -54,8 +54,11 @@ subroutine test_torch_tensor_assign()
   ! array
   call torch_tensor_to_array(tensor2, out_data, shape(in_data))
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_assign")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded assignment operator"
+    stop 999
+  end if
 
   call clean_up()
 
@@ -130,8 +133,11 @@ subroutine test_torch_tensor_add()
   call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
   expected(:,:) = in_data1 + in_data2
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_add")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded addition operator"
+    stop 999
+  end if
 
   call clean_up()
 
@@ -207,8 +213,11 @@ subroutine test_torch_tensor_subtract()
   call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
   expected(:,:) = in_data1 - in_data2
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_subtract")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded subtraction operator"
+    stop 999
+  end if
 
   call clean_up()
 
@@ -284,8 +293,11 @@ subroutine test_torch_tensor_multiply()
   call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
   expected(:,:) = in_data1 * in_data2
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_multiply")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded multiplication operator"
+    stop 999
+  end if
 
   call clean_up()
 
@@ -368,11 +380,17 @@ subroutine test_torch_tensor_scalar_multiply()
   call torch_tensor_to_array(tensor3, out_data3, shape(in_data))
   expected(:,:) = scalar * in_data
   test_pass = assert_allclose(out_data2, expected, test_name="test_torch_tensor_premultiply")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data2))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded post-multiplication operator"
+    stop 999
+  end if
   test_pass = assert_allclose(out_data3, expected, test_name="test_torch_tensor_postmultiply")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data3))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded pre-multiplication operator"
+    stop 999
+  end if
 
   call clean_up()
 
@@ -449,8 +467,11 @@ subroutine test_torch_tensor_divide()
   call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
   expected(:,:) = in_data1 / in_data2
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_divide")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded division operator"
+    stop 999
+  end if
 
   call clean_up()
 
@@ -519,8 +540,11 @@ subroutine test_torch_tensor_scalar_divide()
   call torch_tensor_to_array(tensor2, out_data, shape(in_data))
   expected(:,:) = in_data / scalar
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_postdivide")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded scalar division operator"
+    stop 999
+  end if
 
   call clean_up()
 
@@ -601,11 +625,17 @@ subroutine test_torch_tensor_square()
   call torch_tensor_to_array(tensor3, out_data3, shape(in_data))
   expected(:,:) = in_data ** 2
   test_pass = assert_allclose(out_data2, expected, test_name="test_torch_tensor_square_int")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data2))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded integer exponentation operator"
+    stop 999
+  end if
   test_pass = assert_allclose(out_data3, expected, test_name="test_torch_tensor_square_float")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data3))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded floating point exponentation operator"
+    stop 999
+  end if
 
   call clean_up()
 
@@ -673,8 +703,11 @@ subroutine test_torch_tensor_sqrt()
   call torch_tensor_to_array(tensor2, out_data, shape(in_data))
   expected(:,:) = in_data ** 0.5
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_sqrt")
-  @assertTrue(test_pass)
-  @assertEqual(shape(expected), shape(out_data))
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded square root operator"
+    stop 999
+  end if
 
   call clean_up()
 

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -41,19 +41,32 @@ subroutine test_torch_tensor_assign()
   call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
   tensor2 = tensor1
 
-  ! Extract Fortran array from the assigned tensor
-  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+  ! Check input array is unchanged by the assignment
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_assign", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: input array was changed during assignment"
+    stop 999
+  end if
 
-  ! Compare the data in the tensor to the input data
-  expected(:,:) = in_data
+  ! Extract Fortran array from the assigned tensor and compare the data in the tensor to the input
+  ! array
+  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_assign")
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data))
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_assign
 
@@ -96,20 +109,41 @@ subroutine test_torch_tensor_add()
   call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
   tensor3 = tensor1 + tensor2
 
-  ! Extract Fortran array from the assigned tensor
-  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
+  ! Check input arrays are unchanged by the addition
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data1, expected, test_name="test_torch_tensor_add", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: first input array was changed during addition"
+    stop 999
+  end if
+  expected(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
+  test_pass = assert_allclose(in_data2, expected, test_name="test_torch_tensor_add", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: second input array was changed during addition"
+    stop 999
+  end if
 
-  ! Compare the data in the tensor to the input data
+  ! Extract Fortran array from the assigned tensor and compare the data in the tensor to the sum of
+  ! the input arrays
+  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
   expected(:,:) = in_data1 + in_data2
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_add")
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data))
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
-  call torch_tensor_delete(tensor3)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+      call torch_tensor_delete(tensor3)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_add
 
@@ -152,20 +186,41 @@ subroutine test_torch_tensor_subtract()
   call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
   tensor3 = tensor1 - tensor2
 
-  ! Extract Fortran array from the assigned tensor
-  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
+  ! Check input arrays are unchanged by the subtraction
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data1, expected, test_name="test_torch_tensor_subtract", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: first input array was changed during subtraction"
+    stop 999
+  end if
+  expected(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
+  test_pass = assert_allclose(in_data2, expected, test_name="test_torch_tensor_subtract", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: second input array was changed during subtraction"
+    stop 999
+  end if
 
-  ! Compare the data in the tensor to the input data
+  ! Extract Fortran array from the assigned tensor and compare the data in the tensor to the
+  ! difference of the input arrays
+  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
   expected(:,:) = in_data1 - in_data2
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_subtract")
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data))
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
-  call torch_tensor_delete(tensor3)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+      call torch_tensor_delete(tensor3)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_subtract
 
@@ -208,20 +263,41 @@ subroutine test_torch_tensor_multiply()
   call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
   tensor3 = tensor1 * tensor2
 
-  ! Extract Fortran array from the assigned tensor
-  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
+  ! Check input arrays are unchanged by the multiplication
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data1, expected, test_name="test_torch_tensor_multiply", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: first input array was changed during multiplication"
+    stop 999
+  end if
+  expected(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
+  test_pass = assert_allclose(in_data2, expected, test_name="test_torch_tensor_multiply", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: second input array was changed during multiplication"
+    stop 999
+  end if
 
-  ! Compare the data in the tensor to the input data
+  ! Extract Fortran array from the assigned tensor and compare the data in the tensor to the
+  ! product of the input arrays
+  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
   expected(:,:) = in_data1 * in_data2
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_multiply")
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data))
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
-  call torch_tensor_delete(tensor3)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+      call torch_tensor_delete(tensor3)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_multiply
 
@@ -263,13 +339,33 @@ subroutine test_torch_tensor_scalar_multiply()
   call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
   call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
   tensor2 = scalar * tensor1
+
+  ! Check input array is unchanged by pre-multiplication
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_premultiply", &
+                              rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: input array was changed during scalar pre-multiplication"
+    stop 999
+  end if
+
   tensor3 = tensor1 * scalar
 
-  ! Extract Fortran arrays from the assigned tensors
+  ! Check input array is unchanged by post-multiplication
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_postmultiply", &
+                              rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: input array was changed during scalar post-multiplication"
+    stop 999
+  end if
+
+  ! Extract Fortran arrays from the assigned tensors and compare the data in the tensors to the
+  ! scaled input arrays
   call torch_tensor_to_array(tensor2, out_data2, shape(in_data))
   call torch_tensor_to_array(tensor3, out_data3, shape(in_data))
-
-  ! Compare the data in the tensors to the input data
   expected(:,:) = scalar * in_data
   test_pass = assert_allclose(out_data2, expected, test_name="test_torch_tensor_premultiply")
   @assertTrue(test_pass)
@@ -278,12 +374,18 @@ subroutine test_torch_tensor_scalar_multiply()
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data3))
 
-  ! Cleanup
-  nullify(out_data2)
-  nullify(out_data3)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
-  call torch_tensor_delete(tensor3)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data2)
+      nullify(out_data3)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+      call torch_tensor_delete(tensor3)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_scalar_multiply
 
@@ -326,20 +428,41 @@ subroutine test_torch_tensor_divide()
   call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
   tensor3 = tensor1 / tensor2
 
-  ! Extract Fortran array from the assigned tensor
-  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
+  ! Check input arrays are unchanged by the division
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data1, expected, test_name="test_torch_tensor_divide", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: first input array was changed during division"
+    stop 999
+  end if
+  expected(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
+  test_pass = assert_allclose(in_data2, expected, test_name="test_torch_tensor_divide", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: second input array was changed during division"
+    stop 999
+  end if
 
-  ! Compare the data in the tensor to the input data
+  ! Extract Fortran array from the assigned tensor and compare the data in the tensor to the
+  ! quotient of the input arrays
+  call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
   expected(:,:) = in_data1 / in_data2
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_divide")
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data))
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
-  call torch_tensor_delete(tensor3)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+      call torch_tensor_delete(tensor3)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_divide
 
@@ -381,19 +504,34 @@ subroutine test_torch_tensor_scalar_divide()
   call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
   tensor2 = tensor1 / scalar
 
-  ! Extract Fortran array from the assigned tensor
-  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+  ! Check input array is unchanged by post-division
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_postdivide", &
+                              rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: input array was changed during scalar division"
+    stop 999
+  end if
 
-  ! Compare the data in the tensor to the input data
+  ! Extract Fortran array from the assigned tensor and compare the data in the tensor to the
+  ! scaled input array
+  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
   expected(:,:) = in_data / scalar
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_postdivide")
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data))
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_scalar_divide
 
@@ -434,13 +572,33 @@ subroutine test_torch_tensor_square()
   call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
   call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
   tensor2 = tensor1 ** 2
+
+  ! Check input array is unchanged by pre-multiplication
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_square_int", &
+                              rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: input array was changed during integer exponentation"
+    stop 999
+  end if
+
   tensor3 = tensor1 ** 2.0
 
-  ! Extract Fortran arrays from the assigned tensors
+  ! Check input array is unchanged by pre-multiplication
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_square_float", &
+                              rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: input array was changed during floating point exponentation"
+    stop 999
+  end if
+
+  ! Extract Fortran arrays from the assigned tensors and compare the data in the tensors to the
+  ! squared input array
   call torch_tensor_to_array(tensor2, out_data2, shape(in_data))
   call torch_tensor_to_array(tensor3, out_data3, shape(in_data))
-
-  ! Compare the data in the tensors to the input data
   expected(:,:) = in_data ** 2
   test_pass = assert_allclose(out_data2, expected, test_name="test_torch_tensor_square_int")
   @assertTrue(test_pass)
@@ -449,12 +607,18 @@ subroutine test_torch_tensor_square()
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data3))
 
-  ! Cleanup
-  nullify(out_data2)
-  nullify(out_data3)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
-  call torch_tensor_delete(tensor3)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data2)
+      nullify(out_data3)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+      call torch_tensor_delete(tensor3)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_square
 
@@ -490,23 +654,37 @@ subroutine test_torch_tensor_sqrt()
   ! Create a tensor based off the input array
   call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
 
-  ! Create another empty tensors and assign it to the first tensor to the power of 0.5 using the
+  ! Create another empty tensors and assign it to the tensor to the power of 0.5 using the
   ! overloaded exponentiation operator
   call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
   tensor2 = tensor1 ** 0.5
 
-  ! Extract Fortran arrays from the assigned tensors
-  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+  ! Check input array is unchanged by taking the square root
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_sqrt", rtol=1e-5)
+  if (.not. test_pass) then
+    call clean_up()
+    print *, "Error :: input array was changed during taking the square root"
+    stop 999
+  end if
 
-  ! Compare the data in the tensors to the input data
+  ! Extract Fortran arrays from the assigned tensors and compare the data in the tensors to the
+  ! square root of the input array
+  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
   expected(:,:) = in_data ** 0.5
   test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_sqrt")
   @assertTrue(test_pass)
   @assertEqual(shape(expected), shape(out_data))
 
-  ! Cleanup
-  nullify(out_data)
-  call torch_tensor_delete(tensor1)
-  call torch_tensor_delete(tensor2)
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+    end subroutine clean_up
 
 end subroutine test_torch_tensor_sqrt


### PR DESCRIPTION
Towards #211.
Follows #225.

This PR cuts down the amount of testing done in the autograd example. In particular, it moves the checks that input arrays aren't modified into the unit tests.

The PR also adds a missing summary for the autograd example in `examples/README.md`.