### PR TITLE
Minor build tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ FTorch's test suite has some additional dependencies.
   [pFUnit](https://github.com/Goddard-Fortran-Ecosystem/pFUnit).
 * FTorch's test suite requires that [PyTorch](https://pytorch.org/) has been
   installed, as opposed to LibTorch. We recommend installing `torchvision` in
-  the same command (e.g., `pip install torch torchvision`)<sup>*</sup>.
+  the same command (e.g., `pip install torch torchvision`)<sup>*</sup>. Doing so
+  ensures that `torch` and `torchvision` are configured in the same way.
 * Other Python modules are installed automatically by the `run_test_suite.sh`
   test script (or `run_test_suite.bat` on Windows).
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ To install the library requires the following to be installed on the system:
 
 <sup>*</sup> _The minimal example provided downloads the CPU-only Linux Nightly binary. [Alternative versions](https://pytorch.org/get-started/locally/) may be required._
 
+#### Additional dependencies of the test suite
+
+FTorch's test suite has some additional dependencies.
+
+* You will also need to install the unit testing framework
+  [pFUnit](https://github.com/Goddard-Fortran-Ecosystem/pFUnit).
+* FTorch's test suite requires that [PyTorch](https://pytorch.org/) has been
+  installed, as opposed to LibTorch. We recommend installing `torchvision` in
+  the same command (e.g., `pip install torch torchvision`)<sup>*</sup>.
+* Other Python modules are installed automatically by the `run_test_suite.sh`
+  test script (or `run_test_suite.bat` on Windows).
+
+
+<sup>*</sup> _For more details, see [here](https://pytorch.org/get-started/locally/)._
+
 #### Windows Support
 
 If building in a Windows environment then you can either use

--- a/examples/1_SimpleNet/CMakeLists.txt
+++ b/examples/1_SimpleNet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/2_ResNet18/CMakeLists.txt
+++ b/examples/2_ResNet18/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/5_Looping/CMakeLists.txt
+++ b/examples/5_Looping/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/examples/6_Autograd/CMakeLists.txt
+++ b/examples/6_Autograd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31)
 # policy CMP0076 - target_sources source files are relative to file where
 # target_sources is run
 cmake_policy(SET CMP0076 NEW)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31)
 set(PROJECT_NAME FTorch)
 set(LIB_NAME ftorch)
 set(PACKAGE_VERSION 0.1)

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.31)
 cmake_policy (SET CMP0076 NEW)
 
 project("FTorch unit tests" VERSION 1.0.0 LANGUAGES Fortran)


### PR DESCRIPTION
This PR:

* Gives some information on additional build dependencies in the README. In particular that `torchvision` should be installed at the same time as `torch`.
* Drop `FATAL_ERROR` from CMake versioning, which is ignored.