### PR TITLE
Add `get_dtype` and `get_device_type` methods for `torch_tensor`

### DIFF
--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -139,6 +139,13 @@ EXPORT_C const long long int *torch_tensor_get_sizes(const torch_tensor_t tensor
 #endif
 
 /**
+ * Function to determine the data type of a Torch Tensor
+ * @param Torch Tensor to determine the data type of
+ * @return data type of the Torch Tensor represented as an enum
+ */
+EXPORT_C torch_data_t torch_tensor_get_dtype(const torch_tensor_t tensor);
+
+/**
  * Function to determine the device type of a Torch Tensor
  * @param Torch Tensor to determine the device type of
  * @return device type of the Torch Tensor represented as an enum

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -121,13 +121,6 @@ EXPORT_C void *torch_to_blob(const torch_tensor_t tensor, const torch_data_t dty
 EXPORT_C void torch_tensor_print(const torch_tensor_t tensor);
 
 /**
- * Function to determine the device index of a Torch Tensor
- * @param Torch Tensor to determine the device index of
- * @return device index of the Torch Tensor
- */
-EXPORT_C int torch_tensor_get_device_index(const torch_tensor_t tensor);
-
-/**
  * Function to determine the rank of a Torch Tensor
  * @param Torch Tensor to determine the rank of
  * @return rank of the Torch Tensor
@@ -144,6 +137,20 @@ EXPORT_C const long int *torch_tensor_get_sizes(const torch_tensor_t tensor);
 #else
 EXPORT_C const long long int *torch_tensor_get_sizes(const torch_tensor_t tensor);
 #endif
+
+/**
+ * Function to determine the device type of a Torch Tensor
+ * @param Torch Tensor to determine the device type of
+ * @return device type of the Torch Tensor represented as an enum
+ */
+EXPORT_C torch_device_t torch_tensor_get_device_type(const torch_tensor_t tensor);
+
+/**
+ * Function to determine the device index of a Torch Tensor
+ * @param Torch Tensor to determine the device index of
+ * @return device index of the Torch Tensor
+ */
+EXPORT_C int torch_tensor_get_device_index(const torch_tensor_t tensor);
 
 // =============================================================================
 // --- Functions for deallocating tensors

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2341,10 +2341,21 @@ contains
 
   !> Returns the device type of a tensor.
   function torch_tensor_get_device_type(tensor) result(device_type)
+    use, intrinsic :: iso_c_binding, only : c_int
     class(torch_tensor), intent(in) :: tensor  !! Input tensor
-    integer :: device_type                     !! Device type of tensor
+    integer(c_int) :: device_type              !! Device type of tensor
 
-    device_type = tensor%device_type
+    interface
+      function torch_tensor_get_device_type_c(tensor) result(device_type) &
+          bind(c, name = 'torch_tensor_get_device_type')
+        use, intrinsic :: iso_c_binding, only : c_int, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+        integer(c_int) :: device_type
+      end function torch_tensor_get_device_type_c
+    end interface
+
+    device_type = torch_tensor_get_device_type_c(tensor%p)
   end function torch_tensor_get_device_type
 
   !> Determines the device index of a tensor.

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2333,10 +2333,21 @@ contains
 
   !> Returns the data type of a tensor.
   function torch_tensor_get_dtype(tensor) result(dtype)
+    use, intrinsic :: iso_c_binding, only : c_int
     class(torch_tensor), intent(in) :: tensor  !! Input tensor
-    integer :: dtype                           !! Data type of tensor
+    integer(c_int) :: dtype                !! Data type of tensor
 
-    dtype = tensor%dtype
+    interface
+      function torch_tensor_get_dtype_c(tensor) result(dtype) &
+          bind(c, name = 'torch_tensor_get_dtype')
+        use, intrinsic :: iso_c_binding, only : c_int, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+        integer(c_int) :: dtype
+      end function torch_tensor_get_dtype_c
+    end interface
+
+    dtype = torch_tensor_get_dtype_c(tensor%p)
   end function torch_tensor_get_dtype
 
   !> Returns the device type of a tensor.

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -27,7 +27,7 @@ module ftorch
 
   !> Type for holding a Torch tensor.
   type torch_tensor
-    type(c_ptr) :: p = c_null_ptr    !! pointer to the tensor in memory
+    type(c_ptr) :: p = c_null_ptr  !! pointer to the tensor in memory
   contains
     procedure :: get_rank => torch_tensor_get_rank
     procedure :: get_shape => torch_tensor_get_shape
@@ -2505,13 +2505,10 @@ contains
     integer(int8), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int8
 
@@ -2522,13 +2519,10 @@ contains
     integer(int16), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int16
 
@@ -2539,13 +2533,10 @@ contains
     integer(int32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int32
 
@@ -2556,13 +2547,10 @@ contains
     integer(int64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int64
 
@@ -2573,13 +2561,10 @@ contains
     real(real32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real32
 
@@ -2590,13 +2575,10 @@ contains
     real(real64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real64
 
@@ -2608,13 +2590,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int8), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int8
 
@@ -2625,13 +2604,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int16), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int16
 
@@ -2642,13 +2618,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int32), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int32
 
@@ -2659,13 +2632,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int64), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int64
 
@@ -2676,13 +2646,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     real(real32), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real32
 
@@ -2693,13 +2660,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     real(real64), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real64
 
@@ -2719,13 +2683,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int8), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [divisor], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int8
 
@@ -2736,13 +2697,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int16), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [divisor], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int16
 
@@ -2753,13 +2711,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int32), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [divisor], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int32
 
@@ -2770,13 +2725,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int64), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [divisor], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int64
 
@@ -2787,13 +2739,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     real(real32), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [divisor], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real32
 
@@ -2804,13 +2753,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     real(real64), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [divisor], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real64
 

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -27,15 +27,15 @@ module ftorch
 
   !> Type for holding a Torch tensor.
   type torch_tensor
-    type(c_ptr) :: p = c_null_ptr  !! pointer to the tensor in memory
-    integer, private :: dtype
-    integer, private :: device_type
+    type(c_ptr) :: p = c_null_ptr    !! pointer to the tensor in memory
+    integer, private :: dtype        !! integer representing the tensor's data type
+    integer, private :: device_type  !! integer representing the tensor's device type
   contains
