### PR TITLE
Implement `torch_tensor_minus` for taking negative of a tensor

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -268,6 +268,14 @@ torch_tensor_t torch_tensor_add(const torch_tensor_t tensor1,
   return output;
 }
 
+torch_tensor_t torch_tensor_minus(const torch_tensor_t tensor) {
+  auto t = reinterpret_cast<torch::Tensor *const>(tensor);
+  torch::Tensor *output = nullptr;
+  output = new torch::Tensor;
+  *output = -*t;
+  return output;
+}
+
 torch_tensor_t torch_tensor_subtract(const torch_tensor_t tensor1,
                                      const torch_tensor_t tensor2) {
   auto t1 = reinterpret_cast<torch::Tensor *const>(tensor1);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -268,7 +268,7 @@ torch_tensor_t torch_tensor_add(const torch_tensor_t tensor1,
   return output;
 }
 
-torch_tensor_t torch_tensor_minus(const torch_tensor_t tensor) {
+torch_tensor_t torch_tensor_negative(const torch_tensor_t tensor) {
   auto t = reinterpret_cast<torch::Tensor *const>(tensor);
   torch::Tensor *output = nullptr;
   output = new torch::Tensor;

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -176,11 +176,11 @@ EXPORT_C torch_tensor_t torch_tensor_add(const torch_tensor_t tensor1,
                                          const torch_tensor_t tensor2);
 
 /**
- * Overloads the minus operator for a Torch Tensor
+ * Overloads the minus operator for a single Torch Tensor
  * @param Tensor to take the negative of
  * @return the negative Tensor
  */
-EXPORT_C torch_tensor_t torch_tensor_minus(const torch_tensor_t tensor);
+EXPORT_C torch_tensor_t torch_tensor_negative(const torch_tensor_t tensor);
 
 /**
  * Overloads the subtraction operator for two Torch Tensors

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -176,6 +176,13 @@ EXPORT_C torch_tensor_t torch_tensor_add(const torch_tensor_t tensor1,
                                          const torch_tensor_t tensor2);
 
 /**
+ * Overloads the minus operator for a Torch Tensor
+ * @param Tensor to take the negative of
+ * @return the negative Tensor
+ */
+EXPORT_C torch_tensor_t torch_tensor_minus(const torch_tensor_t tensor);
+
+/**
  * Overloads the subtraction operator for two Torch Tensors
  * @param first Tensor to be subtracted
  * @param second Tensor to be subtracted

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -181,6 +181,7 @@ module ftorch
   end interface
 
   interface operator (-)
+    module procedure torch_tensor_minus
     module procedure torch_tensor_subtract
   end interface
 
@@ -2408,6 +2409,24 @@ contains
 
     output%p = torch_tensor_add_c(tensor1%p, tensor2%p)
   end function torch_tensor_add
+
+  !> Overloads minus operator for a tensor.
+  function torch_tensor_minus(tensor) result(output)
+    type(torch_tensor), intent(in) :: tensor
+    type(torch_tensor) :: output
+
+    interface
+      function torch_tensor_minus_c(tensor_c) result(output_c)  &
+          bind(c, name = 'torch_tensor_minus')
+        use, intrinsic :: iso_c_binding, only : c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor_c
+        type(c_ptr) :: output_c
+      end function torch_tensor_minus_c
+    end interface
+
+    output%p = torch_tensor_minus_c(tensor%p)
+  end function torch_tensor_minus
 
   !> Overloads subtraction operator for two tensors.
   function torch_tensor_subtract(tensor1, tensor2) result(output)

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -181,7 +181,7 @@ module ftorch
   end interface
 
   interface operator (-)
-    module procedure torch_tensor_minus
+    module procedure torch_tensor_negative
     module procedure torch_tensor_subtract
   end interface
 
@@ -2410,23 +2410,23 @@ contains
     output%p = torch_tensor_add_c(tensor1%p, tensor2%p)
   end function torch_tensor_add
 
-  !> Overloads minus operator for a tensor.
-  function torch_tensor_minus(tensor) result(output)
+  !> Overloads negative operator for a tensor.
+  function torch_tensor_negative(tensor) result(output)
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_minus_c(tensor_c) result(output_c)  &
-          bind(c, name = 'torch_tensor_minus')
+      function torch_tensor_negative_c(tensor_c) result(output_c)  &
+          bind(c, name = 'torch_tensor_negative')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
-      end function torch_tensor_minus_c
+      end function torch_tensor_negative_c
     end interface
 
-    output%p = torch_tensor_minus_c(tensor%p)
-  end function torch_tensor_minus
+    output%p = torch_tensor_negative_c(tensor%p)
+  end function torch_tensor_negative
 
   !> Overloads subtraction operator for two tensors.
   function torch_tensor_subtract(tensor1, tensor2) result(output)

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2410,7 +2410,7 @@ contains
     output%p = torch_tensor_add_c(tensor1%p, tensor2%p)
   end function torch_tensor_add
 
-  !> Overloads negative operator for a tensor.
+  !> Overloads negative operator for a single tensor.
   function torch_tensor_negative(tensor) result(output)
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -633,7 +633,7 @@ contains
     output%p = torch_tensor_add_c(tensor1%p, tensor2%p)
   end function torch_tensor_add
 
-  !> Overloads negative operator for a tensor.
+  !> Overloads negative operator for a single tensor.
   function torch_tensor_negative(tensor) result(output)
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -150,6 +150,7 @@ module ftorch
   end interface
 
   interface operator (-)
+    module procedure torch_tensor_minus
     module procedure torch_tensor_subtract
   end interface
 
@@ -631,6 +632,24 @@ contains
 
     output%p = torch_tensor_add_c(tensor1%p, tensor2%p)
   end function torch_tensor_add
+
+  !> Overloads minus operator for a tensor.
+  function torch_tensor_minus(tensor) result(output)
+    type(torch_tensor), intent(in) :: tensor
+    type(torch_tensor) :: output
+
+    interface
+      function torch_tensor_minus_c(tensor_c) result(output_c)  &
+          bind(c, name = 'torch_tensor_minus')
+        use, intrinsic :: iso_c_binding, only : c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor_c
+        type(c_ptr) :: output_c
+      end function torch_tensor_minus_c
+    end interface
+
+    output%p = torch_tensor_minus_c(tensor%p)
+  end function torch_tensor_minus
 
   !> Overloads subtraction operator for two tensors.
   function torch_tensor_subtract(tensor1, tensor2) result(output)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -150,7 +150,7 @@ module ftorch
   end interface
 
   interface operator (-)
-    module procedure torch_tensor_minus
+    module procedure torch_tensor_negative
     module procedure torch_tensor_subtract
   end interface
 
@@ -633,23 +633,23 @@ contains
     output%p = torch_tensor_add_c(tensor1%p, tensor2%p)
   end function torch_tensor_add
 
-  !> Overloads minus operator for a tensor.
-  function torch_tensor_minus(tensor) result(output)
+  !> Overloads negative operator for a tensor.
+  function torch_tensor_negative(tensor) result(output)
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: output
 
     interface
-      function torch_tensor_minus_c(tensor_c) result(output_c)  &
-          bind(c, name = 'torch_tensor_minus')
+      function torch_tensor_negative_c(tensor_c) result(output_c)  &
+          bind(c, name = 'torch_tensor_negative')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr) :: output_c
-      end function torch_tensor_minus_c
+      end function torch_tensor_negative_c
     end interface
 
-    output%p = torch_tensor_minus_c(tensor%p)
-  end function torch_tensor_minus
+    output%p = torch_tensor_negative_c(tensor%p)
+  end function torch_tensor_negative
 
   !> Overloads subtraction operator for two tensors.
   function torch_tensor_subtract(tensor1, tensor2) result(output)

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -154,7 +154,7 @@ subroutine test_torch_tensor_add()
 end subroutine test_torch_tensor_add
 
 @test
-subroutine test_torch_tensor_minus()
+subroutine test_torch_tensor_negative()
   use FUnit
   use ftorch, only: assignment(=), operator(-), ftorch_int, torch_kCPU, torch_kFloat32, &
                     torch_tensor, torch_tensor_delete, torch_tensor_empty, &
@@ -186,13 +186,13 @@ subroutine test_torch_tensor_minus()
   call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
 
   ! Create another empty tensor and assign it to the negative of the first using the overloaded
-  ! minus operator
+  ! negative operator
   call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
   tensor2 = -tensor1
 
   ! Check input arrays are unchanged by the subtraction
   expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
-  if (.not. assert_allclose(in_data, expected, test_name="test_torch_tensor_minus")) then
+  if (.not. assert_allclose(in_data, expected, test_name="test_torch_tensor_negative")) then
     call clean_up()
     print *, "Error :: first input array was changed during subtraction"
     stop 999
@@ -219,7 +219,7 @@ subroutine test_torch_tensor_minus()
       call torch_tensor_delete(tensor2)
     end subroutine clean_up
 
-end subroutine test_torch_tensor_minus
+end subroutine test_torch_tensor_negative
 
 @test
 subroutine test_torch_tensor_subtract()

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -154,6 +154,74 @@ subroutine test_torch_tensor_add()
 end subroutine test_torch_tensor_add
 
 @test
+subroutine test_torch_tensor_minus()
+  use FUnit
+  use ftorch, only: assignment(=), operator(-), ftorch_int, torch_kCPU, torch_kFloat32, &
+                    torch_tensor, torch_tensor_delete, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_to_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  type(torch_tensor) :: tensor1, tensor2
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+  integer, parameter :: device_type = torch_kCPU
+  real(wp), dimension(2,3), target :: in_data
+  real(wp), dimension(:,:), pointer :: out_data
+  real(wp), dimension(2,3) :: expected
+  logical :: test_pass
+
+  ! Create two arbitrary input arrays
+  in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+  ! Create tensors based off the input array
+  call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type)
+
+  ! Create another empty tensor and assign it to the negative of the first using the overloaded
+  ! minus operator
+  call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
+  tensor2 = -tensor1
+
+  ! Check input arrays are unchanged by the subtraction
+  expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+  if (.not. assert_allclose(in_data, expected, test_name="test_torch_tensor_minus")) then
+    call clean_up()
+    print *, "Error :: first input array was changed during subtraction"
+    stop 999
+  end if
+
+  ! Extract Fortran array from the assigned tensor and compare the data in the tensor to the
+  ! negative of the input array
+  call torch_tensor_to_array(tensor2, out_data, shape(in_data))
+  expected(:,:) = -in_data
+  if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_subtract")) then
+    call clean_up()
+    print *, "Error :: incorrect output from overloaded subtraction operator"
+    stop 999
+  end if
+
+  call clean_up()
+
+  contains
+
+    ! Subroutine for freeing memory and nullifying pointers used in the unit test
+    subroutine clean_up()
+      nullify(out_data)
+      call torch_tensor_delete(tensor1)
+      call torch_tensor_delete(tensor2)
+    end subroutine clean_up
+
+end subroutine test_torch_tensor_minus
+
+@test
 subroutine test_torch_tensor_subtract()
   use FUnit
   use ftorch, only: assignment(=), operator(-), ftorch_int, torch_kCPU, torch_kFloat32, &

--- a/src/test/unit/test_tensor_operator_overloads.pf
+++ b/src/test/unit/test_tensor_operator_overloads.pf
@@ -190,7 +190,7 @@ subroutine test_torch_tensor_negative()
   call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
   tensor2 = -tensor1
 
-  ! Check input arrays are unchanged by the subtraction
+  ! Check input arrays are unchanged by the negation
   expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
   if (.not. assert_allclose(in_data, expected, test_name="test_torch_tensor_negative")) then
     call clean_up()
@@ -202,7 +202,7 @@ subroutine test_torch_tensor_negative()
   ! negative of the input array
   call torch_tensor_to_array(tensor2, out_data, shape(in_data))
   expected(:,:) = -in_data
-  if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_subtract")) then
+  if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_negative")) then
     call clean_up()
     print *, "Error :: incorrect output from overloaded subtraction operator"
     stop 999


### PR DESCRIPTION
Closes #246.

Implements and overload for the unary `-` operator: `torch_tensor_minus`, plus unit test.