### PR TITLE
Add conda environment files and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ At the time of writing, LibTorch is only officially available for x86 architectu
 (according to https://pytorch.org/). However, the version of PyTorch provided by
 `pip install torch` uses an ARM binary for LibTorch which works on Apple Silicon.
 
+#### Conda Support
+
+Conda is not our preferred approach for managing dependencies, but for users who want
+an environment to build FTorch in we provide guidance and environment files in
+[`conda/`](https://github.com/Cambridge-ICCS/FTorch/tree/main/conda). Note that these
+are not minimal and will install Python, PyTorch, and modules required for running the
+tests and examples.
+
 ### Library installation
 
 For detailed installation instructions please see the

--- a/conda/README.md
+++ b/conda/README.md
@@ -39,6 +39,32 @@ cmake \
 cmake --build . --target install
 ```
 
+### CUDA
+
+From a conda base environment run:
+```sh
+conda env create -f environment_cuda.yaml
+```
+from this directory to create the environment and install dependencies.
+
+FTorch can then be built as described in the main documentation from within this
+activated environment.
+As nopted above it is convenient to install FTorch into the conda environment using
+`$CONDA_PREFIX`, and locate the CMake headers for torch using the Python utility:
+```sh
+cmake \
+    -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+    -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_CUDA=TRUE \
+    ..
+cmake --build . --target install
+```
+
+### Other Backends
+
+We currently only provide conda environments for CPU and CUDA backends.
+
 If you require something else please [get in touch](https://github.com/Cambridge-ICCS/FTorch/issues)
 or submit a pull request.
 
@@ -47,6 +73,25 @@ or submit a pull request.
 > These environments will install PyTorch (and associated dependencies) to couple to
 > from FTorch. Users wanting a minimal build that relies on LibTorch rather than
 > PyTorch and Python should follow the non-conda build procedure.
+
+
+## Tests
+
+If running the unit tests it is recommended that pFUnit is build an d installed into the
+conda environment at `$CONDA_PREFIX`:
+```sh
+git clone --recursive git@github.com:Goddard-Fortran-Ecosystem/pFUnit.git
+
+cd pFUnit
+mkdir build
+cd build
+
+cmake \
+  -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+  ..
+make tests
+make install
+```
 
 
 ## Examples

--- a/conda/README.md
+++ b/conda/README.md
@@ -102,7 +102,7 @@ Conda users should adjust their approach accordingly.
 
 ## Tests
 
-If running the unit tests it is recommended that pFUnit is build and installed into the
+If running the unit tests it is recommended that pFUnit is built and installed into the
 conda environment at `$CONDA_PREFIX`:
 ```sh
 git clone --recursive git@github.com:Goddard-Fortran-Ecosystem/pFUnit.git
@@ -120,11 +120,11 @@ make install
 
 The unit tests only can be run using the provided script:
 ```sh
-./run_test_suite.sh -u
+./run_test_suite.sh --unit-only
 ```
 
 > [!NOTE]  
 > The automated integration testing also makes use of pip to install pytorch and other
-> python dependencies. Conda users wishing to run this should amend the test script
+> Python dependencies. Conda users wishing to run this should amend the test script
 > to  remove the `pip install` command as these additional requirements are included
 > in the environment files provided.

--- a/conda/README.md
+++ b/conda/README.md
@@ -15,6 +15,10 @@ or submit a pull request if you have a fix.
 
 ## Environments
 
+Environments can be generated from the yaml files in this directory as described below.
+Lower bounds are set to versions which been successfully tested but can be adjusted
+by the user as desired.
+
 ### CPU only
 
 From a conda base environment run:

--- a/conda/README.md
+++ b/conda/README.md
@@ -32,7 +32,7 @@ A CMake build command utilising this may look something like:
 ```sh
 cmake \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-    -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` \
+    -DCMAKE_PREFIX_PATH=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)') \
     -DCMAKE_BUILD_TYPE=Release \
     -DENABLE_CUDA=FALSE \
     ..
@@ -57,7 +57,7 @@ similar to the following:
 ```sh
 cmake \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-    -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` \
+    -DCMAKE_PREFIX_PATH=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)') \
     -DCMAKE_BUILD_TYPE=Release \
     -DENABLE_CUDA=TRUE \
     -DCUDA_TOOLKIT_ROOT_DIR=$CONDA_PREFIX/targets/x86_64-linux \