-    procedure :: torch_tensor_get_rank
-    procedure :: torch_tensor_get_shape
-    procedure :: torch_tensor_get_dtype
-    procedure :: torch_tensor_get_device_type
-    procedure :: torch_tensor_get_device_index
+    procedure :: get_rank => torch_tensor_get_rank
+    procedure :: get_shape => torch_tensor_get_shape
+    procedure :: get_dtype => torch_tensor_get_dtype
+    procedure :: get_device_type => torch_tensor_get_device_type
+    procedure :: get_device_index => torch_tensor_get_device_index
   end type torch_tensor
 
   !| Enumerator for Torch data types
@@ -1382,7 +1382,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1412,7 +1412,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1442,7 +1442,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1472,7 +1472,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1502,7 +1502,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1532,7 +1532,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1562,7 +1562,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1592,7 +1592,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1622,7 +1622,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1652,7 +1652,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1682,7 +1682,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1712,7 +1712,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1742,7 +1742,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1772,7 +1772,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1802,7 +1802,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1832,7 +1832,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1862,7 +1862,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1892,7 +1892,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1922,7 +1922,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1952,7 +1952,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1982,7 +1982,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2012,7 +2012,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2042,7 +2042,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2072,7 +2072,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2102,7 +2102,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2132,7 +2132,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2162,7 +2162,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2192,7 +2192,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2222,7 +2222,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2252,7 +2252,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2326,7 +2326,7 @@ contains
       end function torch_tensor_get_sizes_c
     end interface
 
-    ndims(1) = self%torch_tensor_get_rank()
+    ndims(1) = self%get_rank()
     cptr = torch_tensor_get_sizes_c(self%p)
     call c_f_pointer(cptr, sizes, ndims)
   end function torch_tensor_get_shape
@@ -2497,8 +2497,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int8
@@ -2514,8 +2514,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int16
@@ -2531,8 +2531,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int32
@@ -2548,8 +2548,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int64
@@ -2565,8 +2565,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real32
@@ -2582,8 +2582,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real64
@@ -2600,8 +2600,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int8
@@ -2617,8 +2617,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int16
@@ -2634,8 +2634,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int32
@@ -2651,8 +2651,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int64
@@ -2668,8 +2668,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real32
@@ -2685,8 +2685,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real64
@@ -2711,8 +2711,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int8
@@ -2728,8 +2728,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int16
@@ -2745,8 +2745,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int32
@@ -2762,8 +2762,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int64
@@ -2779,8 +2779,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real32
@@ -2796,8 +2796,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real64

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -31,8 +31,8 @@ module ftorch
     integer, private :: dtype
     integer, private :: device_type
   contains
-    procedure :: get_rank
-    procedure :: get_shape
+    procedure :: torch_tensor_get_rank
+    procedure :: torch_tensor_get_shape
     procedure :: torch_tensor_get_dtype
     procedure :: torch_tensor_get_device_type
   end type torch_tensor
@@ -1381,7 +1381,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1411,7 +1411,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1441,7 +1441,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1471,7 +1471,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1501,7 +1501,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt8  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1531,7 +1531,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1561,7 +1561,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1591,7 +1591,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1621,7 +1621,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1651,7 +1651,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt16  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1681,7 +1681,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1711,7 +1711,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1741,7 +1741,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1771,7 +1771,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1801,7 +1801,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1831,7 +1831,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1861,7 +1861,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1891,7 +1891,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1921,7 +1921,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1951,7 +1951,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kInt64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -1981,7 +1981,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2011,7 +2011,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2041,7 +2041,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2071,7 +2071,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2101,7 +2101,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat32  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2131,7 +2131,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2161,7 +2161,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2191,7 +2191,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2221,7 +2221,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2251,7 +2251,7 @@ contains
     integer(c_int), parameter :: dtype = torch_kFloat64  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -2286,7 +2286,7 @@ contains
   end subroutine torch_tensor_print
 
   !> Determines the rank of a tensor.
-  function get_rank(self) result(rank)
+  function torch_tensor_get_rank(self) result(rank)
     class(torch_tensor), intent(in) :: self
     integer(kind=int32) :: rank  !! rank of tensor
 
@@ -2301,10 +2301,10 @@ contains
     end interface
 
     rank = torch_tensor_get_rank_c(self%p)
-  end function get_rank
+  end function torch_tensor_get_rank
 
   !> Determines the shape of a tensor.
-  function get_shape(self) result(sizes)
+  function torch_tensor_get_shape(self) result(sizes)
     use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_long, c_long_long, c_ptr
     class(torch_tensor), intent(in) :: self
 #ifdef UNIX
@@ -2325,10 +2325,10 @@ contains
       end function torch_tensor_get_sizes_c
     end interface
 
-    ndims(1) = self%get_rank()
+    ndims(1) = self%torch_tensor_get_rank()
     cptr = torch_tensor_get_sizes_c(self%p)
     call c_f_pointer(cptr, sizes, ndims)
-  end function get_shape
+  end function torch_tensor_get_shape
 
   !> Returns the data type of a tensor.
   function torch_tensor_get_dtype(tensor) result(dtype)

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -35,6 +35,7 @@ module ftorch
     procedure :: torch_tensor_get_shape
     procedure :: torch_tensor_get_dtype
     procedure :: torch_tensor_get_device_type
+    procedure :: torch_tensor_get_device_index
   end type torch_tensor
 
   !| Enumerator for Torch data types
@@ -2349,8 +2350,8 @@ contains
   !> Determines the device index of a tensor.
   function torch_tensor_get_device_index(tensor) result(device_index)
     use, intrinsic :: iso_c_binding, only : c_int
-    type(torch_tensor), intent(in) :: tensor  !! Input tensor
-    integer(c_int) :: device_index            !! Device index of tensor
+    class(torch_tensor), intent(in) :: tensor  !! Input tensor
+    integer(c_int) :: device_index             !! Device index of tensor
 
     interface
       function torch_tensor_get_device_index_c(tensor) result(device_index) &

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -28,8 +28,6 @@ module ftorch
   !> Type for holding a Torch tensor.
   type torch_tensor
     type(c_ptr) :: p = c_null_ptr    !! pointer to the tensor in memory
