### PR TITLE
Add instructions for a conda environment on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ Note that LibTorch is not supported for the GNU Fortran compiler with MinGW.
 
 #### Apple Silicon Support
 
-At the time of writing, LibTorch is only officially available for x86 architectures
-(according to https://pytorch.org/). However, the version of PyTorch provided by
-`pip install torch` uses an ARM binary for LibTorch which works on Apple Silicon.
+At the time of writing [there are issues](https://github.com/pytorch/pytorch/issues/143571)
+building FTorch on apple silicon when linking to downloaded `LibTorch` binaries or
+pip-installed PyTorch.
+FTorch can successfully be built, including utilising the MPS backend, from inside a
+conda environment using the environment files and instructions in
+[`conda/`](https://github.com/Cambridge-ICCS/FTorch/tree/main/conda).
 
 #### Conda Support
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Note that LibTorch is not supported for the GNU Fortran compiler with MinGW.
 #### Apple Silicon Support
 
 At the time of writing [there are issues](https://github.com/pytorch/pytorch/issues/143571)
-building FTorch on apple silicon when linking to downloaded `LibTorch` binaries or
+building FTorch on Apple Silicon when linking to downloaded `LibTorch` binaries or
 pip-installed PyTorch.
 FTorch can successfully be built, including utilising the MPS backend, from inside a
 conda environment using the environment files and instructions in

--- a/conda/README.md
+++ b/conda/README.md
@@ -95,6 +95,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
     -DCMAKE_PREFIX_PATH=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)') \
     -DCMAKE_BUILD_TYPE=Release \
+    -DGPU_DEVICE=MPS \
     ..
 cmake --build . --target install
 ```

--- a/conda/README.md
+++ b/conda/README.md
@@ -89,7 +89,7 @@ from this directory to create the environment and install dependencies.
 We install PyTorch using `pip` from within the conda environment which should include
 the MPS backend.
 
-FTorch can then be build with a CMake command similar to the following:
+FTorch can then be built with a CMake command similar to the following:
 ```sh
 cmake \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \

--- a/conda/README.md
+++ b/conda/README.md
@@ -74,6 +74,32 @@ cmake --build . --target install
 Note: There is the option of using `--parallel` to speed this up as described in
 the main documentation.
 
+### Mac and MPS
+
+At the time of writing [there are issues](https://github.com/pytorch/pytorch/issues/143571)
+building FTorch when linking to downloaded `LibTorch` binaries or pip-installed PyTorch.
+FTorch can successfully be built, including utilising the MPS backend, from inside a
+conda environment using the environment files provided here.
+
+From a conda base environment run:
+```sh
+conda env create -f environment_mac.yaml
+```
+from this directory to create the environment and install dependencies.
+We install PyTorch using `pip` from within the conda environment which should include
+the MPS backend.
+
+FTorch can then be build with a CMake command similar to the following:
+```sh
+cmake \
+    -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+    -DCMAKE_PREFIX_PATH=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)') \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+cmake --build . --target install
+```
+Note: There is the option of using `--parallel` to speed this up as described in
+the main documentation.
 
 ### Other Backends
 

--- a/conda/environment_mac.yaml
+++ b/conda/environment_mac.yaml
@@ -1,0 +1,13 @@
+name: ftorch-mac
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - fortran-compiler
+  - cxx-compiler
+  - cmake >=3.15
+  - openmpi >=5.0.6  # For pFUnit
+  - pip
+  - pip:  # We install PyTorch using pip as recommended by PyTorch
+    - torch
+    - torchvision


### PR DESCRIPTION
Can successfully build FTorch and utilise the MPS backend on Apple Silicon.

This provides an alternative for users on mac, and also acts as a workaround whilst we wait for https://github.com/pytorch/pytorch/issues/143571 to be resolved.