--- a/conda/README.md
+++ b/conda/README.md
@@ -47,16 +47,21 @@ conda env create -f environment_cuda.yaml
 ```
 from this directory to create the environment and install dependencies.
 
-FTorch can then be built as described in the main documentation from within this
-activated environment.
-As nopted above it is convenient to install FTorch into the conda environment using
-`$CONDA_PREFIX`, and locate the CMake headers for torch using the Python utility:
+At time of writing building FTorch in this environment requires some additional
+CMake flags to be set in order to correctly locate CUDA components within the
+conda environment, namely `CUDA_TOOLKIT_ROOT_DIR` and `nvtx3_dir`
+(see [this comment](https://github.com/conda-forge/cuda-feedstock/issues/59#issuecomment-2620910028)
+for details).
+Doing this, with the tips described above for CPU builds, results in a CMake command
+similar to the following:
 ```sh
 cmake \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
     -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` \
     -DCMAKE_BUILD_TYPE=Release \
     -DENABLE_CUDA=TRUE \
+    -DCUDA_TOOLKIT_ROOT_DIR=$CONDA_PREFIX/targets/x86_64-linux \
+    -Dnvtx3_dir=$CONDA_PREFIX/targets/x86_64-linux/include/nvtx3 \
     ..
 cmake --build . --target install
 ```
@@ -75,9 +80,20 @@ or submit a pull request.
 > PyTorch and Python should follow the non-conda build procedure.
 
 
+## Examples
+
+The instructions for running the examples make use of virtual environments
+and pip to install dependencies for running any Python code within them.
+
+This is not neccessary from within the conda environment as these dependencies are
+installed as part of the environment files provided.
+
+Conda users should adjust their approach accordingly.
+
+
 ## Tests
 
-If running the unit tests it is recommended that pFUnit is build an d installed into the
+If running the unit tests it is recommended that pFUnit is build and installed into the
 conda environment at `$CONDA_PREFIX`:
 ```sh
 git clone --recursive git@github.com:Goddard-Fortran-Ecosystem/pFUnit.git
@@ -93,18 +109,13 @@ make tests
 make install
 ```
 
-
-## Examples
-
-The instructions for running the examples make use of virtual environments
-and pip to install dependencies for running any Python code within them.
-
-This is not neccessary from within the conda environment as these dependencies are
-installed as part of the environment files provided.
-
-Conda users should adjust their approach accordingly.
+The unit tests only can be run using the provided script:
+```sh
+./run_test_suite.sh -u
+```
 
 > [!NOTE]  
 > The automated integration testing also makes use of pip to install pytorch and other
 > python dependencies. Conda users wishing to run this should amend the test script
-> as appropriate before running.
+> to  remove the `pip install` command as these additional requirements are included
+> in the environment files provided.

--- a/conda/README.md
+++ b/conda/README.md
@@ -38,6 +38,8 @@ cmake \
     ..
 cmake --build . --target install
 ```
+Note: There is the option of using `--parallel` to speed this up as described in
+the main documentation.
 
 ### CUDA
 
@@ -65,6 +67,9 @@ cmake \
     ..
 cmake --build . --target install
 ```
+Note: There is the option of using `--parallel` to speed this up as described in
+the main documentation.
+
 
 ### Other Backends
 