-    integer, private :: dtype        !! integer representing the tensor's data type
-    integer, private :: device_type  !! integer representing the tensor's device type
   contains
     procedure :: get_rank => torch_tensor_get_rank
     procedure :: get_shape => torch_tensor_get_shape
@@ -302,8 +300,6 @@ contains
 
     tensor%p = torch_empty_c(ndims, tensor_shape, dtype, device_type,          &
                              device_index_value, requires_grad_value)
-    tensor%dtype = dtype
-    tensor%device_type = device_type
   end subroutine torch_tensor_empty
 
   !> Returns a tensor filled with the scalar value 0.
@@ -355,8 +351,6 @@ contains
 
     tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device_type,          &
                              device_index_value, requires_grad_value)
-    tensor%dtype = dtype
-    tensor%device_type = device_type
   end subroutine torch_tensor_zeros
 
   !> Returns a tensor filled with the scalar value 1.
@@ -408,8 +402,6 @@ contains
 
     tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device_type,           &
                             device_index_value, requires_grad_value)
-    tensor%dtype = dtype
-    tensor%device_type = device_type
   end subroutine torch_tensor_ones
 
   !| Exposes the given data as a tensor without taking ownership of the original data.
@@ -460,8 +452,6 @@ contains
     tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype,    &
                                  device_type, device_index_value,              &
                                  requires_grad_value)
-    tensor%dtype = dtype
-    tensor%device_type = device_type
   end subroutine torch_tensor_from_blob
 
   !> Return a Torch tensor pointing to data_in array of rank 1 containing data of type `int8`

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2493,9 +2493,13 @@ contains
     integer(int8), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int8
 
@@ -2506,9 +2510,13 @@ contains
     integer(int16), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int16
 
@@ -2519,9 +2527,13 @@ contains
     integer(int32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int32
 
@@ -2532,9 +2544,13 @@ contains
     integer(int64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_int64
 
@@ -2545,9 +2561,13 @@ contains
     real(real32), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real32
 
@@ -2558,9 +2578,13 @@ contains
     real(real64), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_real64
 
@@ -2572,9 +2596,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int8), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int8
 
@@ -2585,9 +2613,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int16), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int16
 
@@ -2598,9 +2630,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int32), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int32
 
@@ -2611,9 +2647,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int64), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_int64
 
@@ -2624,9 +2664,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     real(real32), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real32
 
@@ -2637,9 +2681,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     real(real64), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_real64
 
@@ -2659,9 +2707,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int8), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int8
 
@@ -2672,9 +2724,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int16), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int16
 
@@ -2685,9 +2741,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int32), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int32
 
@@ -2698,9 +2758,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     integer(int64), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_int64
 
@@ -2711,9 +2775,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     real(real32), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real32
 
@@ -2724,9 +2792,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     real(real64), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_real64
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -50,8 +50,8 @@ module ftorch
     integer, private :: dtype
     integer, private :: device_type
   contains
-    procedure :: get_rank
-    procedure :: get_shape
+    procedure :: torch_tensor_get_rank
+    procedure :: torch_tensor_get_shape
     procedure :: torch_tensor_get_dtype
     procedure :: torch_tensor_get_device_type
   end type torch_tensor
@@ -472,7 +472,7 @@ contains
     integer(c_int), parameter :: dtype = ${enum_from_prec(PREC)}$  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%get_shape()
+    my_shape = tensor%torch_tensor_get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -509,7 +509,7 @@ contains
   end subroutine torch_tensor_print
 
   !> Determines the rank of a tensor.
-  function get_rank(self) result(rank)
+  function torch_tensor_get_rank(self) result(rank)
     class(torch_tensor), intent(in) :: self
     integer(kind=int32) :: rank  !! rank of tensor
 
@@ -524,10 +524,10 @@ contains
     end interface
 
     rank = torch_tensor_get_rank_c(self%p)
-  end function get_rank
+  end function torch_tensor_get_rank
 
   !> Determines the shape of a tensor.
-  function get_shape(self) result(sizes)
+  function torch_tensor_get_shape(self) result(sizes)
     use, intrinsic :: iso_c_binding, only : c_f_pointer, c_int, c_long, c_long_long, c_ptr
     class(torch_tensor), intent(in) :: self
 #ifdef UNIX
@@ -548,10 +548,10 @@ contains
       end function torch_tensor_get_sizes_c
     end interface
 
-    ndims(1) = self%get_rank()
+    ndims(1) = self%torch_tensor_get_rank()
     cptr = torch_tensor_get_sizes_c(self%p)
     call c_f_pointer(cptr, sizes, ndims)
-  end function get_shape
+  end function torch_tensor_get_shape
 
   !> Returns the data type of a tensor.
   function torch_tensor_get_dtype(tensor) result(dtype)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -717,9 +717,13 @@ contains
     ${f_type(PREC)}$(${PREC}$), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_${PREC}$
 
@@ -733,9 +737,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    call torch_tensor_from_array(wrk, [scalar], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_${PREC}$
 
@@ -757,9 +765,13 @@ contains
     type(torch_tensor), intent(in) :: tensor
     ${f_type(PREC)}$(${PREC}$), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
+    integer :: device_type
+    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    call torch_tensor_from_array(wrk, [divisor], [1], torch_kCPU)
+    device_type = tensor%torch_tensor_get_device_type()
+    device_index = tensor%torch_tensor_get_device_index()
+    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_${PREC}$
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -47,9 +47,13 @@ module ftorch
   !> Type for holding a Torch tensor.
   type torch_tensor
     type(c_ptr) :: p = c_null_ptr  !! pointer to the tensor in memory
+    integer, private :: dtype
+    integer, private :: device_type
   contains
     procedure :: get_rank
     procedure :: get_shape
+    procedure :: torch_tensor_get_dtype
+    procedure :: torch_tensor_get_device_type
   end type torch_tensor
 
   !| Enumerator for Torch data types
@@ -252,6 +256,8 @@ contains
 
     tensor%p = torch_empty_c(ndims, tensor_shape, dtype, device_type,          &
                              device_index_value, requires_grad_value)
+    tensor%dtype = dtype
+    tensor%device_type = device_type
   end subroutine torch_tensor_empty
 
   !> Returns a tensor filled with the scalar value 0.
@@ -303,6 +309,8 @@ contains
 
     tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device_type,          &
                              device_index_value, requires_grad_value)
