### PR TITLE
XPU and MPS take 3

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -98,8 +98,9 @@ jobs:
         if: always()
         run: |
           cd ${{ github.workspace }}
-          . ftorch_venv/bin/activate  # Uses .clang-tidy config file if present
-          fortitude check src/
+          . ftorch_venv/bin/activate
+          fortitude check --ignore=E001,T041 src/ftorch.F90
+          fortitude check src/ftorch_test_utils.f90
 
       # Apply C++ and C linter and formatter, clang
       # Configurable using the .clang-format and .clang-tidy config files if present

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -114,7 +114,7 @@ jobs:
           style: 'file'
           tidy-checks: ''
           # Use the compile_commands.json from CMake to locate headers
-          database: ${{ github.workspace }}/src/build
+          database: ${{ github.workspace }}/build
           # only 'update' a single comment in a pull request thread.
           thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
       - name: Fail fast?!

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,10 @@ project(
   VERSION ${PACKAGE_VERSION}
   LANGUAGES C CXX Fortran)
 
-# Set GPU device type using consistent numbering as in PyTorch
-# NOTE: numbered consistently with
-#       https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
-option(GPU_DEVICE "Set the GPU device (NONE, CUDA, XPU, or MPS, defaulting to NONE)" NONE)
+# Set GPU device type using consistent numbering as in PyTorch NOTE: numbered
+# consistently with
+# https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
+option(GPU_DEVICE "Set the GPU device (NONE [default], CUDA, XPU, or MPS)" NONE)
 if("${GPU_DEVICE}" STREQUAL "NONE")
   set(GPU_DEVICE_CODE 0)
 elseif("${GPU_DEVICE}" STREQUAL "CUDA")
