### PR TITLE
Enforce the use of a virtual environment in the integration testing script.

### DIFF
--- a/pages/testing.md
+++ b/pages/testing.md
@@ -39,10 +39,10 @@ See the subsections below for instructions on how to run subsets of the full
 test suite.
 
 > <sup>1</sup> _If you built FTorch against LibTorch (rather than creating a
-virtual environment) then either
+virtual environment) then you will need to
 [create a virtual environment](https://docs.python.org/3/library/venv.html) for
-the purposes of testing, or note that this script may have your Python
-environment install some modules._
+the purposes of integration testing as this script will install packages into your
+Python environment and will check that a virtual environment is in use._
 
 #### Running unit tests on Unix
 

--- a/run_test_suite.sh
+++ b/run_test_suite.sh
@@ -87,8 +87,9 @@ if [ "${RUN_INTEGRATION}" = true ]; then
   else
     EXAMPLES="1_SimpleNet 2_ResNet18 4_MultiIO 6_Autograd"
   fi
+  export PIP_REQUIRE_VIRTUALENV=true
   for EXAMPLE in ${EXAMPLES}; do
-    pip -q install -r examples/"${EXAMPLE}"/requirements.txt
+    python -m pip -q install -r examples/"${EXAMPLE}"/requirements.txt
     cd "${BUILD_DIR}"/test/examples/"${EXAMPLE}"
     ctest "${CTEST_ARGS}"
     cd -


### PR DESCRIPTION
Closes #265 

Enforces use of a venv through setting `PIP_REQUIRE_VIRTUALENV=true` in the unix tests script.

Running without a virtual environment will give:

```console
./run_test_suite.sh --verbose --integration-only
ERROR: Could not find an activated virtualenv (required).
Error: Process completed with exit code 3.
```