+    tensor%dtype = dtype
+    tensor%device_type = device_type
   end subroutine torch_tensor_zeros
 
   !> Returns a tensor filled with the scalar value 1.
@@ -354,6 +362,8 @@ contains
 
     tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device_type,           &
                             device_index_value, requires_grad_value)
+    tensor%dtype = dtype
+    tensor%device_type = device_type
   end subroutine torch_tensor_ones
 
   !| Exposes the given data as a tensor without taking ownership of the original data.
@@ -404,6 +414,8 @@ contains
     tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype,    &
                                  device_type, device_index_value,              &
                                  requires_grad_value)
+    tensor%dtype = dtype
+    tensor%device_type = device_type
   end subroutine torch_tensor_from_blob
 
   #:for PREC in PRECISIONS
@@ -496,25 +508,6 @@ contains
     call torch_tensor_print_c(tensor%p)
   end subroutine torch_tensor_print
 
-  !> Determines the device index of a tensor.
-  function torch_tensor_get_device_index(tensor) result(device_index)
-    use, intrinsic :: iso_c_binding, only : c_int
-    type(torch_tensor), intent(in) :: tensor  !! Input tensor
-    integer(c_int) :: device_index            !! Device index of tensor
-
-    interface
-      function torch_tensor_get_device_index_c(tensor) result(device_index) &
-          bind(c, name = 'torch_tensor_get_device_index')
-        use, intrinsic :: iso_c_binding, only : c_int, c_ptr
-        implicit none
-        type(c_ptr), value, intent(in) :: tensor
-        integer(c_int) :: device_index
-      end function torch_tensor_get_device_index_c
-    end interface
-
-    device_index = torch_tensor_get_device_index_c(tensor%p)
-  end function torch_tensor_get_device_index
-
   !> Determines the rank of a tensor.
   function get_rank(self) result(rank)
     class(torch_tensor), intent(in) :: self
@@ -559,6 +552,41 @@ contains
     cptr = torch_tensor_get_sizes_c(self%p)
     call c_f_pointer(cptr, sizes, ndims)
   end function get_shape
+
+  !> Returns the data type of a tensor.
+  function torch_tensor_get_dtype(tensor) result(dtype)
+    class(torch_tensor), intent(in) :: tensor  !! Input tensor
+    integer :: dtype                           !! Data type of tensor
+
+    dtype = tensor%dtype
+  end function torch_tensor_get_dtype
+
+  !> Returns the device type of a tensor.
+  function torch_tensor_get_device_type(tensor) result(device_type)
+    class(torch_tensor), intent(in) :: tensor  !! Input tensor
+    integer :: device_type                     !! Device type of tensor
+
+    device_type = tensor%device_type
+  end function torch_tensor_get_device_type
+
+  !> Determines the device index of a tensor.
+  function torch_tensor_get_device_index(tensor) result(device_index)
+    use, intrinsic :: iso_c_binding, only : c_int
+    type(torch_tensor), intent(in) :: tensor  !! Input tensor
+    integer(c_int) :: device_index            !! Device index of tensor
+
+    interface
+      function torch_tensor_get_device_index_c(tensor) result(device_index) &
+          bind(c, name = 'torch_tensor_get_device_index')
+        use, intrinsic :: iso_c_binding, only : c_int, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+        integer(c_int) :: device_index
+      end function torch_tensor_get_device_index_c
+    end interface
+
+    device_index = torch_tensor_get_device_index_c(tensor%p)
+  end function torch_tensor_get_device_index
 
   ! ============================================================================
   ! --- Procedures for deallocating tensors

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -556,10 +556,21 @@ contains
 
   !> Returns the data type of a tensor.
   function torch_tensor_get_dtype(tensor) result(dtype)
+    use, intrinsic :: iso_c_binding, only : c_int
     class(torch_tensor), intent(in) :: tensor  !! Input tensor
-    integer :: dtype                           !! Data type of tensor
+    integer(c_int) :: dtype                !! Data type of tensor
 
-    dtype = tensor%dtype
+    interface
+      function torch_tensor_get_dtype_c(tensor) result(dtype) &
+          bind(c, name = 'torch_tensor_get_dtype')
+        use, intrinsic :: iso_c_binding, only : c_int, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+        integer(c_int) :: dtype
+      end function torch_tensor_get_dtype_c
+    end interface
+
+    dtype = torch_tensor_get_dtype_c(tensor%p)
   end function torch_tensor_get_dtype
 
   !> Returns the device type of a tensor.

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -564,10 +564,21 @@ contains
 
   !> Returns the device type of a tensor.
   function torch_tensor_get_device_type(tensor) result(device_type)
+    use, intrinsic :: iso_c_binding, only : c_int
     class(torch_tensor), intent(in) :: tensor  !! Input tensor
-    integer :: device_type                     !! Device type of tensor
+    integer(c_int) :: device_type              !! Device type of tensor
 
-    device_type = tensor%device_type
+    interface
+      function torch_tensor_get_device_type_c(tensor) result(device_type) &
+          bind(c, name = 'torch_tensor_get_device_type')
+        use, intrinsic :: iso_c_binding, only : c_int, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+        integer(c_int) :: device_type
+      end function torch_tensor_get_device_type_c
+    end interface
+
+    device_type = torch_tensor_get_device_type_c(tensor%p)
   end function torch_tensor_get_device_type
 
   !> Determines the device index of a tensor.

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -46,7 +46,7 @@ module ftorch
 
   !> Type for holding a Torch tensor.
   type torch_tensor
-    type(c_ptr) :: p = c_null_ptr    !! pointer to the tensor in memory
+    type(c_ptr) :: p = c_null_ptr  !! pointer to the tensor in memory
   contains
     procedure :: get_rank => torch_tensor_get_rank
     procedure :: get_shape => torch_tensor_get_shape
