### PR TITLE
Add multiproc build note

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ To build and install the library:
     cmake --install .
     ```
 
+   Note: If using a machine capable of running multiple jobs this can be sped up by
+   adding `--parallel [<jobs>]` or `-j [<jobs>]` to the `cmake build` command.
+   See the [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-build-j)
+   for more information.
+
     Note: If you are using CMake < 3.15 then you will need to build and install separately
     using the make system specific commands.
     For example, if using `make` on UNIX this would be:

--- a/README.md
+++ b/README.md
@@ -189,14 +189,6 @@ To build and install the library:
    See the [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-build-j)
    for more information.
 
-    Note: If you are using CMake < 3.15 then you will need to build and install separately
-    using the make system specific commands.
-    For example, if using `make` on UNIX this would be:
-    ```
-    make
-    make install
-    ```
-
     Installation will place the following directories at the install location:  
     * `CMAKE_INSTALL_PREFIX/include/` - contains header and mod files
     * `CMAKE_INSTALL_PREFIX/lib/` - contains `cmake` directory and `.so` files  

--- a/pages/cmake.md
+++ b/pages/cmake.md
@@ -103,14 +103,6 @@ cmake --build . --target install
 > See the [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-build-j)
 > for more information._
 
-> Note: _If you are using CMake < 3.15 then you will need to build and install separately
-> using the make system specific commands._
-For example, if using `make` on UNIX this would be:
-```
-make
-make install
-```
-
 Installation will place the following directories at the install location:
 
 * `CMAKE_INSTALL_PREFIX/include/` - contains C header and Fortran mod files

--- a/pages/cmake.md
+++ b/pages/cmake.md
@@ -98,6 +98,11 @@ Once this completes you should be able to generate the code and install using:
 cmake --build . --target install
 ```
 
+> Note: _If using a machine capable of running multiple jobs this can be sped up by
+> adding `--parallel [<jobs>]` or `-j [<jobs>]` to the `cmake build` command.
+> See the [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-build-j)
+> for more information._
+
 > Note: _If you are using CMake < 3.15 then you will need to build and install separately
 > using the make system specific commands._
 For example, if using `make` on UNIX this would be:


### PR DESCRIPTION
As suggested in #264 This adds a note to the README and docs to let users know that they can build in parallel when available with an additional argument to `cmake build`.

I also take the liberty of removing a now defunct note aboiut building using `make` for CMake < 3.15 as we recently set the minimum version to this (see #228).