--- a/conda/README.md
+++ b/conda/README.md
@@ -1,0 +1,65 @@
+# Conda environments for FTorch
+
+A number of users manage software environments with conda.
+
+Our preference in FTorch is to manage the installation of key dependencies ourselves,
+with any Python dependencies managed via pip, as described in our documentation.
+
+However, for those who wish to use conda we provide environment files and instructions
+for installation here.
+
+As it is not our preference these environments are not actively maintained.
+If you experience problems please [open an issue](https://github.com/Cambridge-ICCS/FTorch/issues)
+or submit a pull request if you have a fix.
+
+
+## Environments
+
+### CPU only
+
+From a conda base environment run:
+```sh
+conda env create -f environment_cpu.yaml
+```
+from this directory to create the environment and install dependencies.
+
+FTorch can then be built as described in the main documentation from within this
+activated environment.
+Note that it is convenient to install FTorch into the conda environment using
+`$CONDA_PREFIX`, and locate the CMake headers for torch using the Python utility.
+
+A CMake build command utilising this may look something like:
+```sh
+cmake \
+    -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+    -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_CUDA=FALSE \
+    ..
+cmake --build . --target install
+```
+
+If you require something else please [get in touch](https://github.com/Cambridge-ICCS/FTorch/issues)
+or submit a pull request.
+
+
+> [!NOTE]  
+> These environments will install PyTorch (and associated dependencies) to couple to
+> from FTorch. Users wanting a minimal build that relies on LibTorch rather than
+> PyTorch and Python should follow the non-conda build procedure.
+
+
+## Examples
+
+The instructions for running the examples make use of virtual environments
+and pip to install dependencies for running any Python code within them.
+
+This is not neccessary from within the conda environment as these dependencies are
+installed as part of the environment files provided.
+
+Conda users should adjust their approach accordingly.
+
+> [!NOTE]  
+> The automated integration testing also makes use of pip to install pytorch and other
+> python dependencies. Conda users wishing to run this should amend the test script
+> as appropriate before running.

--- a/conda/environment_cpu.yaml
+++ b/conda/environment_cpu.yaml
@@ -1,11 +1,12 @@
 name: FTorch-cpu
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - fortran-compiler
   - cxx-compiler
-  - cmake
-  - openmpi  # For pFUnit
-  - pytorch-cpu  # Force cpu-only version
+  - cmake >=3.15
+  - openmpi >=5.0.6  # For pFUnit
+  - pytorch-cpu >=2.5.1  # Force cpu-only version
   - torchvision  # For example 2
   - zlib  # missing dependency for pytorch

--- a/conda/environment_cpu.yaml
+++ b/conda/environment_cpu.yaml
@@ -1,0 +1,11 @@
+name: FTorch-cpu
+channels:
+  - conda-forge
+dependencies:
+  - fortran-compiler
+  - cxx-compiler
+  - cmake
+  - openmpi  # For pFUnit
+  - pytorch-cpu  # Force cpu-only version
+  - torchvision  # For example 2
+  - zlib  # missing dependency for pytorch

--- a/conda/environment_cpu.yaml
+++ b/conda/environment_cpu.yaml
@@ -8,5 +8,5 @@ dependencies:
   - cmake >=3.15
   - openmpi >=5.0.6  # For pFUnit
   - pytorch-cpu >=2.5.1  # Force cpu-only version
-  - torchvision  # For example 2
+  - torchvision  # For the ResNet example
   - zlib  # missing dependency for pytorch

--- a/conda/environment_cuda.yaml
+++ b/conda/environment_cuda.yaml
@@ -7,12 +7,13 @@ dependencies:
   - fortran-compiler
   - cxx-compiler
   - cmake
-  - openmpi  # For pFUnit to run the test suite and example 3
+  - openmpi-mpifort  # For pFUnit to run the test suite and MultiGPU example
   - cuda-version 12.6  # Set version of cuda here
   - cuda-compiler
   - cuda-libraries-dev
   - cuda-nvtx-dev
   - python <3.13  # Restrict as PyTorch not functional in 3.13 at present
   - pytorch
-  - torchvision  # For example 2 only
+  - torchvision  # For ResNet example only
+  - mpi4py  # For MultiGPU example only
   - zlib  # missing dependency of pytorch

--- a/conda/environment_cuda.yaml
+++ b/conda/environment_cuda.yaml
@@ -1,0 +1,18 @@
+name: FTorch-cuda
+channels:
+  - conda-forge
+  - nvidia
+  - nodefaults
+dependencies:
+  - fortran-compiler
+  - cxx-compiler
+  - cmake
+  - openmpi  # For pFUnit to run the test suite and example 3
+  - cuda-version 12.6  # Set version of cuda here
+  - cuda-compiler
+  - cuda-libraries-dev
+  - cuda-nvtx-dev
+  - python <3.13  # Restrict as PyTorch not functional in 3.13 at present
+  - pytorch
+  - torchvision  # For example 2 only
+  - zlib  # missing dependency of pytorch

--- a/conda/environment_cuda.yaml
+++ b/conda/environment_cuda.yaml
@@ -1,19 +1,18 @@
 name: FTorch-cuda
 channels:
   - conda-forge
-  - nvidia
   - nodefaults
 dependencies:
   - fortran-compiler
   - cxx-compiler
-  - cmake
-  - openmpi-mpifort  # For pFUnit to run the test suite and MultiGPU example
+  - cmake >=3.15
+  - openmpi-mpifort >=5.0.6  # For pFUnit to run the test suite and MultiGPU example
   - cuda-version 12.6  # Set version of cuda here
-  - cuda-compiler
-  - cuda-libraries-dev
-  - cuda-nvtx-dev
+  - cuda-compiler >=12.6.3
+  - cuda-libraries-dev >=12.6.3
+  - cuda-nvtx-dev >=12.6.77
   - python <3.13  # Restrict as PyTorch not functional in 3.13 at present
-  - pytorch
+  - pytorch >=2.5.1
   - torchvision  # For ResNet example only
-  - mpi4py  # For MultiGPU example only
+  - mpi4py >=4.0.1  # For MultiGPU example only
   - zlib  # missing dependency of pytorch

--- a/pages/cmake.md
+++ b/pages/cmake.md
@@ -152,3 +152,10 @@ unless installing in a default location:
 ```
 export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:<path/to/installation>/lib64
 ```
+
+## Conda Support
+
+Conda is not our preferred approach for managing dependencies, but for users who want
+an environment to build FTorch in we provide [guidance and environment files](https://github.com/Cambridge-ICCS/FTorch/tree/main/conda).
+Note that these are not minimal and will install Python, PyTorch, and modules required
+for running the tests and examples.


### PR DESCRIPTION
This should hopefully address some of  #214 

- [x] Add conda environment for CPU-only builds
- [x] Add conda environment for CUDA build
- [x] Add instructions for conda users
- [x] Independent test build by someone else

Queries:

- What is best practice, should we be pinning versions to any extent? Currently I just name the packages
- Should we add a workflow to check anything? Seems like a lot more effort to do properly (without pip) and I do say in the docs this is not our preferred or maintained approach...