@@ -729,13 +729,10 @@ contains
     ${f_type(PREC)}$(${PREC}$), target, intent(in) :: scalar
     type(torch_tensor), intent(in) :: tensor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_${PREC}$
 
@@ -749,13 +746,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     ${f_type(PREC)}$(${PREC}$), intent(in) :: scalar
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [scalar], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_${PREC}$
 
@@ -777,13 +771,10 @@ contains
     type(torch_tensor), intent(in) :: tensor
     ${f_type(PREC)}$(${PREC}$), intent(in) :: divisor
     type(torch_tensor) :: wrk, output
-    integer :: device_type
-    integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%get_device_type()
-    device_index = tensor%get_device_index()
-    call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
+    call torch_tensor_from_array(wrk, [divisor], [1], tensor%get_device_type(), &
+                                 tensor%get_device_index())
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_${PREC}$
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -54,6 +54,7 @@ module ftorch
     procedure :: torch_tensor_get_shape
     procedure :: torch_tensor_get_dtype
     procedure :: torch_tensor_get_device_type
+    procedure :: torch_tensor_get_device_index
   end type torch_tensor
 
   !| Enumerator for Torch data types
@@ -572,8 +573,8 @@ contains
   !> Determines the device index of a tensor.
   function torch_tensor_get_device_index(tensor) result(device_index)
     use, intrinsic :: iso_c_binding, only : c_int
-    type(torch_tensor), intent(in) :: tensor  !! Input tensor
-    integer(c_int) :: device_index            !! Device index of tensor
+    class(torch_tensor), intent(in) :: tensor  !! Input tensor
+    integer(c_int) :: device_index             !! Device index of tensor
 
     interface
       function torch_tensor_get_device_index_c(tensor) result(device_index) &

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -46,15 +46,15 @@ module ftorch
 
   !> Type for holding a Torch tensor.
   type torch_tensor
-    type(c_ptr) :: p = c_null_ptr  !! pointer to the tensor in memory
-    integer, private :: dtype
-    integer, private :: device_type
+    type(c_ptr) :: p = c_null_ptr    !! pointer to the tensor in memory
+    integer, private :: dtype        !! integer representing the tensor's data type
+    integer, private :: device_type  !! integer representing the tensor's device type
   contains
-    procedure :: torch_tensor_get_rank
-    procedure :: torch_tensor_get_shape
-    procedure :: torch_tensor_get_dtype
-    procedure :: torch_tensor_get_device_type
-    procedure :: torch_tensor_get_device_index
+    procedure :: get_rank => torch_tensor_get_rank
+    procedure :: get_shape => torch_tensor_get_shape
+    procedure :: get_dtype => torch_tensor_get_dtype
+    procedure :: get_device_type => torch_tensor_get_device_type
+    procedure :: get_device_index => torch_tensor_get_device_index
   end type torch_tensor
 
   !| Enumerator for Torch data types
@@ -473,7 +473,7 @@ contains
     integer(c_int), parameter :: dtype = ${enum_from_prec(PREC)}$  !! Data type
     type(c_ptr) :: cptr
 
-    my_shape = tensor%torch_tensor_get_shape()
+    my_shape = tensor%get_shape()
 
     if (present(sizes)) then
       if (.not. all(my_shape == sizes)) then
@@ -549,7 +549,7 @@ contains
       end function torch_tensor_get_sizes_c
     end interface
 
-    ndims(1) = self%torch_tensor_get_rank()
+    ndims(1) = self%get_rank()
     cptr = torch_tensor_get_sizes_c(self%p)
     call c_f_pointer(cptr, sizes, ndims)
   end function torch_tensor_get_shape
@@ -721,8 +721,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(wrk%p, tensor%p)
   end function torch_tensor_premultiply_${PREC}$
@@ -741,8 +741,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-multiplier
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [scalar], [1], device_type, device_index)
     output%p = torch_tensor_multiply_c(tensor%p, wrk%p)
   end function torch_tensor_postmultiply_${PREC}$
@@ -769,8 +769,8 @@ contains
     integer :: device_index
 
     ! Create a tensor with a single entry, the scalar post-divisor
-    device_type = tensor%torch_tensor_get_device_type()
-    device_index = tensor%torch_tensor_get_device_index()
+    device_type = tensor%get_device_type()
+    device_index = tensor%get_device_index()
     call torch_tensor_from_array(wrk, [divisor], [1], device_type, device_index)
     output%p = torch_tensor_divide_c(tensor%p, wrk%p)
   end function torch_tensor_postdivide_${PREC}$

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -47,8 +47,6 @@ module ftorch
   !> Type for holding a Torch tensor.
   type torch_tensor
     type(c_ptr) :: p = c_null_ptr    !! pointer to the tensor in memory
-    integer, private :: dtype        !! integer representing the tensor's data type
-    integer, private :: device_type  !! integer representing the tensor's device type
   contains
     procedure :: get_rank => torch_tensor_get_rank
     procedure :: get_shape => torch_tensor_get_shape
@@ -257,8 +255,6 @@ contains
 
     tensor%p = torch_empty_c(ndims, tensor_shape, dtype, device_type,          &
                              device_index_value, requires_grad_value)
-    tensor%dtype = dtype
-    tensor%device_type = device_type
   end subroutine torch_tensor_empty
 
   !> Returns a tensor filled with the scalar value 0.
@@ -310,8 +306,6 @@ contains
 
     tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device_type,          &
                              device_index_value, requires_grad_value)
-    tensor%dtype = dtype
-    tensor%device_type = device_type
   end subroutine torch_tensor_zeros
 
   !> Returns a tensor filled with the scalar value 1.
@@ -363,8 +357,6 @@ contains
 
     tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device_type,           &
                             device_index_value, requires_grad_value)
-    tensor%dtype = dtype
-    tensor%device_type = device_type
   end subroutine torch_tensor_ones
 
   !| Exposes the given data as a tensor without taking ownership of the original data.
@@ -415,8 +407,6 @@ contains
     tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype,    &
                                  device_type, device_index_value,              &
                                  requires_grad_value)
