### PR TITLE
Use `get_device_index` method in test

### DIFF
--- a/src/test/unit/test_tensor_interrogation_cuda.pf
+++ b/src/test/unit/test_tensor_interrogation_cuda.pf
@@ -34,7 +34,7 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
 
     ! Check that torch_tensor_get_device_index can get the device index
-    if (expected /= torch_tensor_get_device_index(tensor)) then
+    if (expected /= tensor%get_device_index()) then
       call torch_tensor_delete(tensor)
       print *, "Error :: torch_tensor_get_device_index returned incorrect CUDA device index"
       stop 999


### PR DESCRIPTION
Looks like I failed to re-test later changes in #222.

Building with CUDA support I got
```
/home/joewa/software/FTorch/src/build/test/unit/test_tensor_interrogation_cuda.F90:64:19:

   64 |     if (expected /= torch_tensor_get_device_index(tensor)) then
      |                   1
Error: Function ‘torch_tensor_get_device_index’ at (1) has no IMPLICIT type
/home/joewa/software/FTorch/src/build/test/unit/test_tensor_interrogation_cuda.F90:77:8:

   77 |    use test_tensor_interrogation_cuda
      |        1
Fatal Error: Cannot open module file ‘test_tensor_interrogation_cuda.mod’ for reading at (1): No such file or directory
compilation terminated.
```
which is fixed here.