### PR TITLE
Bugfix: mismatch in Fortran array character array lengths in example 2

### DIFF
--- a/examples/2_ResNet18/resnet_infer_fortran.f90
+++ b/examples/2_ResNet18/resnet_infer_fortran.f90
@@ -161,7 +161,7 @@ contains
 
       character(len=*), intent(in) :: filename_cats
       integer, intent(in) :: N_cats
-      character(len=100), intent(out) :: categories(N_cats)
+      character(len=128), intent(out) :: categories(N_cats)
 
       integer :: ios
       character(len=100) :: ioerrmsg

--- a/examples/2_ResNet18/resnet_infer_fortran.f90
+++ b/examples/2_ResNet18/resnet_infer_fortran.f90
@@ -40,9 +40,9 @@ contains
       ! Path to input data
       character(len=128) :: data_dir
       ! Binary file containing input tensor
-      character(len=116) :: filename
+      character(len=128) :: filename
       ! Text file containing categories
-      character(len=114) :: filename_cats
+      character(len=128) :: filename_cats
 
       ! Length of tensor and number of categories
       integer, parameter :: tensor_length = 150528


### PR DESCRIPTION
A mismatch in character array lengths was causing the wrong resnet category to be printed in the Fortran.

At some point lengths in the main routine were updated to 128, but not in the subroutine required to read categories leading to the arrays becoming garbled during the passing.

Also updates the filename strings to 128 for consistency, rather than seemingly arbitrary lengths.