-    tensor%dtype = dtype
-    tensor%device_type = device_type
   end subroutine torch_tensor_from_blob
 
   #:for PREC in PRECISIONS

--- a/src/test/unit/test_tensor_interrogation.pf
+++ b/src/test/unit/test_tensor_interrogation.pf
@@ -157,6 +157,32 @@ contains
 
   end subroutine test_torch_tensor_get_shape_3D
 
+  ! Unit test for the torch_tensor_get_device_type function applied to a tensor on the CPU
+  @test
+  subroutine test_torch_tensor_get_device_type()
+    use ftorch, only: torch_tensor_get_device_type
+
+    implicit none
+
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    integer, parameter :: dtype = torch_kFloat32
+    integer, parameter :: expected = torch_kCPU
+
+    ! Create an empty tensor on the CPU with the default device type
+    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
+
+    ! Check that torch_tensor_get_device_type can get the device type
+    if (expected /= tensor%torch_tensor_get_device_type()) then
+      call torch_tensor_delete(tensor)
+      print *, "Error :: torch_tensor_get_device_type returned incorrect device type"
+      stop 999
+    end if
+    call torch_tensor_delete(tensor)
+
+  end subroutine test_torch_tensor_get_device_type
+
   ! Unit test for the torch_tensor_get_device_index function applied to a tensor on the CPU
   @test
   subroutine test_torch_tensor_get_device_index_default()

--- a/src/test/unit/test_tensor_interrogation.pf
+++ b/src/test/unit/test_tensor_interrogation.pf
@@ -160,7 +160,6 @@ contains
   ! Unit test for the torch_tensor_get_dtype function
   @test
   subroutine test_torch_tensor_get_dtype()
-    use ftorch, only: torch_tensor_get_dtype
 
     implicit none
 
@@ -186,7 +185,6 @@ contains
   ! Unit test for the torch_tensor_get_device_type function applied to a tensor on the CPU
   @test
   subroutine test_torch_tensor_get_device_type()
-    use ftorch, only: torch_tensor_get_device_type
 
     implicit none
 
@@ -212,7 +210,6 @@ contains
   ! Unit test for the torch_tensor_get_device_index function applied to a tensor on the CPU
   @test
   subroutine test_torch_tensor_get_device_index_default()
-    use ftorch, only: torch_tensor_get_device_index
 
     implicit none
 

--- a/src/test/unit/test_tensor_interrogation.pf
+++ b/src/test/unit/test_tensor_interrogation.pf
@@ -19,32 +19,6 @@ module test_tensor_interrogation
 
 contains
 
-  ! Unit test for the torch_tensor_get_device_index function applied to a tensor on the CPU
-  @test
-  subroutine test_torch_tensor_get_device_index_default()
-    use ftorch, only: torch_tensor_get_device_index
-
-    implicit none
-
-    type(torch_tensor) :: tensor
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-    integer, parameter :: dtype = torch_kFloat32
-    integer, parameter :: expected = -1
-
-    ! Create an empty tensor on the CPU with the default device index
-    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-
-    ! Check that torch_tensor_get_device_index can get the device index
-    if (expected /= torch_tensor_get_device_index(tensor)) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_device_index returned incorrect CPU device index"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
-
-  end subroutine test_torch_tensor_get_device_index_default
-
   ! Unit test for the torch_tensor_get_rank method of a 1D tensor
   @test
   subroutine test_torch_tensor_get_rank_1D()
@@ -182,5 +156,31 @@ contains
     call torch_tensor_delete(tensor)
 
   end subroutine test_torch_tensor_get_shape_3D
+
+  ! Unit test for the torch_tensor_get_device_index function applied to a tensor on the CPU
+  @test
+  subroutine test_torch_tensor_get_device_index_default()
+    use ftorch, only: torch_tensor_get_device_index
+
+    implicit none
+
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    integer, parameter :: dtype = torch_kFloat32
+    integer, parameter :: expected = -1
+
+    ! Create an empty tensor on the CPU with the default device index
+    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
+
+    ! Check that torch_tensor_get_device_index can get the device index
+    if (expected /= tensor%torch_tensor_get_device_index()) then
+      call torch_tensor_delete(tensor)
+      print *, "Error :: torch_tensor_get_device_index returned incorrect CPU device index"
+      stop 999
+    end if
+    call torch_tensor_delete(tensor)
+
+  end subroutine test_torch_tensor_get_device_index_default
 
 end module test_tensor_interrogation

--- a/src/test/unit/test_tensor_interrogation.pf
+++ b/src/test/unit/test_tensor_interrogation.pf
@@ -33,9 +33,9 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
     ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%torch_tensor_get_rank()) then
+    if (ndims /= tensor%get_rank()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_rank returned incorrect rank for 1D tensor"
+      print *, "Error :: tensor%get_rank() returned incorrect rank for 1D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
@@ -56,9 +56,9 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
     ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%torch_tensor_get_rank()) then
+    if (ndims /= tensor%get_rank()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_rank returned incorrect rank for 2D tensor"
+      print *, "Error :: tensor%get_rank() returned incorrect rank for 2D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
@@ -79,9 +79,9 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
     ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%torch_tensor_get_rank()) then
+    if (ndims /= tensor%get_rank()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_rank returned incorrect rank for 3D tensor"
+      print *, "Error :: tensor%get_rank() returned incorrect rank for 3D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
@@ -102,9 +102,9 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
     ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%torch_tensor_get_shape())) then
+    if (.not. all(tensor_shape == tensor%get_shape())) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_rank returned incorrect shape for 1D tensor"
+      print *, "Error :: tensor%get_shape() returned incorrect shape for 1D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
@@ -125,9 +125,9 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
     ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%torch_tensor_get_shape())) then
+    if (.not. all(tensor_shape == tensor%get_shape())) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_rank returned incorrect shape for 2D tensor"
+      print *, "Error :: tensor%get_shape() returned incorrect shape for 2D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
@@ -148,9 +148,9 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
     ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%torch_tensor_get_shape())) then