@@ -79,7 +79,8 @@ add_library(${LIB_NAME} SHARED src/ctorch.cpp src/ftorch.F90
 
 if(UNIX AND NOT APPLE)
   # only add UNIX definition for linux (not apple which is also unix)
-  target_compile_definitions(${LIB_NAME} PRIVATE UNIX GPU_DEVICE=${GPU_DEVICE_CODE})
+  target_compile_definitions(${LIB_NAME} PRIVATE UNIX
+                                                 GPU_DEVICE=${GPU_DEVICE_CODE})
 else()
   target_compile_definitions(${LIB_NAME} PRIVATE GPU_DEVICE=${GPU_DEVICE_CODE})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ project(
 # consistently with
 # https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
 option(GPU_DEVICE "Set the GPU device (NONE [default], CUDA, XPU, or MPS)" NONE)
+if("${GPU_DEVICE}" STREQUAL "OFF")
+  set(GPU_DEVICE NONE)
+endif()
 if("${GPU_DEVICE}" STREQUAL "NONE")
   set(GPU_DEVICE_CODE 0)
 elseif("${GPU_DEVICE}" STREQUAL "CUDA")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(
   VERSION ${PACKAGE_VERSION}
   LANGUAGES C CXX Fortran)
 
+option(ENABLE_CUDA "Enable running on CUDA GPU devices" OFF)
+option(ENABLE_XPU "Enable running on XPU GPU devices" OFF)
+
 if(WIN32)
   # if building on windows we need to make sure the symbols are exported
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# GPU specific setup
 include(CheckLanguage)
 if(ENABLE_CUDA)
   check_language(CUDA)
@@ -30,6 +31,9 @@ if(ENABLE_CUDA)
   else()
     message(WARNING "No CUDA support")
   endif()
+endif()
+if(ENABLE_XPU)
+  set(CMAKE_Fortran_FLAGS "-fpscomp logicals ${CMAKE_Fortran_FLAGS}")
 endif()
 
 # Set RPATH behaviour

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,25 +8,6 @@ project(
   VERSION ${PACKAGE_VERSION}
   LANGUAGES C CXX Fortran)
 
-# Set GPU device type using consistent numbering as in PyTorch NOTE: numbered
-# consistently with
-# https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
-option(GPU_DEVICE "Set the GPU device (NONE [default], CUDA, XPU, or MPS)" NONE)
-if("${GPU_DEVICE}" STREQUAL "OFF")
-  set(GPU_DEVICE NONE)
-endif()
-if("${GPU_DEVICE}" STREQUAL "NONE")
-  set(GPU_DEVICE_CODE 0)
-elseif("${GPU_DEVICE}" STREQUAL "CUDA")
-  set(GPU_DEVICE_CODE 1)
-elseif("${GPU_DEVICE}" STREQUAL "XPU")
-  set(GPU_DEVICE_CODE 12)
-elseif("${GPU_DEVICE}" STREQUAL "MPS")
-  set(GPU_DEVICE_CODE 13)
-else()
-  message(SEND_ERROR "GPU_DEVICE '${GPU_DEVICE}' not recognised")
-endif()
-
 if(WIN32)
   # if building on windows we need to make sure the symbols are exported
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
@@ -41,7 +22,29 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# GPU specific setup
+# Set GPU device type using consistent numbering as in PyTorch
+# https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
+set(GPU_DEVICE_NONE 0)
+set(GPU_DEVICE_CUDA 1)
+set(GPU_DEVICE_XPU 12)
+set(GPU_DEVICE_MPS 13)
+option(GPU_DEVICE "Set the GPU device (NONE [default], CUDA, XPU, or MPS)" NONE)
+if("${GPU_DEVICE}" STREQUAL "OFF")
+  set(GPU_DEVICE NONE)
+endif()
+if("${GPU_DEVICE}" STREQUAL "NONE")
+  set(GPU_DEVICE_CODE ${GPU_DEVICE_NONE})
+elseif("${GPU_DEVICE}" STREQUAL "CUDA")
+  set(GPU_DEVICE_CODE ${GPU_DEVICE_CUDA})
+elseif("${GPU_DEVICE}" STREQUAL "XPU")
+  set(GPU_DEVICE_CODE ${GPU_DEVICE_XPU})
+elseif("${GPU_DEVICE}" STREQUAL "MPS")
+  set(GPU_DEVICE_CODE ${GPU_DEVICE_MPS})
+else()
+  message(SEND_ERROR "GPU_DEVICE '${GPU_DEVICE}' not recognised")
+endif()
+
+# Other GPU specific setup
 include(CheckLanguage)
 if("${GPU_DEVICE}" STREQUAL "CUDA")
   check_language(CUDA)
@@ -51,7 +54,7 @@ if("${GPU_DEVICE}" STREQUAL "CUDA")
     message(WARNING "No CUDA support")
   endif()
 endif()
-if(ENABLE_XPU)
+if("${GPU_DEVICE}" STREQUAL "XPU")
   set(CMAKE_Fortran_FLAGS "-fpscomp logicals ${CMAKE_Fortran_FLAGS}")
 endif()
 
@@ -80,13 +83,18 @@ find_package(Torch REQUIRED)
 add_library(${LIB_NAME} SHARED src/ctorch.cpp src/ftorch.F90
                                src/ftorch_test_utils.f90)
 
+# Define compile definitions, including GPU devices
+set(COMPILE_DEFS "")
 if(UNIX AND NOT APPLE)
   # only add UNIX definition for linux (not apple which is also unix)
-  target_compile_definitions(${LIB_NAME} PRIVATE UNIX
-                                                 GPU_DEVICE=${GPU_DEVICE_CODE})
-else()
-  target_compile_definitions(${LIB_NAME} PRIVATE GPU_DEVICE=${GPU_DEVICE_CODE})
+  set(COMPILE_DEFS UNIX)
 endif()
+target_compile_definitions(${LIB_NAME} PRIVATE ${COMPILE_DEFS}
+                                                GPU_DEVICE=${GPU_DEVICE_CODE}
+                                                GPU_DEVICE_NONE=${GPU_DEVICE_NONE}
+                                                GPU_DEVICE_CUDA=${GPU_DEVICE_CUDA}
+                                                GPU_DEVICE_XPU=${GPU_DEVICE_XPU}
+                                                GPU_DEVICE_MPS=${GPU_DEVICE_MPS})
 
 # Add an alias FTorch::ftorch for the library
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,12 +89,11 @@ if(UNIX AND NOT APPLE)
   # only add UNIX definition for linux (not apple which is also unix)
   set(COMPILE_DEFS UNIX)
 endif()
-target_compile_definitions(${LIB_NAME} PRIVATE ${COMPILE_DEFS}
-                                                GPU_DEVICE=${GPU_DEVICE_CODE}
-                                                GPU_DEVICE_NONE=${GPU_DEVICE_NONE}
-                                                GPU_DEVICE_CUDA=${GPU_DEVICE_CUDA}
-                                                GPU_DEVICE_XPU=${GPU_DEVICE_XPU}
-                                                GPU_DEVICE_MPS=${GPU_DEVICE_MPS})
+target_compile_definitions(
+  ${LIB_NAME}
+  PRIVATE ${COMPILE_DEFS} GPU_DEVICE=${GPU_DEVICE_CODE}
+          GPU_DEVICE_NONE=${GPU_DEVICE_NONE} GPU_DEVICE_CUDA=${GPU_DEVICE_CUDA}
+          GPU_DEVICE_XPU=${GPU_DEVICE_XPU} GPU_DEVICE_MPS=${GPU_DEVICE_MPS})
 
 # Add an alias FTorch::ftorch for the library
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,21 @@ project(
   VERSION ${PACKAGE_VERSION}
   LANGUAGES C CXX Fortran)
 
-option(ENABLE_CUDA "Enable running on CUDA GPU devices" OFF)
-option(ENABLE_XPU "Enable running on XPU GPU devices" OFF)
+# Set GPU device type using consistent numbering as in PyTorch
+# NOTE: numbered consistently with
+#       https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
+option(GPU_DEVICE "Set the GPU device (NONE, CUDA, XPU, or MPS, defaulting to NONE)" NONE)
+if("${GPU_DEVICE}" STREQUAL "NONE")
+  set(GPU_DEVICE_CODE 0)
+elseif("${GPU_DEVICE}" STREQUAL "CUDA")
+  set(GPU_DEVICE_CODE 1)
+elseif("${GPU_DEVICE}" STREQUAL "XPU")
+  set(GPU_DEVICE_CODE 12)
+elseif("${GPU_DEVICE}" STREQUAL "MPS")
+  set(GPU_DEVICE_CODE 13)
+else()
+  message(SEND_ERROR "GPU_DEVICE '${GPU_DEVICE}' not recognised")
+endif()
 
 if(WIN32)
   # if building on windows we need to make sure the symbols are exported
@@ -27,7 +40,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # GPU specific setup
 include(CheckLanguage)
-if(ENABLE_CUDA)
+if("${GPU_DEVICE}" STREQUAL "CUDA")
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
@@ -64,10 +77,11 @@ find_package(Torch REQUIRED)
 add_library(${LIB_NAME} SHARED src/ctorch.cpp src/ftorch.F90
                                src/ftorch_test_utils.f90)
 
-if(UNIX)
-  if(NOT APPLE) # only add definition for linux (not apple which is also unix)
-    target_compile_definitions(${LIB_NAME} PRIVATE UNIX)
-  endif()
+if(UNIX AND NOT APPLE)
+  # only add UNIX definition for linux (not apple which is also unix)
+  target_compile_definitions(${LIB_NAME} PRIVATE UNIX GPU_DEVICE=${GPU_DEVICE_CODE})
+else()
+  target_compile_definitions(${LIB_NAME} PRIVATE GPU_DEVICE=${GPU_DEVICE_CODE})
 endif()
 
 # Add an alias FTorch::ftorch for the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,6 @@ if("${GPU_DEVICE}" STREQUAL "CUDA")
     message(WARNING "No CUDA support")
   endif()
 endif()
-if("${GPU_DEVICE}" STREQUAL "XPU")
-  set(CMAKE_Fortran_FLAGS "-fpscomp logicals ${CMAKE_Fortran_FLAGS}")
-endif()
 
 # Set RPATH behaviour
 set(CMAKE_SKIP_RPATH FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Set GPU device type using consistent numbering as in PyTorch
 # https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
-# Set in a single location here and passed as preprocessor flag for use throughout source files.
+# Set in a single location here and passed as preprocessor flag for use
+# throughout source files.
 set(GPU_DEVICE_NONE 0)
 set(GPU_DEVICE_CUDA 1)
 set(GPU_DEVICE_XPU 12)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Set GPU device type using consistent numbering as in PyTorch
 # https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
+# Set in a single location here and passed as preprocessor flag for use throughout source files.
 set(GPU_DEVICE_NONE 0)
 set(GPU_DEVICE_CUDA 1)
 set(GPU_DEVICE_XPU 12)

--- a/README.md
+++ b/README.md
@@ -219,12 +219,16 @@ These steps are described in more detail in the
 
 ## GPU Support
 
-To run on GPU requires a CUDA-compatible installation of LibTorch and two main
-adaptations to the code:
+To run on GPU requires an installation of LibTorch compatible for the GPU device
+you wish to target and two main adaptations to the code:
 
-1. When saving a TorchScript model, ensure that it is on the GPU
+1. When saving a TorchScript model, ensure that it is on the appropriate GPU
+   device type. The `pt2ts.py` script has a command line argument
+   `--device_type`, which currently accepts four different device types: `cpu`
+   (default), `cuda`, `xpu`, or `mps`.
 2. When using FTorch in Fortran, set the device for the input
-   tensor(s) to `torch_kCUDA`, rather than `torch_kCPU`.
+   tensor(s) to the appropriate GPU device type, rather than `torch_kCPU`. There
+   are currently three options: `torch_kCUDA`, `torch_kXPU`, or `torch_kMPS`.
 
 For detailed guidance about running on GPU, including instructions for using multiple
 devices, please see the

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ To build and install the library:
     | [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)  | `</path/to/install/lib/at/>` | Location at which the library files should be installed. By default this is `/usr/local` |
     | [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)          | `Release` / `Debug`          | Specifies build type. The default is `Debug`, use `Release` for production code|
     | `CMAKE_BUILD_TESTS`                                                                               | `TRUE` / `FALSE`             | Specifies whether to compile FTorch's [test suite](https://cambridge-iccs.github.io/FTorch/page/testing.html) as part of the build. |
-    | `ENABLE_CUDA`                                                                                     | `TRUE` / `FALSE`             | Specifies whether to check for and enable CUDA<sup>3</sup> |
+    | `GPU_DEVICE` | `NONE` / `CUDA` / `XPU` / `MPS` | Specifies the target GPU architecture (if any) <sup>3</sup> |
 
     <sup>1</sup> _On Windows this may need to be the full path to the compiler if CMake cannot locate it by default._  
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,9 @@ To build and install the library:
           e.g. with `pip install torch`, then this should be `</path/to/venv/>lib/python<3.xx>/site-packages/torch/`.  
 		  You can find the location of your torch install by importing torch from your Python environment (`import torch`) and running `print(torch.__file__)`_
 
-    <sup>3</sup> _This is often overridden by PyTorch. When installing with pip, the `index-url` flag can be used to ensure a CPU or GPU only version is installed, e.g.
-          `pip install torch --index-url https://download.pytorch.org/whl/cpu`
-          or
-          `pip install torch --index-url https://download.pytorch.org/whl/cu118`
-          (for CUDA 11.8). URLs for alternative versions can be found [here](https://pytorch.org/get-started/locally/)._
+    <sup>3</sup> _This is often overridden by PyTorch. When installing with pip, the `index-url` flag can be used to ensure a CPU-only or GPU-enabled version is installed, e.g.
+          `pip install torch --index-url https://download.pytorch.org/whl/cpu`.
+          URLs for alternative versions can be found [here](https://pytorch.org/get-started/locally/)._
 
 4. Make and install the library to the desired location with either:
 	```

--- a/conda/README.md
+++ b/conda/README.md
@@ -38,7 +38,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
     -DCMAKE_PREFIX_PATH=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)') \
     -DCMAKE_BUILD_TYPE=Release \
-    -DENABLE_CUDA=FALSE \
+    -DGPU_DEVICE=NONE \
     ..
 cmake --build . --target install
 ```
@@ -65,7 +65,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
     -DCMAKE_PREFIX_PATH=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)') \
     -DCMAKE_BUILD_TYPE=Release \
-    -DENABLE_CUDA=TRUE \
+    -DGPU_DEVICE=CUDA \
     -DCUDA_TOOLKIT_ROOT_DIR=$CONDA_PREFIX/targets/x86_64-linux \
     -Dnvtx3_dir=$CONDA_PREFIX/targets/x86_64-linux/include/nvtx3 \
     ..

--- a/examples/1_SimpleNet/CMakeLists.txt
+++ b/examples/1_SimpleNet/CMakeLists.txt
@@ -33,9 +33,8 @@ if(CMAKE_BUILD_TESTS)
   #   pt2ts.py script
   add_test(
     NAME pt2ts
-    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
-                                  # the model
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --filepath
+            ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 3. Check the model can be loaded from file and run in Python and that its
@@ -43,8 +42,7 @@ if(CMAKE_BUILD_TESTS)
   add_test(
     NAME simplenet_infer_python
     COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet_infer_python.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the
-                                  # model
+            --filepath ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 4. Check the model can be loaded from file and run in Fortran and that its

--- a/examples/1_SimpleNet/pt2ts.py
+++ b/examples/1_SimpleNet/pt2ts.py
@@ -72,6 +72,28 @@ def load_torchscript(filename: Optional[str] = "saved_model.pt") -> torch.nn.Mod
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--device_type",
+        help="Device type to run the inference on",
+        type=str,
+        choices=["cpu", "cuda", "xpu", "mps"],
+        default="cpu",
+    )
+    parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parsed_args = parser.parse_args()
+    device_type = parsed_args.device_type
+    filepath = parsed_args.filepath
+
     # =====================================================
     # Load model and prepare for saving
     # =====================================================
@@ -97,12 +119,12 @@ if __name__ == "__main__":
     # This example assumes one input of size (5)
     trained_model_dummy_input = torch.ones(5)
 
-    # FPTLIB-TODO
-    # Uncomment the following lines to save for inference on GPU (rather than CPU):
-    # device = torch.device('cuda')
-    # trained_model = trained_model.to(device)
-    # trained_model.eval()
-    # trained_model_dummy_input = trained_model_dummy_input.to(device)
+    # Transfer the model and inputs to GPU device, if appropriate
+    if device_type != "cpu":
+        device = torch.device(device_type)
+        trained_model = trained_model.to(device)
+        trained_model.eval()
+        trained_model_dummy_input = trained_model_dummy_input.to(device)
 
     # FPTLIB-TODO
     # Run model for dummy inputs
@@ -117,7 +139,7 @@ if __name__ == "__main__":
 
     # FPTLIB-TODO
     # Set the name of the file you want to save the torchscript model to:
-    saved_ts_filename = "saved_simplenet_model_cpu.pt"
+    saved_ts_filename = f"saved_simplenet_model_{device_type}.pt"
     # A filepath may also be provided. To do this, pass the filepath as an argument to
     # this script when it is run from the command line, i.e. `./pt2ts.py path/to/model`.
 
@@ -141,9 +163,7 @@ if __name__ == "__main__":
     # Check model saved OK
     # =====================================================
 
-    # Load torchscript and run model as a test
-    # FPTLIB-TODO
-    # Scale inputs as above and, if required, move inputs and mode to GPU
+    # Load torchscript and run model as a test, scaling inputs as above
     trained_model_dummy_input = 2.0 * trained_model_dummy_input
     trained_model_testing_outputs = trained_model(
         trained_model_dummy_input,
@@ -169,7 +189,6 @@ if __name__ == "__main__":
             raise RuntimeError(model_error)
 
     # Check that the model file is created
-    filepath = os.path.dirname(__file__) if len(sys.argv) == 1 else sys.argv[1]
     if not os.path.exists(os.path.join(filepath, saved_ts_filename)):
         torchscript_file_error = (
             f"Saved TorchScript file {os.path.join(filepath, saved_ts_filename)} "

--- a/examples/1_SimpleNet/pt2ts.py
+++ b/examples/1_SimpleNet/pt2ts.py
@@ -1,7 +1,6 @@
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os
-import sys
 from typing import Optional
 
 # FPTLIB-TODO

--- a/examples/1_SimpleNet/simplenet_infer_python.py
+++ b/examples/1_SimpleNet/simplenet_infer_python.py
@@ -1,7 +1,6 @@
 """Load saved SimpleNet to TorchScript and run inference example."""
 
 import os
-import sys
 
 import torch
 

--- a/examples/1_SimpleNet/simplenet_infer_python.py
+++ b/examples/1_SimpleNet/simplenet_infer_python.py
@@ -49,7 +49,19 @@ def deploy(saved_model: str, device: str, batch_size: int = 1) -> torch.Tensor:
 
 
 if __name__ == "__main__":
-    filepath = os.path.dirname(__file__) if len(sys.argv) == 1 else sys.argv[1]
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parsed_args = parser.parse_args()
+    filepath = parsed_args.filepath
     saved_model_file = os.path.join(filepath, "saved_simplenet_model_cpu.pt")
 
     device_to_run = "cpu"

--- a/examples/2_ResNet18/CMakeLists.txt
+++ b/examples/2_ResNet18/CMakeLists.txt
@@ -35,9 +35,8 @@ if(CMAKE_BUILD_TESTS)
   #   pt2ts.py script
   add_test(
     NAME pt2ts
-    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
-                                  # the model
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --filepath
+            ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 3. Check the model can be loaded from file and run in Fortran and that its

--- a/examples/2_ResNet18/pt2ts.py
+++ b/examples/2_ResNet18/pt2ts.py
@@ -75,6 +75,28 @@ def load_torchscript(filename: Optional[str] = "saved_model.pt") -> torch.nn.Mod
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--device_type",
+        help="Device type to run the inference on",
+        type=str,
+        choices=["cpu", "cuda", "xpu", "mps"],
+        default="cpu",
+    )
+    parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parsed_args = parser.parse_args()
+    device_type = parsed_args.device_type
+    filepath = parsed_args.filepath
+
     # =====================================================
     # Load model and prepare for saving
     # =====================================================
@@ -103,12 +125,12 @@ if __name__ == "__main__":
     # of resolution 244x244 in a batch size of 1.
     trained_model_dummy_input = torch.ones(1, 3, 224, 224)
 
-    # FPTLIB-TODO
-    # Uncomment the following lines to save for inference on GPU (rather than CPU):
-    # device = torch.device('cuda')
-    # trained_model = trained_model.to(device)
-    # trained_model.eval()
-    # trained_model_dummy_input = trained_model_dummy_input.to(device)
+    # Transfer the model and inputs to GPU device, if appropriate
+    if device_type != "cpu":
+        device = torch.device(device_type)
+        trained_model = trained_model.to(device)
+        trained_model.eval()
+        trained_model_dummy_input = trained_model_dummy_input.to(device)
 
     # FPTLIB-TODO
     # Run model for dummy inputs
@@ -123,7 +145,7 @@ if __name__ == "__main__":
 
     # FPTLIB-TODO
     # Set the name of the file you want to save the torchscript model to:
-    saved_ts_filename = "saved_resnet18_model_cpu.pt"
+    saved_ts_filename = f"saved_resnet18_model_{device_type}.pt"
     # A filepath may also be provided. To do this, pass the filepath as an argument to
     # this script when it is run from the command line, i.e. `./pt2ts.py path/to/model`.
 
@@ -147,9 +169,7 @@ if __name__ == "__main__":
     # Check model saved OK
     # =====================================================
 
-    # Load torchscript and run model as a test
-    # FPTLIB-TODO
-    # Scale inputs as above and, if required, move inputs and mode to GPU
+    # Load torchscript and run model as a test, scaling inputs as above
     trained_model_dummy_input = 2.0 * trained_model_dummy_input
     trained_model_testing_outputs = trained_model(
         trained_model_dummy_input,
@@ -175,7 +195,6 @@ if __name__ == "__main__":
             raise RuntimeError(model_error)
 
     # Check that the model file is created
-    filepath = os.path.dirname(__file__) if len(sys.argv) == 1 else sys.argv[1]
     if not os.path.exists(os.path.join(filepath, saved_ts_filename)):
         torchscript_file_error = (
             f"Saved TorchScript file {os.path.join(filepath, saved_ts_filename)} "

--- a/examples/2_ResNet18/pt2ts.py
+++ b/examples/2_ResNet18/pt2ts.py
@@ -1,7 +1,6 @@
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os
-import sys
 from typing import Optional
 
 # FPTLIB-TODO

--- a/examples/2_ResNet18/resnet_infer_python.py
+++ b/examples/2_ResNet18/resnet_infer_python.py
@@ -1,7 +1,6 @@
 """Load ResNet-18 saved to TorchScript and run inference with an example image."""
 
 import os
-import sys
 from math import isclose
 
 import numpy as np

--- a/examples/2_ResNet18/resnet_infer_python.py
+++ b/examples/2_ResNet18/resnet_infer_python.py
@@ -78,11 +78,22 @@ def check_results(output: torch.Tensor) -> None:
 
 
 if __name__ == "__main__":
-    filepath = os.path.dirname(__file__) if len(sys.argv) == 1 else sys.argv[1]
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parsed_args = parser.parse_args()
+    filepath = parsed_args.filepath
     saved_model_file = os.path.join(filepath, "saved_resnet18_model_cpu.pt")
 
     device_to_run = "cpu"
-    # device_to_run = "cuda"
 
     batch_size_to_run = 1
 

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -92,6 +92,7 @@ if(CMAKE_BUILD_TESTS)
       NAME multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type xpu
+              --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
     # 4b. Check the model can be loaded from file and run on two XPU devices in

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -50,16 +50,16 @@ if(CMAKE_BUILD_TESTS)
               cuda --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3a. Check the model can be loaded from file and run on two CUDA devices
-    # in Python and that its outputs meet expectations
+    # 3a. Check the model can be loaded from file and run on two CUDA devices in
+    # Python and that its outputs meet expectations
     add_test(
       NAME multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type cuda
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4a. Check the model can be loaded from file and run on two CUDA devices
-    # in Fortran and that its outputs meet expectations
+    # 4a. Check the model can be loaded from file and run on two CUDA devices in
+    # Fortran and that its outputs meet expectations
     add_test(
       NAME multigpu_infer_fortran
       COMMAND multigpu_infer_fortran cuda
@@ -86,16 +86,16 @@ if(CMAKE_BUILD_TESTS)
               xpu --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3b. Check the model can be loaded from file and run on two XPU devices
-    # in Python and that its outputs meet expectations
+    # 3b. Check the model can be loaded from file and run on two XPU devices in
+    # Python and that its outputs meet expectations
     add_test(
       NAME multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type xpu
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4b. Check the model can be loaded from file and run on two XPU devices
-    # in Fortran and that its outputs meet expectations
+    # 4b. Check the model can be loaded from file and run on two XPU devices in
+    # Fortran and that its outputs meet expectations
     add_test(
       NAME multigpu_infer_fortran
       COMMAND multigpu_infer_fortran xpu

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   if(ENABLE_CUDA)
-    # 1a. Check the PyTorch model runs and its outputs meet expectations
+    # 1a. Check the PyTorch model runs on a CUDA device and its outputs meet expectations
     add_test(NAME simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type cuda)
@@ -49,7 +49,7 @@ if(CMAKE_BUILD_TESTS)
               cuda --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3a. Check the model can be loaded from file and run in Python and that its
+    # 3a. Check the model can be loaded from file and run on two CUDA devices in Python and that its
     # outputs meet expectations
     add_test(
       NAME multigpu_infer_python
@@ -57,7 +57,7 @@ if(CMAKE_BUILD_TESTS)
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type cuda
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4a. Check the model can be loaded from file and run in Fortran and that
+    # 4a. Check the model can be loaded from file and run on two CUDA devices in Fortran and that
     # its outputs meet expectations
     add_test(
       NAME multigpu_infer_fortran
@@ -71,7 +71,7 @@ if(CMAKE_BUILD_TESTS)
   endif()
 
   if(ENABLE_XPU)
-    # 1b. Check the PyTorch model runs and its outputs meet expectations
+    # 1b. Check the PyTorch model runs on an XPU device and its outputs meet expectations
     add_test(NAME simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type xpu)
@@ -84,7 +84,7 @@ if(CMAKE_BUILD_TESTS)
               xpu --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3b. Check the model can be loaded from file and run in Python and that its
+    # 3b. Check the model can be loaded from file and run on two XPU devices in Python and that its
     # outputs meet expectations
     add_test(
       NAME multigpu_infer_python
@@ -92,7 +92,7 @@ if(CMAKE_BUILD_TESTS)
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type xpu
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4b. Check the model can be loaded from file and run in Fortran and that
+    # 4b. Check the model can be loaded from file and run on two XPU devices in Fortran and that
     # its outputs meet expectations
     add_test(
       NAME multigpu_infer_fortran
@@ -103,5 +103,12 @@ if(CMAKE_BUILD_TESTS)
     set_tests_properties(
       multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
                                         "MultiGPU example ran successfully")
+  endif()
+
+  if(ENABLE_MPS)
+    # 1c. Check the PyTorch model runs on an MPS device and its outputs meet expectations
+    add_test(NAME simplenet
+             COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
+                     --device_type mps)
   endif()
 endif()

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(FTorch)
 message(STATUS "Building with Fortran PyTorch coupling")
 
 include(CheckLanguage)
-if(ENABLE_CUDA)
+if("${GPU_DEVICE}" STREQUAL "CUDA")
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
@@ -35,7 +35,7 @@ target_link_libraries(multigpu_infer_fortran PRIVATE FTorch::ftorch)
 if(CMAKE_BUILD_TESTS)
   include(CTest)
 
-  if(ENABLE_CUDA)
+  if("${GPU_DEVICE}" STREQUAL "CUDA")
     # 1a. Check the PyTorch model runs on a CUDA device and its outputs meet
     # expectations
     add_test(NAME simplenet
@@ -71,7 +71,7 @@ if(CMAKE_BUILD_TESTS)
                                         "MultiGPU example ran successfully")
   endif()
 
-  if(ENABLE_XPU)
+  if("${GPU_DEVICE}" STREQUAL "XPU")
     # 1b. Check the PyTorch model runs on an XPU device and its outputs meet
     # expectations
     add_test(NAME simplenet
@@ -107,7 +107,7 @@ if(CMAKE_BUILD_TESTS)
                                         "MultiGPU example ran successfully")
   endif()
 
-  if(ENABLE_MPS)
+  if("${GPU_DEVICE}" STREQUAL "MPS")
     # 1c. Check the PyTorch model runs on an MPS device and its outputs meet
     # expectations
     add_test(NAME simplenet

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -114,5 +114,33 @@ if(CMAKE_BUILD_TESTS)
     add_test(NAME simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type mps)
+    # 2c. Check the model is saved to file in the expected location with the
+    # pt2ts.py script
+    add_test(
+      NAME pt2ts
+      COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --device_type
+              mps --filepath ${PROJECT_BINARY_DIR}
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+
+    # 3c. Check the model can be loaded from file and run on one MPS device in
+    # Python and that its outputs meet expectations
+    add_test(
+      NAME multigpu_infer_python
+      COMMAND ${Python_EXECUTABLE}
+              ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type mps
+              --filepath ${PROJECT_BINARY_DIR}
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+
+    # 4c. Check the model can be loaded from file and run on one MPS device in
+    # Fortran and that its outputs meet expectations
+    add_test(
+      NAME multigpu_infer_fortran
+      COMMAND multigpu_infer_fortran mps
+              ${PROJECT_BINARY_DIR}/saved_multigpu_model_mps.pt
+      # Command line arguments for device type and model file
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    set_tests_properties(
+      multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+                                        "MultiGPU example ran successfully")
   endif()
 endif()

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -32,57 +32,76 @@ add_executable(multigpu_infer_fortran multigpu_infer_fortran.f90)
 target_link_libraries(multigpu_infer_fortran PRIVATE FTorch::ftorch)
 
 # Integration testing
-if (CMAKE_BUILD_TESTS)
+if(CMAKE_BUILD_TESTS)
   include(CTest)
 
-  # 1. Check the PyTorch model runs and its outputs meet expectations
-  add_test(NAME simplenet COMMAND ${Python_EXECUTABLE}
-                                  ${PROJECT_SOURCE_DIR}/simplenet.py)
-
-  # 2. Check the model is saved to file in the expected location with the
-  #   pt2ts.py script
-  add_test(
-    NAME pt2ts
-    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
-                                  # the model
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-
-  # 3. Check the model can be loaded from file and run in Python and that its
-  #   outputs meet expectations
-  add_test(
-    NAME multigpu_infer_python
-    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the
-                                  # model
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  # TODO: Separate out XPU and CUDA
-
   if(ENABLE_CUDA)
-    # 4. Check the model can be loaded from file and run in Fortran and that its
-    #   outputs meet expectations
+    # 1a. Check the PyTorch model runs and its outputs meet expectations
+    add_test(NAME simplenet
+             COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
+                     --device_type cuda)
+
+    # 2a. Check the model is saved to file in the expected location with the
+    # pt2ts.py script
+    add_test(
+      NAME pt2ts
+      COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --device_type
+              cuda --filepath ${PROJECT_BINARY_DIR}
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+
+    # 3a. Check the model can be loaded from file and run in Python and that its
+    # outputs meet expectations
+    add_test(
+      NAME multigpu_infer_python
+      COMMAND ${Python_EXECUTABLE}
+              ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type cuda
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+
+    # 4a. Check the model can be loaded from file and run in Fortran and that
+    # its outputs meet expectations
     add_test(
       NAME multigpu_infer_fortran
-      COMMAND
-        multigpu_infer_fortran ${PROJECT_BINARY_DIR}/saved_multigpu_model_cuda.pt
-        # Command line argument: model file
+      COMMAND multigpu_infer_fortran cuda
+              ${PROJECT_BINARY_DIR}/saved_multigpu_model_cuda.pt
+      # Command line arguments for device type and model file
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     set_tests_properties(
       multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-      "MultiGPU example ran successfully")
+                                        "MultiGPU example ran successfully")
   endif()
 
   if(ENABLE_XPU)
-    # 5. Check the model can be loaded from file and run in Fortran and that its
-    #   outputs meet expectations
+    # 1b. Check the PyTorch model runs and its outputs meet expectations
+    add_test(NAME simplenet
+             COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
+                     --device_type xpu)
+
+    # 2b. Check the model is saved to file in the expected location with the
+    # pt2ts.py script
+    add_test(
+      NAME pt2ts
+      COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --device_type
+              xpu --filepath ${PROJECT_BINARY_DIR}
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+
+    # 3b. Check the model can be loaded from file and run in Python and that its
+    # outputs meet expectations
+    add_test(
+      NAME multigpu_infer_python
+      COMMAND ${Python_EXECUTABLE}
+              ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type xpu
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+
+    # 4b. Check the model can be loaded from file and run in Fortran and that
+    # its outputs meet expectations
     add_test(
       NAME multigpu_infer_fortran
-      COMMAND
-        multigpu_infer_fortran ${PROJECT_BINARY_DIR}/saved_multigpu_model_xpu.pt
-        # Command line argument: model file
+      COMMAND multigpu_infer_fortran xpu
+              ${PROJECT_BINARY_DIR}/saved_multigpu_model_xpu.pt
+      # Command line arguments for device type and model file
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     set_tests_properties(
       multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-      "MultiGPU example ran successfully")
+                                        "MultiGPU example ran successfully")
   endif()
 endif()

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -36,7 +36,8 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   if(ENABLE_CUDA)
-    # 1a. Check the PyTorch model runs on a CUDA device and its outputs meet expectations
+    # 1a. Check the PyTorch model runs on a CUDA device and its outputs meet
+    # expectations
     add_test(NAME simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type cuda)
@@ -49,16 +50,16 @@ if(CMAKE_BUILD_TESTS)
               cuda --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3a. Check the model can be loaded from file and run on two CUDA devices in Python and that its
-    # outputs meet expectations
+    # 3a. Check the model can be loaded from file and run on two CUDA devices
+    # in Python and that its outputs meet expectations
     add_test(
       NAME multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type cuda
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4a. Check the model can be loaded from file and run on two CUDA devices in Fortran and that
-    # its outputs meet expectations
+    # 4a. Check the model can be loaded from file and run on two CUDA devices
+    # in Fortran and that its outputs meet expectations
     add_test(
       NAME multigpu_infer_fortran
       COMMAND multigpu_infer_fortran cuda
@@ -71,7 +72,8 @@ if(CMAKE_BUILD_TESTS)
   endif()
 
   if(ENABLE_XPU)
-    # 1b. Check the PyTorch model runs on an XPU device and its outputs meet expectations
+    # 1b. Check the PyTorch model runs on an XPU device and its outputs meet
+    # expectations
     add_test(NAME simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type xpu)
@@ -84,16 +86,16 @@ if(CMAKE_BUILD_TESTS)
               xpu --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3b. Check the model can be loaded from file and run on two XPU devices in Python and that its
-    # outputs meet expectations
+    # 3b. Check the model can be loaded from file and run on two XPU devices
+    # in Python and that its outputs meet expectations
     add_test(
       NAME multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type xpu
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4b. Check the model can be loaded from file and run on two XPU devices in Fortran and that
-    # its outputs meet expectations
+    # 4b. Check the model can be loaded from file and run on two XPU devices
+    # in Fortran and that its outputs meet expectations
     add_test(
       NAME multigpu_infer_fortran
       COMMAND multigpu_infer_fortran xpu
@@ -106,7 +108,8 @@ if(CMAKE_BUILD_TESTS)
   endif()
 
   if(ENABLE_MPS)
-    # 1c. Check the PyTorch model runs on an MPS device and its outputs meet expectations
+    # 1c. Check the PyTorch model runs on an MPS device and its outputs meet
+    # expectations
     add_test(NAME simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type mps)

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -18,11 +18,13 @@ find_package(FTorch)
 message(STATUS "Building with Fortran PyTorch coupling")
 
 include(CheckLanguage)
-check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
-  enable_language(CUDA)
-else()
-  message(ERROR "No CUDA support")
+if(ENABLE_CUDA)
+  check_language(CUDA)
+  if(CMAKE_CUDA_COMPILER)
+    enable_language(CUDA)
+  else()
+    message(ERROR "No CUDA support")
+  endif()
 endif()
 
 # Fortran example
@@ -54,16 +56,33 @@ if (CMAKE_BUILD_TESTS)
             ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the
                                   # model
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+  # TODO: Separate out XPU and CUDA
 
-  # 4. Check the model can be loaded from file and run in Fortran and that its
-  #   outputs meet expectations
-  add_test(
-    NAME multigpu_infer_fortran
-    COMMAND
-      multigpu_infer_fortran ${PROJECT_BINARY_DIR}/saved_multigpu_model_cuda.pt
-      # Command line argument: model file
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  set_tests_properties(
-    multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-    "MultiGPU example ran successfully")
+  if(ENABLE_CUDA)
+    # 4. Check the model can be loaded from file and run in Fortran and that its
+    #   outputs meet expectations
+    add_test(
+      NAME multigpu_infer_fortran
+      COMMAND
+        multigpu_infer_fortran ${PROJECT_BINARY_DIR}/saved_multigpu_model_cuda.pt
+        # Command line argument: model file
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    set_tests_properties(
+      multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+      "MultiGPU example ran successfully")
+  endif()
+
+  if(ENABLE_XPU)
+    # 5. Check the model can be loaded from file and run in Fortran and that its
+    #   outputs meet expectations
+    add_test(
+      NAME multigpu_infer_fortran
+      COMMAND
+        multigpu_infer_fortran ${PROJECT_BINARY_DIR}/saved_multigpu_model_xpu.pt
+        # Command line argument: model file
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    set_tests_properties(
+      multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+      "MultiGPU example ran successfully")
+  endif()
 endif()

--- a/examples/3_MultiGPU/CMakeLists.txt
+++ b/examples/3_MultiGPU/CMakeLists.txt
@@ -56,6 +56,7 @@ if(CMAKE_BUILD_TESTS)
       NAME multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type cuda
+              --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
     # 4a. Check the model can be loaded from file and run on two CUDA devices in

--- a/examples/3_MultiGPU/README.md
+++ b/examples/3_MultiGPU/README.md
@@ -20,7 +20,7 @@ the TorchScript model in inference mode.
 To run this example requires:
 
 - CMake
-- Two (or more) CUDA or XPU GPU devices (or a single Mps device).
+- Two (or more) CUDA or XPU GPU devices (or a single MPS device).
 - FTorch (installed with a GPU_DEVICE enabled as described in main package)
 - Python 3
 
@@ -93,7 +93,7 @@ cmake --build .
 and should match the compiler that was used to locally build FTorch.)
 
 To run the compiled code calling the saved `SimpleNet` TorchScript from
-Fortran, run the executable with argumentsof device type and the saved model file:
+Fortran, run the executable with arguments of device type and the saved model file:
 ```
 ./multigpu_infer_fortran <cuda/xpu/mps> ../saved_multigpu_model_<cuda/xpu>.pt
 ```
@@ -106,7 +106,7 @@ input on device 1: [  1.0,  2.0,  3.0,  4.0,  5.0]
 output on device 0: [  0.0,  2.0,  4.0,  6.0,  8.0]
 output on device 1: [  2.0,  4.0,  6.0,  8.0, 10.0]
 ```
-Again, note that Mps will only use device 0.
+Again, note that MPS will only use device 0.
 
 Alternatively, we can use `make`, instead of CMake, copying the Makefile over from the
 first example:

--- a/examples/3_MultiGPU/README.md
+++ b/examples/3_MultiGPU/README.md
@@ -20,8 +20,8 @@ the TorchScript model in inference mode.
 To run this example requires:
 
 - CMake
-- Two (or more) CUDA or XPU GPU devices.
-- FTorch (installed with CUDA or XPU enabled as described in main package)
+- Two (or more) CUDA or XPU GPU devices (or a single Mps device).
+- FTorch (installed with a GPU_DEVICE enabled as described in main package)
 - Python 3
 
 ## Running
@@ -36,13 +36,10 @@ pip install -r requirements.txt
 
 You can check that everything is working by running `simplenet.py`:
 ```
-python3 simplenet.py --device_type cuda
+python3 simplenet.py --device_type <my_device_type>
 ```
-for a CUDA device or
-```
-python3 simplenet.py --device_type xpu
-```
-for an XPU device.
+where `<my_device_type>` is `cuda`/`xpu`/`mps` as appropriate for your device.
+
 As before, this defines the network and runs it with an input tensor
 [0.0, 1.0, 2.0, 3.0, 4.0]. The difference is that the code will make use of the
 default GPU device (index 0) to produce the result:
@@ -50,14 +47,14 @@ default GPU device (index 0) to produce the result:
 SimpleNet forward pass on CUDA device 0
 tensor([[0, 2, 4, 6, 8]])
 ```
-and similarly for XPU.
+for CUDA, and similarly for other device types.
 
 To save the `SimpleNet` model to TorchScript run the modified version of the
 `pt2ts.py` tool:
 ```
-python3 pt2ts.py --device_type <cuda/xpu>
+python3 pt2ts.py --device_type <my_device_type>
 ```
-which will generate `saved_multigpu_model_<cuda/xpu>.pt` - the TorchScript
+which will generate `saved_multigpu_model_<my_device_type>.pt` - the TorchScript
 instance of the network. The only difference with the earlier example is that
 the model is built to be run on GPU devices rather than on CPU.
 
@@ -65,7 +62,7 @@ You can check that everything is working by running the
 `multigpu_infer_python.py` script. It's set up such that it loops over two GPU
 devices. Run with:
 ```
-python3 multigpu_infer_python.py --device_type <cuda/xpu>
+python3 multigpu_infer_python.py --device_type <my_device_type>
 ```
 This reads the model in from the TorchScript file and runs it with an different input
 tensor on each GPU device: [0.0, 1.0, 2.0, 3.0, 4.0], plus the device index in each
@@ -74,6 +71,7 @@ entry. The result should be:
 Output on device 0: tensor([[0., 2., 4., 6., 8.]])
 Output on device 1: tensor([[ 2., 4.,  6.,  8., 10.]])
 ```
+Note that Mps will only use device 0.
 
 At this point we no longer require Python, so can deactivate the virtual environment:
 ```
@@ -95,9 +93,9 @@ cmake --build .
 and should match the compiler that was used to locally build FTorch.)
 
 To run the compiled code calling the saved `SimpleNet` TorchScript from
-Fortran, run the executable with an argument of the saved model file:
+Fortran, run the executable with argumentsof device type and the saved model file:
 ```
-./multigpu_infer_fortran ../saved_multigpu_model_<cuda/xpu>.pt
+./multigpu_infer_fortran <cuda/xpu/mps> ../saved_multigpu_model_<cuda/xpu>.pt
 ```
 
 This runs the model with the same inputs as described above and should produce (some
@@ -108,6 +106,7 @@ input on device 1: [  1.0,  2.0,  3.0,  4.0,  5.0]
 output on device 0: [  0.0,  2.0,  4.0,  6.0,  8.0]
 output on device 1: [  2.0,  4.0,  6.0,  8.0, 10.0]
 ```
+Again, note that Mps will only use device 0.
 
 Alternatively, we can use `make`, instead of CMake, copying the Makefile over from the
 first example:

--- a/examples/3_MultiGPU/README.md
+++ b/examples/3_MultiGPU/README.md
@@ -20,8 +20,8 @@ the TorchScript model in inference mode.
 To run this example requires:
 
 - CMake
-- Two (or more) GPU devices that support CUDA and have it installed.
-- FTorch (installed with CUDA enabled as described in main package)
+- Two (or more) CUDA or XPU GPU devices.
+- FTorch (installed with CUDA or XPU enabled as described in main package)
 - Python 3
 
 ## Running
@@ -36,30 +36,36 @@ pip install -r requirements.txt
 
 You can check that everything is working by running `simplenet.py`:
 ```
-python3 simplenet.py
+python3 simplenet.py --device_type cuda
 ```
+for a CUDA device or
+```
+python3 simplenet.py --device_type xpu
+```
+for an XPU device.
 As before, this defines the network and runs it with an input tensor
 [0.0, 1.0, 2.0, 3.0, 4.0]. The difference is that the code will make use of the
-default CUDA device (index 0) to produce the result:
+default GPU device (index 0) to produce the result:
 ```
 SimpleNet forward pass on CUDA device 0
 tensor([[0, 2, 4, 6, 8]])
 ```
+and similarly for XPU.
 
 To save the `SimpleNet` model to TorchScript run the modified version of the
 `pt2ts.py` tool:
 ```
-python3 pt2ts.py
+python3 pt2ts.py --device_type <cuda/xpu>
 ```
-which will generate `saved_multigpu_model_cuda.pt` - the TorchScript instance
-of the network. The only difference with the earlier example is that the model
-is built to be run using CUDA rather than on CPU.
+which will generate `saved_multigpu_model_<cuda/xpu>.pt` - the TorchScript
+instance of the network. The only difference with the earlier example is that
+the model is built to be run on GPU devices rather than on CPU.
 
 You can check that everything is working by running the
 `multigpu_infer_python.py` script. It's set up such that it loops over two GPU
 devices. Run with:
 ```
-python3 multigpu_infer_python.py
+python3 multigpu_infer_python.py --device_type <cuda/xpu>
 ```
 This reads the model in from the TorchScript file and runs it with an different input
 tensor on each GPU device: [0.0, 1.0, 2.0, 3.0, 4.0], plus the device index in each
@@ -91,7 +97,7 @@ and should match the compiler that was used to locally build FTorch.)
 To run the compiled code calling the saved `SimpleNet` TorchScript from
 Fortran, run the executable with an argument of the saved model file:
 ```
-./multigpu_infer_fortran ../saved_multigpu_model_cuda.pt
+./multigpu_infer_fortran ../saved_multigpu_model_<cuda/xpu>.pt
 ```
 
 This runs the model with the same inputs as described above and should produce (some

--- a/examples/3_MultiGPU/multigpu_infer_fortran.f90
+++ b/examples/3_MultiGPU/multigpu_infer_fortran.f90
@@ -87,7 +87,7 @@ program inference
       200 format("output on device ", i1,": [", 4(f5.1,","), f5.1,"]")
 
       ! Check output tensor matches expected value
-      expected = [(device_index + 2*i, i = 0, 4)]
+      expected = [(2 * (device_index + i), i = 0, 4)]
       test_pass = assert_allclose(out_data, expected, test_name="MultiGPU")
 
       ! Cleanup

--- a/examples/3_MultiGPU/multigpu_infer_fortran.f90
+++ b/examples/3_MultiGPU/multigpu_infer_fortran.f90
@@ -30,15 +30,21 @@ program inference
    integer, parameter :: num_devices = 2
    integer :: device_type, device_index, i
 
-   ! Get TorchScript model file as a command line argument
+   ! Get device type as first command line argument and TorchScript model file as second command
+   ! line argument
    num_args = command_argument_count()
    allocate(args(num_args))
    do ix = 1, num_args
       call get_command_argument(ix,args(ix))
    end do
-
-   ! TODO: Accept command line argument for device type
-   device_type = torch_kCUDA
+   if (trim(args(1)) == "cuda") then
+      device_type = torch_kCUDA
+   else if (trim(args(1)) == "xpu") then
+      device_type = torch_kXPU
+   else
+      write (*,*) "Error :: invalid device type", trim(args(1))
+      stop 999
+   end if
 
    do device_index = 0, num_devices-1
 
@@ -60,7 +66,7 @@ program inference
 
       ! Load ML model. Ensure that the same device type and device index are used
       ! as for the input data.
-      call torch_model_load(model, args(1), device_type, device_index=device_index)
+      call torch_model_load(model, args(2), device_type, device_index=device_index)
 
       ! Infer
       call torch_model_forward(model, in_tensors, out_tensors)

--- a/examples/3_MultiGPU/multigpu_infer_fortran.f90
+++ b/examples/3_MultiGPU/multigpu_infer_fortran.f90
@@ -4,7 +4,8 @@ program inference
    use, intrinsic :: iso_fortran_env, only : sp => real32
 
    ! Import our library for interfacing with PyTorch
-   use ftorch, only : torch_model, torch_tensor, torch_kCPU, torch_kCUDA, torch_kXPU, &
+   use ftorch, only : torch_model, torch_tensor, &
+                      torch_kCPU, torch_kCUDA, torch_kXPU, torch_kMPS, &
                       torch_tensor_from_array, torch_model_load, torch_model_forward, &
                       torch_delete
 
@@ -27,7 +28,7 @@ program inference
    type(torch_tensor), dimension(1) :: out_tensors
 
    ! Variables for multi-GPU setup
-   integer, parameter :: num_devices = 2
+   integer :: num_devices = 2
    integer :: device_type, device_index, i
 
    ! Get device type as first command line argument and TorchScript model file as second command
@@ -41,6 +42,9 @@ program inference
       device_type = torch_kCUDA
    else if (trim(args(1)) == "xpu") then
       device_type = torch_kXPU
+   else if (trim(args(1)) == "mps") then
+      device_type = torch_kMPS
+      num_devices = 1
    else
       write (*,*) "Error :: invalid device type", trim(args(1))
       stop 999

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
 
         print(f"Output on device {device_to_run}: {result}")
 
-        expected = torch.Tensor([2*i + device_index for i in range(5)])
+        expected = torch.Tensor([2 * i + device_index for i in range(5)])
         if not torch.allclose(result, expected):
             result_error = (
                 f"result:\n{result}\ndoes not match expected value:\n{expected}"

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
 
         print(f"Output on device {device_to_run}: {result}")
 
-        expected = torch.Tensor([2 * i + device_index for i in range(5)])
+        expected = torch.Tensor([2 * (i + device_index) for i in range(5)])
         if not torch.allclose(result, expected):
             result_error = (
                 f"result:\n{result}\ndoes not match expected value:\n{expected}"

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -46,7 +46,9 @@ def deploy(saved_model: str, device: str, batch_size: int = 1) -> torch.Tensor:
 
     # All previously saved modules, no matter their device, are first
     # loaded onto CPU, and then are moved to the devices they were saved
-    # from, so we don't need to manually transfer the model to the GPU
+    # from.
+    # Since we are loading one saved model to multiple devices we explicitly
+    # transfer using `.to(device)` to ensure the model is on the correct index.
     model = torch.jit.load(saved_model)
     model = model.to(device)
     input_tensor_gpu = input_tensor.to(torch.device(device))

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -61,13 +61,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentParserDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "--device_type",
-        description="Device type to run the inference on",
+        help="Device type to run the inference on",
         type=str,
-        options=["cpu", "cuda", "xpu"],
+        choices=["cpu", "cuda", "xpu"],
         default="cuda",
     )
     parsed_args = parser.parse_args()

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -35,6 +35,9 @@ def deploy(saved_model: str, device: str, batch_size: int = 1) -> torch.Tensor:
     elif device.startswith("xpu"):
         # XPU devices need to be initialised before use
         torch.xpu.init()
+    elif device.startswith("mps"):
+        mps_error = "FTorch has not been tested with multiple MPS devices"
+        raise ValueError(mps_error)
     else:
         device_error = f"Device '{device}' not recognised."
         raise ValueError(device_error)

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -65,6 +65,12 @@ if __name__ == "__main__":
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parser.add_argument(
         "--device_type",
         help="Device type to run the inference on",
         type=str,
@@ -72,11 +78,11 @@ if __name__ == "__main__":
         default="cuda",
     )
     parsed_args = parser.parse_args()
+    filepath = parsed_args.filepath
     device_type = parsed_args.device_type
+    saved_model_file = os.path.join(filepath, f"saved_multigpu_model_{device_type}.pt")
 
-    saved_model_file = f"saved_multigpu_model_{device_type}.pt"
-
-    # Use 2 devices unless Mps for which there is only one
+    # Use 2 devices unless MPS for which there is only one
     num_devices = 1 if device_type == "mps" else 2
 
     for device_index in range(num_devices):

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -36,8 +36,7 @@ def deploy(saved_model: str, device: str, batch_size: int = 1) -> torch.Tensor:
         # XPU devices need to be initialised before use
         torch.xpu.init()
     elif device.startswith("mps"):
-        mps_error = "FTorch has not been tested with multiple MPS devices"
-        raise ValueError(mps_error)
+        pass
     else:
         device_error = f"Device '{device}' not recognised."
         raise ValueError(device_error)
@@ -67,7 +66,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu"],
+        choices=["cpu", "cuda", "xpu", "mps"],
         default="cuda",
     )
     parsed_args = parser.parse_args()
@@ -75,7 +74,8 @@ if __name__ == "__main__":
 
     saved_model_file = f"saved_multigpu_model_{device_type}.pt"
 
-    num_devices = 2
+    # Use 2 devices unless Mps for which there is only one
+    num_devices = 1 if device_type == "mps" else 2
 
     for device_index in range(num_devices):
         device_to_run = f"{device_type}:{device_index}"

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -55,8 +55,20 @@ def deploy(saved_model: str, device: str, batch_size: int = 1) -> torch.Tensor:
 
 
 if __name__ == "__main__":
-    # TODO: Accept command line argument for device type
-    device_type = "cuda"
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentParserDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--device_type",
+        description="Device type to run the inference on",
+        type=str,
+        options=["cpu", "cuda", "xpu"],
+        default="cuda",
+    )
+    parsed_args = parser.parse_args()
+    device_type = parsed_args.device_type
 
     saved_model_file = f"saved_multigpu_model_{device_type}.pt"
 

--- a/examples/3_MultiGPU/multigpu_infer_python.py
+++ b/examples/3_MultiGPU/multigpu_infer_python.py
@@ -1,5 +1,7 @@
 """Load saved SimpleNet to TorchScript and run inference example."""
 
+import os
+
 import torch
 
 

--- a/examples/3_MultiGPU/pt2ts.py
+++ b/examples/3_MultiGPU/pt2ts.py
@@ -78,21 +78,21 @@ if __name__ == "__main__":
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parser.add_argument(
         "--device_type",
         help="Device type to run the inference on",
         type=str,
         choices=["cpu", "cuda", "xpu", "mps"],
         default="cuda",
     )
-    parser.add_argument(
-        "--filepath",
-        help="Path to the file containing the PyTorch model",
-        type=str,
-        default=os.path.dirname(__file__),
-    )
     parsed_args = parser.parse_args()
-    device_type = parsed_args.device_type
     filepath = parsed_args.filepath
+    device_type = parsed_args.device_type
 
     # =====================================================
     # Load model and prepare for saving

--- a/examples/3_MultiGPU/pt2ts.py
+++ b/examples/3_MultiGPU/pt2ts.py
@@ -75,18 +75,18 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentParserDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "--device_type",
-        description="Device type to run the inference on",
+        help="Device type to run the inference on",
         type=str,
-        options=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "xpu", "mps"],
         default="cuda",
     )
     parser.add_argument(
         "--filepath",
-        description="Path to the file containing the PyTorch model",
+        help="Path to the file containing the PyTorch model",
         type=str,
         default=os.path.dirname(__file__),
     )

--- a/examples/3_MultiGPU/pt2ts.py
+++ b/examples/3_MultiGPU/pt2ts.py
@@ -76,6 +76,9 @@ if __name__ == "__main__":
     # Load model and prepare for saving
     # =====================================================
 
+    # TODO: Accept command line argument for device type
+    device_type = "cuda"
+
     # FPTLIB-TODO
     # Load a pre-trained PyTorch model
     # Insert code here to load your model as `trained_model`.
@@ -99,7 +102,7 @@ if __name__ == "__main__":
 
     # FPTLIB-TODO
     # Uncomment the following lines to save for inference on GPU (rather than CPU):
-    device = torch.device("cuda")
+    device = torch.device(device_type)
     trained_model = trained_model.to(device)
     trained_model.eval()
     trained_model_dummy_input = trained_model_dummy_input.to(device)
@@ -117,7 +120,7 @@ if __name__ == "__main__":
 
     # FPTLIB-TODO
     # Set the name of the file you want to save the torchscript model to:
-    saved_ts_filename = "saved_multigpu_model_cuda.pt"
+    saved_ts_filename = f"saved_multigpu_model_{device_type}.pt"
     # A filepath may also be provided. To do this, pass the filepath as an argument to
     # this script when it is run from the command line, i.e. `./pt2ts.py path/to/model`.
 
@@ -145,7 +148,7 @@ if __name__ == "__main__":
     # FPTLIB-TODO
     # Scale inputs as above and, if required, move inputs and mode to GPU
     trained_model_dummy_input = 2.0 * trained_model_dummy_input
-    trained_model_dummy_input = trained_model_dummy_input.to("cuda")
+    trained_model_dummy_input = trained_model_dummy_input.to(device_type)
     trained_model_testing_outputs = trained_model(
         trained_model_dummy_input,
     )

--- a/examples/3_MultiGPU/pt2ts.py
+++ b/examples/3_MultiGPU/pt2ts.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         "--device_type",
         description="Device type to run the inference on",
         type=str,
-        options=["cpu", "cuda", "xpu"],
+        options=["cpu", "cuda", "xpu", "mps"],
         default="cuda",
     )
     parser.add_argument(

--- a/examples/3_MultiGPU/pt2ts.py
+++ b/examples/3_MultiGPU/pt2ts.py
@@ -119,12 +119,12 @@ if __name__ == "__main__":
     # This example assumes one input of size (5)
     trained_model_dummy_input = torch.ones(5)
 
-    # FPTLIB-TODO
-    # Uncomment the following lines to save for inference on GPU (rather than CPU):
-    device = torch.device(device_type)
-    trained_model = trained_model.to(device)
-    trained_model.eval()
-    trained_model_dummy_input = trained_model_dummy_input.to(device)
+    # Transfer the model and inputs to GPU device, if appropriate
+    if device_type != "cpu":
+        device = torch.device(device_type)
+        trained_model = trained_model.to(device)
+        trained_model.eval()
+        trained_model_dummy_input = trained_model_dummy_input.to(device)
 
     # FPTLIB-TODO
     # Run model for dummy inputs
@@ -163,11 +163,8 @@ if __name__ == "__main__":
     # Check model saved OK
     # =====================================================
 
-    # Load torchscript and run model as a test
-    # FPTLIB-TODO
-    # Scale inputs as above and, if required, move inputs and mode to GPU
+    # Load torchscript and run model as a test, scaling inputs as above
     trained_model_dummy_input = 2.0 * trained_model_dummy_input
-    trained_model_dummy_input = trained_model_dummy_input.to(device_type)
     trained_model_testing_outputs = trained_model(
         trained_model_dummy_input,
     )

--- a/examples/3_MultiGPU/pt2ts.py
+++ b/examples/3_MultiGPU/pt2ts.py
@@ -72,12 +72,31 @@ def load_torchscript(filename: Optional[str] = "saved_model.pt") -> torch.nn.Mod
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentParserDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--device_type",
+        description="Device type to run the inference on",
+        type=str,
+        options=["cpu", "cuda", "xpu"],
+        default="cuda",
+    )
+    parser.add_argument(
+        "--filepath",
+        description="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parsed_args = parser.parse_args()
+    device_type = parsed_args.device_type
+    filepath = parsed_args.filepath
+
     # =====================================================
     # Load model and prepare for saving
     # =====================================================
-
-    # TODO: Accept command line argument for device type
-    device_type = "cuda"
 
     # FPTLIB-TODO
     # Load a pre-trained PyTorch model
@@ -173,7 +192,6 @@ if __name__ == "__main__":
             raise RuntimeError(model_error)
 
     # Check that the model file is created
-    filepath = os.path.dirname(__file__) if len(sys.argv) == 1 else sys.argv[1]
     if not os.path.exists(os.path.join(filepath, saved_ts_filename)):
         torchscript_file_error = (
             f"Saved TorchScript file {os.path.join(filepath, saved_ts_filename)} "

--- a/examples/3_MultiGPU/pt2ts.py
+++ b/examples/3_MultiGPU/pt2ts.py
@@ -1,7 +1,6 @@
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os
-import sys
 from typing import Optional
 
 # FPTLIB-TODO

--- a/examples/3_MultiGPU/simplenet.py
+++ b/examples/3_MultiGPU/simplenet.py
@@ -45,13 +45,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentParserDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "--device_type",
-        description="Device type to run the inference on",
+        help="Device type to run the inference on",
         type=str,
-        options=["cpu", "cuda", "xpu"],
+        choices=["cpu", "cuda", "xpu"],
         default="cuda",
     )
     parsed_args = parser.parse_args()

--- a/examples/3_MultiGPU/simplenet.py
+++ b/examples/3_MultiGPU/simplenet.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu"],
+        choices=["cpu", "cuda", "xpu", "mps"],
         default="cuda",
     )
     parsed_args = parser.parse_args()

--- a/examples/3_MultiGPU/simplenet.py
+++ b/examples/3_MultiGPU/simplenet.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         f" {input_tensor_gpu.get_device()}"
     )
     with torch.no_grad():
-        output_tensor = model(input_tensor_gpu)
+        output_tensor = model(input_tensor_gpu).to("cpu")
 
     print(output_tensor)
     if not torch.allclose(output_tensor, 2 * input_tensor):

--- a/examples/3_MultiGPU/simplenet.py
+++ b/examples/3_MultiGPU/simplenet.py
@@ -42,13 +42,19 @@ class SimpleNet(nn.Module):
 
 
 if __name__ == "__main__":
-    model = SimpleNet().to(torch.device("cuda"))
+    # TODO: Accept command line argument for device type
+    device_type = "cuda"
+
+    model = SimpleNet().to(torch.device(device_type))
     model.eval()
 
     input_tensor = torch.Tensor([0.0, 1.0, 2.0, 3.0, 4.0])
-    input_tensor_gpu = input_tensor.to(torch.device("cuda"))
+    input_tensor_gpu = input_tensor.to(torch.device(device_type))
 
-    print(f"SimpleNet forward pass on CUDA device {input_tensor_gpu.get_device()}")
+    print(
+        f"SimpleNet forward pass on {device_type.capitalize()} device"
+        f" {input_tensor_gpu.get_device()}"
+    )
     with torch.no_grad():
         output = model(input_tensor_gpu)
     print(output)

--- a/examples/3_MultiGPU/simplenet.py
+++ b/examples/3_MultiGPU/simplenet.py
@@ -42,8 +42,20 @@ class SimpleNet(nn.Module):
 
 
 if __name__ == "__main__":
-    # TODO: Accept command line argument for device type
-    device_type = "cuda"
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentParserDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--device_type",
+        description="Device type to run the inference on",
+        type=str,
+        options=["cpu", "cuda", "xpu"],
+        default="cuda",
+    )
+    parsed_args = parser.parse_args()
+    device_type = parsed_args.device_type
 
     model = SimpleNet().to(torch.device(device_type))
     model.eval()

--- a/examples/3_MultiGPU/simplenet.py
+++ b/examples/3_MultiGPU/simplenet.py
@@ -68,5 +68,12 @@ if __name__ == "__main__":
         f" {input_tensor_gpu.get_device()}"
     )
     with torch.no_grad():
-        output = model(input_tensor_gpu)
-    print(output)
+        output_tensor = model(input_tensor_gpu)
+
+    print(output_tensor)
+    if not torch.allclose(output_tensor, 2 * input_tensor):
+        result_error = (
+            f"result:\n{output_tensor}\ndoes not match expected value:\n"
+            f"{2 * input_tensor}"
+        )
+        raise ValueError(result_error)

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -33,9 +33,8 @@ if(CMAKE_BUILD_TESTS)
   #   pt2ts.py script
   add_test(
     NAME pt2ts
-    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py
-            ${PROJECT_BINARY_DIR} # Command line argument: filepath for saving
-                                  # the model
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --filepath
+            ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 3. Check the model can be loaded from file and run in Python and that its
@@ -44,7 +43,7 @@ if(CMAKE_BUILD_TESTS)
     NAME multiionet_infer_python
     COMMAND
       ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet_infer_python.py
-      ${PROJECT_BINARY_DIR} # Command line argument: filepath to find the model
+      --filepath ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
   # 4. Check the model can be loaded from file and run in Fortran and that its

--- a/examples/4_MultiIO/multiionet_infer_python.py
+++ b/examples/4_MultiIO/multiionet_infer_python.py
@@ -1,7 +1,6 @@
 """Load saved MultIONet to TorchScript and run inference example."""
 
 import os
-import sys
 
 import torch
 

--- a/examples/4_MultiIO/multiionet_infer_python.py
+++ b/examples/4_MultiIO/multiionet_infer_python.py
@@ -52,7 +52,19 @@ def deploy(saved_model: str, device: str, batch_size: int = 1) -> torch.Tensor:
 
 
 if __name__ == "__main__":
-    filepath = os.path.dirname(__file__) if len(sys.argv) == 1 else sys.argv[1]
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parsed_args = parser.parse_args()
+    filepath = parsed_args.filepath
     saved_model_file = os.path.join(filepath, "saved_multiio_model_cpu.pt")
 
     device_to_run = "cpu"

--- a/examples/4_MultiIO/pt2ts.py
+++ b/examples/4_MultiIO/pt2ts.py
@@ -72,6 +72,28 @@ def load_torchscript(filename: Optional[str] = "saved_model.pt") -> torch.nn.Mod
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--device_type",
+        help="Device type to run the inference on",
+        type=str,
+        choices=["cpu", "cuda", "xpu", "mps"],
+        default="cpu",
+    )
+    parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parsed_args = parser.parse_args()
+    device_type = parsed_args.device_type
+    filepath = parsed_args.filepath
+
     # =====================================================
     # Load model and prepare for saving
     # =====================================================
@@ -97,12 +119,12 @@ if __name__ == "__main__":
     # This example assumes one input of size (5)
     trained_model_dummy_inputs = (torch.ones(4), torch.ones(4))
 
-    # FPTLIB-TODO
-    # Uncomment the following lines to save for inference on GPU (rather than CPU):
-    # device = torch.device('cuda')
-    # trained_model = trained_model.to(device)
-    # trained_model.eval()
-    # trained_model_dummy_input = trained_model_dummy_input.to(device)
+    # Transfer the model and inputs to GPU device, if appropriate
+    if device_type != "cpu":
+        device = torch.device(device_type)
+        trained_model = trained_model.to(device)
+        trained_model.eval()
+        trained_model_dummy_inputs = trained_model_dummy_inputs.to(device)
 
     # FPTLIB-TODO
     # Run model for dummy inputs
@@ -117,7 +139,7 @@ if __name__ == "__main__":
 
     # FPTLIB-TODO
     # Set the name of the file you want to save the torchscript model to:
-    saved_ts_filename = "saved_multiio_model_cpu.pt"
+    saved_ts_filename = f"saved_multiio_model_{device_type}.pt"
     # A filepath may also be provided. To do this, pass the filepath as an argument to
     # this script when it is run from the command line, i.e. `./pt2ts.py path/to/model`.
 
@@ -141,9 +163,7 @@ if __name__ == "__main__":
     # Check model saved OK
     # =====================================================
 
-    # Load torchscript and run model as a test
-    # FPTLIB-TODO
-    # Scale inputs as above and, if required, move inputs and mode to GPU
+    # Load torchscript and run model as a test, scaling inputs as above
     trained_model_dummy_inputs = (
         2.0 * trained_model_dummy_inputs[0],
         3.0 * trained_model_dummy_inputs[1],
@@ -172,7 +192,6 @@ if __name__ == "__main__":
             raise RuntimeError(model_error)
 
     # Check that the model file is created
-    filepath = os.path.dirname(__file__) if len(sys.argv) == 1 else sys.argv[1]
     if not os.path.exists(os.path.join(filepath, saved_ts_filename)):
         torchscript_file_error = (
             f"Saved TorchScript file {os.path.join(filepath, saved_ts_filename)} "

--- a/examples/4_MultiIO/pt2ts.py
+++ b/examples/4_MultiIO/pt2ts.py
@@ -1,7 +1,6 @@
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os
-import sys
 from typing import Optional
 
 # FPTLIB-TODO

--- a/examples/5_Looping/pt2ts.py
+++ b/examples/5_Looping/pt2ts.py
@@ -1,7 +1,6 @@
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os
-import sys
 from typing import Optional
 
 # FPTLIB-TODO

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CMAKE_BUILD_TESTS)
   add_subdirectory(1_SimpleNet)
   add_subdirectory(2_ResNet18)
-  if(ENABLE_CUDA)
+  if(ENABLE_CUDA OR ENABLE_XPU)
     add_subdirectory(3_MultiGPU)
   endif()
   add_subdirectory(4_MultiIO)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CMAKE_BUILD_TESTS)
   add_subdirectory(1_SimpleNet)
   add_subdirectory(2_ResNet18)
-  if(ENABLE_CUDA OR ENABLE_XPU OR ENABLE_MPS)
+  if(NOT "${GPU_DEVICE}" STREQUAL "NONE")
     add_subdirectory(3_MultiGPU)
   endif()
   add_subdirectory(4_MultiIO)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CMAKE_BUILD_TESTS)
   add_subdirectory(1_SimpleNet)
   add_subdirectory(2_ResNet18)
-  if(ENABLE_CUDA OR ENABLE_XPU)
+  if(ENABLE_CUDA OR ENABLE_XPU OR ENABLE_MPS)
     add_subdirectory(3_MultiGPU)
   endif()
   add_subdirectory(4_MultiIO)

--- a/pages/cmake.md
+++ b/pages/cmake.md
@@ -62,7 +62,7 @@ The following CMake flags are available and can be passed as arguments through `
 | [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)  | `</path/to/install/lib/at/>` | Location at which the library files should be installed. By default this is `/usr/local` |
 | [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)          | `Release` / `Debug`          | Specifies build type. The default is `Debug`, use `Release` for production code|
 | `CMAKE_BUILD_TESTS`                                                                               | `TRUE` / `FALSE`             | Specifies whether to compile FTorch's [test suite](testing.html) as part of the build. |
-| `ENABLE_CUDA`                                                                                     | `TRUE` / `FALSE`             | Specifies whether to check for and enable CUDA<sup>3</sup> |
+| `GPU_DEVICE` | `NONE` / `CUDA` / `XPU` / `MPS` | Specifies the target GPU architecture (if any) <sup>3</sup> |
 
 
 

--- a/pages/cmake.md
+++ b/pages/cmake.md
@@ -68,18 +68,16 @@ The following CMake flags are available and can be passed as arguments through `
 
 > <sup>1</sup> _On Windows this may need to be the full path to the compiler if CMake
 > cannot locate it by default._
-> 
+>
 > <sup>2</sup> _The path to the Torch installation needs to allow CMake to locate the relevant Torch CMake files.  
 >       If Torch has been [installed as LibTorch](https://pytorch.org/cppdocs/installing.html)
 >       then this should be the absolute path to the unzipped LibTorch distribution.
 >       If Torch has been installed as PyTorch in a Python [venv (virtual environment)](https://docs.python.org/3/library/venv.html),
 >       e.g. with `pip install torch`, then this should be `</path/to/venv/>lib/python<3.xx>/site-packages/torch/`._
-> 
-> <sup>3</sup> _This is often overridden by PyTorch. When installing with pip, the `index-url` flag can be used to ensure a CPU or GPU only version is installed, e.g.
->       `pip install torch --index-url https://download.pytorch.org/whl/cpu`
->       or
->       `pip install torch --index-url https://download.pytorch.org/whl/cu118`
->       (for CUDA 11.8). URLs for alternative versions can be found [here](https://pytorch.org/get-started/locally/)._
+>
+> <sup>3</sup> _This is often overridden by PyTorch. When installing with pip, the `index-url` flag can be used to ensure a CPU-only or GPU-enabled version is installed, e.g.
+>       `pip install torch --index-url https://download.pytorch.org/whl/cpu`.
+>       URLs for alternative versions can be found [here](https://pytorch.org/get-started/locally/)._
 
 For example, to build on a unix system using the gnu compilers and install to `$HOME/FTorchbin/`
 we would need to run:

--- a/pages/gpu.md
+++ b/pages/gpu.md
@@ -33,8 +33,8 @@ if device_type != "cpu":
 
 > Note: _This code moves the dummy input tensors to the GPU, as well as the
 > model.
-> Whilst not necessary for saving the model, but the tensors must also be on
-> the GPU to test that the models runs._
+> Whilst this is not necessary for saving the model the tensors must be on
+> the same GPU device to test that the models runs._
 
 3) When calling `torch_tensor_from_array` in Fortran, the device type for the
    input tensor(s) should be set to the relevant device type (`torch_kCUDA`,

--- a/pages/gpu.md
+++ b/pages/gpu.md
@@ -4,27 +4,41 @@ title: GPU Support
 
 ## GPU Support
 
-In order to run a model on GPU, two main changes are required:
+In order to run a model on GPU, three main changes are required:
 
-1) When saving your TorchScript model, ensure that it is on the GPU.
+1) When building FTorch, specify the target GPU architecture using the
+`GPU_DEVICE` argument. That is, set
+```sh
+cmake .. -DGPU_DEVICE=<CUDA/XPU/MPS>
+```
+as appropriate. The default setting is equivalent to
+```sh
+cmake .. -DGPU_DEVICE=NONE
+```
+i.e., CPU-only.
+
+2) When saving your TorchScript model, ensure that it is on the GPU.
 For example, when using
 [`pt2ts.py`](https://github.com/Cambridge-ICCS/FTorch/blob/main/utils/pt2ts.py),
-this can be done by uncommenting the following lines:
-
+this can be done by passing the `--device_type <cuda/xpu/mps>` argument. This
+sets the `device_type` variable, which has the effect of transferring the model
+and any input arrays to the specified GPU device in the following lines:
 ```python
-device_type = torch.device("cuda")
-trained_model = trained_model.to(device_type)
-trained_model.eval()
-trained_model_dummy_input_1 = trained_model_dummy_input_1.to(device_type)
-trained_model_dummy_input_2 = trained_model_dummy_input_2.to(device_type)
+if device_type != "cpu":
+    trained_model = trained_model.to(device_type)
+    trained_model.eval()
+    trained_model_dummy_input_1 = trained_model_dummy_input_1.to(device_type)
+    trained_model_dummy_input_2 = trained_model_dummy_input_2.to(device_type)
 ```
 
-> Note: _This code also moves the dummy input tensors to the GPU.
-> Whilst not necessary for saving the model, but the tensors must also be on the GPU
-> to test that the models runs._
+> Note: _This code moves the dummy input tensors to the GPU, as well as the
+> model.
+> Whilst not necessary for saving the model, but the tensors must also be on
+> the GPU to test that the models runs._
 
-2) When calling `torch_tensor_from_array` in Fortran, the device type for the input
-   tensor(s) should be set to `torch_kCUDA`, rather than `torch_kCPU`.
+3) When calling `torch_tensor_from_array` in Fortran, the device type for the
+   input tensor(s) should be set to the relevant device type (`torch_kCUDA`,
+   `torch_kXPU`, or `torch_kMPS`) rather than `torch_kCPU`.
    This ensures that the inputs are on the same device type as the model.
 
 > Note: _You do **not** need to change the device type for the output tensors as we
@@ -32,25 +46,28 @@ trained_model_dummy_input_2 = trained_model_dummy_input_2.to(device_type)
 
 ### Multi-GPU runs
 
-In the case of having multiple GPU devices, as well as setting `torch_kCUDA` as the
-device type for any input tensors and models, you should also specify their device index
-as the GPU device to be targeted. This argument is optional and will default to device
-index 0 if unset.
+In the case of having multiple GPU devices, as well as setting the device type
+for any input tensors and models, you should also specify their device index
+as the GPU device to be targeted. This argument is optional and will default to
+device index 0 if unset.
 
-For example, the following code snippet sets up a Torch tensor with GPU device index 2:
-
+For example, the following code snippet sets up a Torch tensor with CUDA GPU
+device index 2:
 ```fortran
 device_index = 2
 call torch_tensor_from_array(in_tensors(1), in_data, tensor_layout, &
                              torch_kCUDA, device_index=device_index)
 ```
-
-Whereas the following code snippet sets up a Torch tensor with (default) device index 0:
-
+Whereas the following code snippet sets up a Torch tensor with (default) CUDA
+device index 0:
 ```fortran
 call torch_tensor_from_array(in_tensors(1), in_data, tensor_layout, &
                              torch_kCUDA)
 ```
+Similarly for the XPU device type.
+
+> Note: The MPS device type does not currently support multiple devices, so the
+> default device index should always be used.
 
 See the
 [MultiGPU example](https://github.com/Cambridge-ICCS/FTorch/tree/main/examples/3_MultiGPU)

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -96,6 +96,12 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
                 << std::endl;
     }
     return torch::Device(torch::kMPS);
+  case torch_kXPU:
+    if (device_index != -1) {
+      std::cerr << "[WARNING]: device index unused for XPU runs"
+                << std::endl;
+    }
+    return torch::Device(torch::kXPU);
   default:
     std::cerr << "[WARNING]: unknown device type, setting to torch_kCPU" << std::endl;
     return torch::Device(torch::kCPU);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -90,6 +90,12 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
                 << " for device count " << torch::cuda::device_count() << std::endl;
       exit(EXIT_FAILURE);
     }
+  case torch_kMPS:
+    if (device_index != -1 && device_index != 0) {
+      std::cerr << "[WARNING]: Only one device is available for MPS runs"
+                << std::endl;
+    }
+    return torch::Device(torch::kMPS);
   default:
     std::cerr << "[WARNING]: unknown device type, setting to torch_kCPU" << std::endl;
     return torch::Device(torch::kCPU);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -8,6 +8,10 @@
 
 #include "ctorch.h"
 
+#ifndef GPU_DEVICE
+#define GPU_DEVICE GPU_DEVICE_NONE
+#endif
+
 // =============================================================================
 // --- Constant expressions
 // =============================================================================
@@ -78,7 +82,7 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
       std::cerr << "[WARNING]: device index unused for CPU-only runs" << std::endl;
     }
     return torch::Device(torch::kCPU);
-#ifdef ENABLE_CUDA
+#if GPU_DEVICE == GPU_DEVICE_CUDA
   case torch_kCUDA:
     if (device_index == -1) {
       std::cerr << "[WARNING]: device index unset, defaulting to 0" << std::endl;
@@ -97,7 +101,7 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
       std::cerr << "[WARNING]: Only one device is available for MPS runs" << std::endl;
     }
     return torch::Device(torch::kMPS);
-#ifdef ENABLE_XPU
+#if GPU_DEVICE == GPU_DEVICE_XPU
   case torch_kXPU:
     if (device_index == -1) {
       std::cerr << "[WARNING]: device index unset, defaulting to 0" << std::endl;

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -97,11 +97,19 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
     }
     return torch::Device(torch::kMPS);
   case torch_kXPU:
-    if (device_index != -1) {
-      std::cerr << "[WARNING]: device index unused for XPU runs"
+    if (device_index == -1) {
+      std::cerr << "[WARNING]: device index unset, defaulting to 0"
                 << std::endl;
+      device_index = 0;
     }
-    return torch::Device(torch::kXPU);
+    if (device_index >= 0 && device_index < torch::xpu::device_count()) {
+      return torch::Device(torch::kXPU, device_index);
+    } else {
+      std::cerr << "[ERROR]: invalid device index " << device_index
+                << " for XPU device count " << torch::xpu::device_count()
+                << std::endl;
+      exit(EXIT_FAILURE);
+    }
   default:
     std::cerr << "[WARNING]: unknown device type, setting to torch_kCPU" << std::endl;
     return torch::Device(torch::kCPU);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -78,6 +78,7 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
       std::cerr << "[WARNING]: device index unused for CPU-only runs" << std::endl;
     }
     return torch::Device(torch::kCPU);
+#ifdef ENABLE_CUDA
   case torch_kCUDA:
     if (device_index == -1) {
       std::cerr << "[WARNING]: device index unset, defaulting to 0" << std::endl;
@@ -90,11 +91,13 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
                 << " for device count " << torch::cuda::device_count() << std::endl;
       exit(EXIT_FAILURE);
     }
+#endif
   case torch_kMPS:
     if (device_index != -1 && device_index != 0) {
       std::cerr << "[WARNING]: Only one device is available for MPS runs" << std::endl;
     }
     return torch::Device(torch::kMPS);
+#ifdef ENABLE_XPU
   case torch_kXPU:
     if (device_index == -1) {
       std::cerr << "[WARNING]: device index unset, defaulting to 0" << std::endl;
@@ -107,6 +110,7 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
                 << " for XPU device count " << torch::xpu::device_count() << std::endl;
       exit(EXIT_FAILURE);
     }
+#endif
   default:
     std::cerr << "[WARNING]: unknown device type, setting to torch_kCPU" << std::endl;
     return torch::Device(torch::kCPU);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -92,22 +92,19 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
     }
   case torch_kMPS:
     if (device_index != -1 && device_index != 0) {
-      std::cerr << "[WARNING]: Only one device is available for MPS runs"
-                << std::endl;
+      std::cerr << "[WARNING]: Only one device is available for MPS runs" << std::endl;
     }
     return torch::Device(torch::kMPS);
   case torch_kXPU:
     if (device_index == -1) {
-      std::cerr << "[WARNING]: device index unset, defaulting to 0"
-                << std::endl;
+      std::cerr << "[WARNING]: device index unset, defaulting to 0" << std::endl;
       device_index = 0;
     }
     if (device_index >= 0 && device_index < torch::xpu::device_count()) {
       return torch::Device(torch::kXPU, device_index);
     } else {
       std::cerr << "[ERROR]: invalid device index " << device_index
-                << " for XPU device count " << torch::xpu::device_count()
-                << std::endl;
+                << " for XPU device count " << torch::xpu::device_count() << std::endl;
       exit(EXIT_FAILURE);
     }
   default:
@@ -123,6 +120,10 @@ const torch_device_t get_ftorch_device(torch::DeviceType device_type) {
     return torch_kCPU;
   case torch::kCUDA:
     return torch_kCUDA;
+  case torch::kXPU:
+    return torch_kXPU;
+  case torch::kMPS:
+    return torch_kMPS;
   default:
     std::cerr << "[ERROR]: device type " << device_type << " not implemented in FTorch"
               << std::endl;

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -38,7 +38,7 @@ typedef enum {
 } torch_data_t;
 
 // Device types
-typedef enum { torch_kCPU, torch_kCUDA, torch_kMPS } torch_device_t;
+typedef enum { torch_kCPU, torch_kCUDA, torch_kMPS, torch_kXPU } torch_device_t;
 
 // =============================================================================
 // --- Functions for constructing tensors

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -7,13 +7,6 @@
 #define EXPORT_C
 #endif
 
-// GPU device codes numbered consistently with
-//     https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
-#define GPU_DEVICE_NONE 0
-#define GPU_DEVICE_CUDA 1
-#define GPU_DEVICE_XPU 12
-#define GPU_DEVICE_MPS 13
-
 #include <stdint.h>
 
 // =============================================================================

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -7,6 +7,13 @@
 #define EXPORT_C
 #endif
 
+// GPU device codes numbered consistently with
+//     https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
+#define GPU_DEVICE_NONE 0
+#define GPU_DEVICE_CUDA 1
+#define GPU_DEVICE_XPU 12
+#define GPU_DEVICE_MPS 13
+
 #include <stdint.h>
 
 // =============================================================================
@@ -38,13 +45,11 @@ typedef enum {
 } torch_data_t;
 
 // Device types
-// NOTE: Numbered consistently with
-//       https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
 typedef enum {
-  torch_kCPU = 0,
-  torch_kCUDA = 1,
-  torch_kXPU = 12,
-  torch_kMPS = 13,
+  torch_kCPU = GPU_DEVICE_NONE,
+  torch_kCUDA = GPU_DEVICE_CUDA,
+  torch_kXPU = GPU_DEVICE_XPU,
+  torch_kMPS = GPU_DEVICE_MPS,
 } torch_device_t;
 
 // =============================================================================

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -38,7 +38,14 @@ typedef enum {
 } torch_data_t;
 
 // Device types
-typedef enum { torch_kCPU, torch_kCUDA, torch_kMPS, torch_kXPU } torch_device_t;
+// NOTE: Numbered consistently with
+//       https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
+typedef enum {
+  torch_kCPU = 0,
+  torch_kCUDA = 1,
+  torch_kXPU = 12,
+  torch_kMPS = 13,
+} torch_device_t;
 
 // =============================================================================
 // --- Functions for constructing tensors

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -38,6 +38,7 @@ typedef enum {
 } torch_data_t;
 
 // Device types
+// Defined in main CMakeLists and passed via preprocessor
 typedef enum {
   torch_kCPU = GPU_DEVICE_NONE,
   torch_kCUDA = GPU_DEVICE_CUDA,

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -38,7 +38,7 @@ typedef enum {
 } torch_data_t;
 
 // Device types
-// Defined in main CMakeLists and passed via preprocessor
+// NOTE: Defined in main CMakeLists and passed via preprocessor
 typedef enum {
   torch_kCPU = GPU_DEVICE_NONE,
   torch_kCUDA = GPU_DEVICE_CUDA,

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -38,7 +38,7 @@ typedef enum {
 } torch_data_t;
 
 // Device types
-typedef enum { torch_kCPU, torch_kCUDA } torch_device_t;
+typedef enum { torch_kCPU, torch_kCUDA, torch_kMPS } torch_device_t;
 
 // =============================================================================
 // --- Functions for constructing tensors

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -52,13 +52,11 @@ module ftorch
 
   !| Enumerator for Torch devices
   !  From c_torch.h (torch_device_t)
-  !   NOTE: Numbered consistently with
-  !         https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
   enum, bind(c)
-    enumerator :: torch_kCPU = 0
-    enumerator :: torch_kCUDA = 1
-    enumerator :: torch_kXPU = 12
-    enumerator :: torch_kMPS = 13
+    enumerator :: torch_kCPU = GPU_DEVICE_NONE
+    enumerator :: torch_kCUDA = GPU_DEVICE_CUDA
+    enumerator :: torch_kXPU = GPU_DEVICE_XPU
+    enumerator :: torch_kMPS = GPU_DEVICE_MPS
   end enum
 
   ! ============================================================================

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -52,11 +52,13 @@ module ftorch
 
   !| Enumerator for Torch devices
   !  From c_torch.h (torch_device_t)
+  !   NOTE: Numbered consistently with
+  !         https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
   enum, bind(c)
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
-    enumerator :: torch_kMPS = 2
-    enumerator :: torch_kXPU = 3
+    enumerator :: torch_kXPU = 12
+    enumerator :: torch_kMPS = 13
   end enum
 
   ! ============================================================================

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -52,6 +52,7 @@ module ftorch
 
   !| Enumerator for Torch devices
   !  From c_torch.h (torch_device_t)
+  !  NOTE: Defined in main CMakeLists and passed via preprocessor
   enum, bind(c)
     enumerator :: torch_kCPU = GPU_DEVICE_NONE
     enumerator :: torch_kCUDA = GPU_DEVICE_CUDA

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -55,6 +55,8 @@ module ftorch
   enum, bind(c)
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
+    enumerator :: torch_kMPS = 2
+    enumerator :: torch_kXPU = 3
   end enum
 
   ! ============================================================================

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -74,6 +74,7 @@ module ftorch
   enum, bind(c)
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
+    enumerator :: torch_kMPS = 2
   end enum
 
   ! ============================================================================

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -71,11 +71,13 @@ module ftorch
 
   !| Enumerator for Torch devices
   !  From c_torch.h (torch_device_t)
+  !   NOTE: Numbered consistently with
+  !         https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
   enum, bind(c)
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
-    enumerator :: torch_kMPS = 2
-    enumerator :: torch_kXPU = 3
+    enumerator :: torch_kXPU = 12
+    enumerator :: torch_kMPS = 13
   end enum
 
   ! ============================================================================

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -71,6 +71,7 @@ module ftorch
 
   !| Enumerator for Torch devices
   !  From c_torch.h (torch_device_t)
+  !  NOTE: Defined in main CMakeLists and passed via preprocessor
   enum, bind(c)
     enumerator :: torch_kCPU = GPU_DEVICE_NONE
     enumerator :: torch_kCUDA = GPU_DEVICE_CUDA

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -75,6 +75,7 @@ module ftorch
     enumerator :: torch_kCPU = 0
     enumerator :: torch_kCUDA = 1
     enumerator :: torch_kMPS = 2
+    enumerator :: torch_kXPU = 3
   end enum
 
   ! ============================================================================

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -71,13 +71,11 @@ module ftorch
 
   !| Enumerator for Torch devices
   !  From c_torch.h (torch_device_t)
-  !   NOTE: Numbered consistently with
-  !         https://github.com/pytorch/pytorch/blob/main/c10/core/DeviceType.h
   enum, bind(c)
-    enumerator :: torch_kCPU = 0
-    enumerator :: torch_kCUDA = 1
-    enumerator :: torch_kXPU = 12
-    enumerator :: torch_kMPS = 13
+    enumerator :: torch_kCPU = GPU_DEVICE_NONE
+    enumerator :: torch_kCUDA = GPU_DEVICE_CUDA
+    enumerator :: torch_kXPU = GPU_DEVICE_XPU
+    enumerator :: torch_kMPS = GPU_DEVICE_MPS
   end enum
 
   ! ============================================================================

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,7 +15,7 @@ add_pfunit_ctest(test_tensor_interrogation
 add_pfunit_ctest(test_operator_overloads
   TEST_SOURCES test_tensor_operator_overloads.pf LINK_LIBRARIES FTorch::ftorch)
 
-if(ENABLE_CUDA)
+if("${GPU_DEVICE}" STREQUAL "CUDA")
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)

--- a/utils/README.md
+++ b/utils/README.md
@@ -4,13 +4,15 @@ This directory contains useful utilities for users of the library.
 
 ## `pt2ts.py`
 
-This is a python script that can take a PyTorch model and convert it to Torchscript.
+This is a python script that can take a PyTorch model and convert it to
+TorchScript.
 It provides the user with the option to [jit.script](https://pytorch.org/docs/stable/generated/torch.jit.script.html#torch.jit.script) or [jit.trace](https://pytorch.org/docs/stable/generated/torch.jit.trace.html#torch.jit.trace) for both CPU and GPU.
 
 Dependencies:
 - PyTorch
 
 ### Usage
+
 1. Create and activate a virtual environment with PyTorch and any dependencies for your model.
 2. Place the `pt2ts.py` script in the same folder as your model files.
 3. Import your model into `pt2ts.py` and amend options as necessary (search for `FPTLIB-TODO`).
@@ -18,3 +20,14 @@ Dependencies:
 
 The Torchscript model will be saved locally in the same location from which the `pt2ts.py`
 script is being run.
+
+#### Command line arguments
+
+The `pt2ts.py` script is set up with the `argparse` Python module such that it
+accepts two command line arguments:
+* `--filepath </path/to/save/model>`, which allows you to specify the file path
+  to the directory in which the TorchScript model should be saved.
+* `--device_type <cpu/cuda/xpu/mps>`, which allows you to specify the CPU or GPU
+  device type with which to save the model. (To read and make use of a model on
+  a particular architecture, it's important that the model was targeted for that
+  architecture when it was saved.)

--- a/utils/README.md
+++ b/utils/README.md
@@ -25,7 +25,7 @@ script is being run.
 
 The `pt2ts.py` script is set up with the `argparse` Python module such that it
 accepts two command line arguments:
-* `--filepath </path/to/save/model>`, which allows you to specify the file path
+* `--filepath </path/to/save/model>`, which allows you to specify the path
   to the directory in which the TorchScript model should be saved.
 * `--device_type <cpu/cuda/xpu/mps>`, which allows you to specify the CPU or GPU
   device type with which to save the model. (To read and make use of a model on

--- a/utils/pt2ts.py
+++ b/utils/pt2ts.py
@@ -1,7 +1,6 @@
 """Load a PyTorch model and convert it to TorchScript."""
 
 import os
-import sys
 from typing import Optional
 
 # FPTLIB-TODO


### PR DESCRIPTION
Closes #127.
Builds upon #125 and #209.
(Contains changes from #268 so that will need to be merged first.)

This PR adds support XPU and MPS. Unfortunately, it ended up requiring an overhaul of the `pt2ts` scripts, too.

Notable changes:
* Switching from `ENABLE_CUDA` to the more general and extensible `GPU_DEVICE=<NONE/CUDA/XPU/MPS>`.
* Pre-processor directives for handling different GPU types.
* Support for XPU under GPU device code 12.
* Support for MPS under GPU device code 13.
* Use of `argparse` for reading command line arguments into Python scripts, rather than `sys.argv`.
* Updates to docs.

## Checklist
- [x] Test on 2 Nvidia GPUs
- [x] Test on 2 XPUs
- [x] Test on 1 MPS device