+    if (.not. all(tensor_shape == tensor%get_shape())) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_rank returned incorrect shape for 3D tensor"
+      print *, "Error :: tensor%get_shape() returned incorrect shape for 3D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
@@ -174,9 +174,9 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
 
     ! Check that torch_tensor_get_dtype can get the device type
-    if (expected /= tensor%torch_tensor_get_dtype()) then
+    if (expected /= tensor%get_dtype()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_dtype returned incorrect dtype"
+      print *, "Error :: tensor%get_dtype() returned incorrect dtype"
       stop 999
     end if
     call torch_tensor_delete(tensor)
@@ -200,9 +200,9 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
 
     ! Check that torch_tensor_get_device_type can get the device type
-    if (expected /= tensor%torch_tensor_get_device_type()) then
+    if (expected /= tensor%get_device_type()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_device_type returned incorrect device type"
+      print *, "Error :: tensor%get_device_type() returned incorrect device type"
       stop 999
     end if
     call torch_tensor_delete(tensor)
@@ -226,9 +226,9 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
 
     ! Check that torch_tensor_get_device_index can get the device index
-    if (expected /= tensor%torch_tensor_get_device_index()) then
+    if (expected /= tensor%get_device_index()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_device_index returned incorrect CPU device index"
+      print *, "Error :: tensor%get_device_index() returned incorrect CPU device index"
       stop 999
     end if
     call torch_tensor_delete(tensor)

--- a/src/test/unit/test_tensor_interrogation.pf
+++ b/src/test/unit/test_tensor_interrogation.pf
@@ -45,9 +45,9 @@ contains
 
   end subroutine test_torch_tensor_get_device_index_default
 
-  ! Unit test for the get_rank method of a 1D tensor
+  ! Unit test for the torch_tensor_get_rank method of a 1D tensor
   @test
-  subroutine test_get_rank_1D()
+  subroutine test_torch_tensor_get_rank_1D()
 
     implicit none
 
@@ -56,20 +56,21 @@ contains
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [6]
     integer, parameter :: dtype = torch_kFloat32
 
-    ! Create a tensor with uninitialised values and check get_rank can correctly identify its rank
+    ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
+    ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%get_rank()) then
+    if (ndims /= tensor%torch_tensor_get_rank()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: get_rank returned incorrect rank for 1D tensor"
+      print *, "Error :: torch_tensor_get_rank returned incorrect rank for 1D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
 
-  end subroutine test_get_rank_1D
+  end subroutine test_torch_tensor_get_rank_1D
 
-  ! Unit test for the get_rank method of a 2D tensor
+  ! Unit test for the torch_tensor_get_rank method of a 2D tensor
   @test
-  subroutine test_get_rank_2D()
+  subroutine test_torch_tensor_get_rank_2D()
 
     implicit none
 
@@ -78,20 +79,21 @@ contains
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [2,3]
     integer, parameter :: dtype = torch_kFloat32
 
-    ! Create a tensor with uninitialised values and check get_rank can correctly identify its rank
+    ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
+    ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%get_rank()) then
+    if (ndims /= tensor%torch_tensor_get_rank()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: get_rank returned incorrect rank for 2D tensor"
+      print *, "Error :: torch_tensor_get_rank returned incorrect rank for 2D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
 
-  end subroutine test_get_rank_2D
+  end subroutine test_torch_tensor_get_rank_2D
 
-  ! Unit test for the get_rank method of a 3D tensor
+  ! Unit test for the torch_tensor_get_rank method of a 3D tensor
   @test
-  subroutine test_get_rank_3D()
+  subroutine test_torch_tensor_get_rank_3D()
 
     implicit none
 
@@ -100,20 +102,21 @@ contains
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [1,2,3]
     integer, parameter :: dtype = torch_kFloat32
 
-    ! Create a tensor with uninitialised values and check get_rank can correctly identify its rank
+    ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
+    ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%get_rank()) then
+    if (ndims /= tensor%torch_tensor_get_rank()) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: get_rank returned incorrect rank for 3D tensor"
+      print *, "Error :: torch_tensor_get_rank returned incorrect rank for 3D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
 
-  end subroutine test_get_rank_3D
+  end subroutine test_torch_tensor_get_rank_3D
 
-  ! Unit test for the get_shape method of a 1D tensor
+  ! Unit test for the torch_tensor_get_shape method of a 1D tensor
   @test
-  subroutine test_get_shape_1D()
+  subroutine test_torch_tensor_get_shape_1D()
 
     implicit none
 
@@ -122,20 +125,21 @@ contains
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [6]
     integer, parameter :: dtype = torch_kFloat32
 
-    ! Create a tensor with uninitialised values and check get_shape can correctly identify its shape
+    ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
+    ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%get_shape())) then
+    if (.not. all(tensor_shape == tensor%torch_tensor_get_shape())) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: get_rank returned incorrect shape for 1D tensor"
+      print *, "Error :: torch_tensor_get_rank returned incorrect shape for 1D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
 
-  end subroutine test_get_shape_1D
+  end subroutine test_torch_tensor_get_shape_1D
 
-  ! Unit test for the get_shape method of a 2D tensor
+  ! Unit test for the torch_tensor_get_shape method of a 2D tensor
   @test
-  subroutine test_get_shape_2D()
+  subroutine test_torch_tensor_get_shape_2D()
 
     implicit none
 
@@ -144,20 +148,21 @@ contains
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [2, 3]
     integer, parameter :: dtype = torch_kFloat32
 
-    ! Create a tensor with uninitialised values and check get_shape can correctly identify its shape
+    ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
+    ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%get_shape())) then
+    if (.not. all(tensor_shape == tensor%torch_tensor_get_shape())) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: get_rank returned incorrect shape for 2D tensor"
+      print *, "Error :: torch_tensor_get_rank returned incorrect shape for 2D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
 
-  end subroutine test_get_shape_2D
+  end subroutine test_torch_tensor_get_shape_2D
 
-  ! Unit test for the get_shape method of a 3D tensor
+  ! Unit test for the torch_tensor_get_shape method of a 3D tensor
   @test
-  subroutine test_get_shape_3D()
+  subroutine test_torch_tensor_get_shape_3D()
 
     implicit none
 
@@ -166,15 +171,16 @@ contains
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [1, 2, 3]
     integer, parameter :: dtype = torch_kFloat32
 
-    ! Create a tensor with uninitialised values and check get_shape can correctly identify its shape
+    ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
+    ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%get_shape())) then
+    if (.not. all(tensor_shape == tensor%torch_tensor_get_shape())) then
       call torch_tensor_delete(tensor)
-      print *, "Error :: get_rank returned incorrect shape for 3D tensor"
+      print *, "Error :: torch_tensor_get_rank returned incorrect shape for 3D tensor"
       stop 999
     end if
     call torch_tensor_delete(tensor)
 
-  end subroutine test_get_shape_3D
+  end subroutine test_torch_tensor_get_shape_3D
 
 end module test_tensor_interrogation

--- a/src/test/unit/test_tensor_interrogation.pf
+++ b/src/test/unit/test_tensor_interrogation.pf
@@ -157,6 +157,32 @@ contains
 
   end subroutine test_torch_tensor_get_shape_3D
 
+  ! Unit test for the torch_tensor_get_dtype function
+  @test
+  subroutine test_torch_tensor_get_dtype()
+    use ftorch, only: torch_tensor_get_dtype
+
+    implicit none
+
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    integer, parameter :: dtype = torch_kFloat32
+    integer, parameter :: expected = torch_kFloat32
+
+    ! Create an empty tensor for 32-bit floats
+    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
+
+    ! Check that torch_tensor_get_dtype can get the device type
+    if (expected /= tensor%torch_tensor_get_dtype()) then
+      call torch_tensor_delete(tensor)
+      print *, "Error :: torch_tensor_get_dtype returned incorrect dtype"
+      stop 999
+    end if
+    call torch_tensor_delete(tensor)
+
+  end subroutine test_torch_tensor_get_dtype
+
   ! Unit test for the torch_tensor_get_device_type function applied to a tensor on the CPU
   @test
   subroutine test_torch_tensor_get_device_type()

--- a/src/test/unit/test_tensor_interrogation_cuda.pf
+++ b/src/test/unit/test_tensor_interrogation_cuda.pf
@@ -22,7 +22,6 @@ contains
   ! Unit test for the torch_tensor_get_device_type function applied to a tensor on a CUDA device
   @test
   subroutine test_torch_tensor_get_device_type()
-    use ftorch, only: torch_tensor_get_device_type
 
     implicit none
 
@@ -49,7 +48,6 @@ contains
   ! Tensor is created without specifying a device_index so should default to device 0
   @test
   subroutine test_torch_tensor_get_device_index_default()
-    use ftorch, only: torch_tensor_get_device_index
 
     implicit none
 

--- a/src/test/unit/test_tensor_interrogation_cuda.pf
+++ b/src/test/unit/test_tensor_interrogation_cuda.pf
@@ -5,21 +5,24 @@
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
 module test_tensor_interrogation_cuda
+  use funit
+  use ftorch, only: torch_kFloat32, torch_kCUDA, torch_tensor, torch_tensor_delete, &
+                    torch_tensor_empty
+  use iso_c_binding, only: c_int64_t
 
   implicit none
 
   public
 
+  ! Parameters common across all test cases
+  integer, parameter :: device_type = torch_kCUDA
+
 contains
 
-  ! Unit test for the torch_tensor_get_device_index function applied to a tensor on a CUDA device
-  ! Tensor is created without specifying a device_index so should default to device 0
+  ! Unit test for the torch_tensor_get_device_type function applied to a tensor on a CUDA device
   @test
-  subroutine test_torch_tensor_get_device_index_default()
-    use funit
-    use ftorch, only: torch_kFloat32, torch_kCUDA, torch_tensor, torch_tensor_delete, &
-                      torch_tensor_empty, torch_tensor_get_device_index
-    use iso_c_binding, only: c_int64_t
+  subroutine test_torch_tensor_get_device_type()
+    use ftorch, only: torch_tensor_get_device_type
 
     implicit none
 
@@ -27,7 +30,33 @@ contains
     integer, parameter :: ndims = 1
     integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
     integer, parameter :: dtype = torch_kFloat32
-    integer, parameter :: device_type = torch_kCUDA
+    integer, parameter :: expected = torch_kCUDA
+
+    ! Create an empty tensor on the CUDAD device
+    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
+
+    ! Check that torch_tensor_get_device_type can get the device type
+    if (expected /= tensor%torch_tensor_get_device_type()) then
+      call torch_tensor_delete(tensor)
+      print *, "Error :: torch_tensor_get_device_type returned incorrect device type"
+      stop 999
+    end if
+    call torch_tensor_delete(tensor)
+
+  end subroutine test_torch_tensor_get_device_type
+
+  ! Unit test for the torch_tensor_get_device_index function applied to a tensor on a CUDA device
+  ! Tensor is created without specifying a device_index so should default to device 0
+  @test
+  subroutine test_torch_tensor_get_device_index_default()
+    use ftorch, only: torch_tensor_get_device_index
+
+    implicit none
+
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    integer, parameter :: dtype = torch_kFloat32
     integer, parameter :: expected = 0
 
     ! Create an empty tensor on the CUDA device with the default device index

--- a/src/test/unit/test_tensor_interrogation_cuda.pf
+++ b/src/test/unit/test_tensor_interrogation_cuda.pf
@@ -36,7 +36,7 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
 
     ! Check that torch_tensor_get_device_type can get the device type
-    if (expected /= tensor%torch_tensor_get_device_type()) then
+    if (expected /= tensor%get_device_type()) then
       call torch_tensor_delete(tensor)
       print *, "Error :: torch_tensor_get_device_type returned incorrect device type"
       stop 999


### PR DESCRIPTION
Closes #248.

This PR adds functions for getting the data type and device type of a tensor, including unit tests. It also improves the consistency of the existing functions so that they are called `torch_tensor_get_X` but are mapped to methods of the `torch_tensor` class as just `get_X`. This makes it clearer what we are getting the rank/shape of when we call as functions, and reduces unnecessary verbosity when calling as methods.

Using the new utility for getting the device type, the operator overloads involving scalars are corrected so that CPU isn't assumed.