### PR TITLE
Hook up `requires_grad`

### DIFF
--- a/examples/6_Autograd/autograd.f90
+++ b/examples/6_Autograd/autograd.f90
@@ -34,9 +34,8 @@ program example
   ! Initialise Torch Tensors from input arrays as in Python example
   in_data1(:,1) = [2.0_wp, 3.0_wp]
   in_data2(:,1) = [6.0_wp, 4.0_wp]
-  ! TODO: Implement requires_grad=.true.
-  call torch_tensor_from_array(a, in_data1, tensor_layout, torch_kCPU)
-  call torch_tensor_from_array(b, in_data2, tensor_layout, torch_kCPU)
+  call torch_tensor_from_array(a, in_data1, tensor_layout, torch_kCPU, requires_grad=.true.)
+  call torch_tensor_from_array(b, in_data2, tensor_layout, torch_kCPU, requires_grad=.true.)
 
   ! Initialise Torch Tensor from array used for output
   call torch_tensor_from_array(Q, out_data, tensor_layout, torch_kCPU)

--- a/pages/autograd.md
+++ b/pages/autograd.md
@@ -35,7 +35,8 @@ Torch tensors, see the associated
 
 ### The `requires_grad` property
 
-*Not yet implemented.*
+For Tensors that you would like to differentiate with respect to, be sure to
+set the `requires_grad` optional argument to `.true.` when you construct it.
 
 ### The `backward` operator
 

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -151,9 +151,12 @@ torch_tensor_t torch_empty(int ndim, const int64_t *shape, torch_data_t dtype,
   try {
     // This doesn't throw if shape and dimensions are incompatible
     c10::IntArrayRef vshape(shape, ndim);
+    auto options = torch::TensorOptions()
+                       .dtype(get_libtorch_dtype(dtype))
+                       .device(get_libtorch_device(device_type, device_index))
+                       .requires_grad(requires_grad);
     tensor = new torch::Tensor;
-    *tensor = torch::empty(vshape, torch::dtype(get_libtorch_dtype(dtype)))
-                  .to(get_libtorch_device(device_type, device_index));
+    *tensor = torch::empty(vshape, options);
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
     delete tensor;
@@ -174,9 +177,12 @@ torch_tensor_t torch_zeros(int ndim, const int64_t *shape, torch_data_t dtype,
   try {
     // This doesn't throw if shape and dimensions are incompatible
     c10::IntArrayRef vshape(shape, ndim);
+    auto options = torch::TensorOptions()
+                       .dtype(get_libtorch_dtype(dtype))
+                       .device(get_libtorch_device(device_type, device_index))
+                       .requires_grad(requires_grad);
     tensor = new torch::Tensor;
-    *tensor = torch::zeros(vshape, torch::dtype(get_libtorch_dtype(dtype)))
-                  .to(get_libtorch_device(device_type, device_index));
+    *tensor = torch::zeros(vshape, options);
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
     delete tensor;
@@ -197,9 +203,12 @@ torch_tensor_t torch_ones(int ndim, const int64_t *shape, torch_data_t dtype,
   try {
     // This doesn't throw if shape and dimensions are incompatible
     c10::IntArrayRef vshape(shape, ndim);
+    auto options = torch::TensorOptions()
+                       .dtype(get_libtorch_dtype(dtype))
+                       .device(get_libtorch_device(device_type, device_index))
+                       .requires_grad(requires_grad);
     tensor = new torch::Tensor;
-    *tensor = torch::ones(vshape, torch::dtype(get_libtorch_dtype(dtype)))
-                  .to(get_libtorch_device(device_type, device_index));
+    *tensor = torch::ones(vshape, options);
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
     delete tensor;
@@ -225,10 +234,12 @@ torch_tensor_t torch_from_blob(void *data, int ndim, const int64_t *shape,
     // This doesn't throw if shape and dimensions are incompatible
     c10::IntArrayRef vshape(shape, ndim);
     c10::IntArrayRef vstrides(strides, ndim);
+    auto options = torch::TensorOptions()
+                       .dtype(get_libtorch_dtype(dtype))
+                       .device(get_libtorch_device(device_type, device_index))
+                       .requires_grad(requires_grad);
     tensor = new torch::Tensor;
-    *tensor = torch::from_blob(data, vshape, vstrides,
-                               torch::dtype(get_libtorch_dtype(dtype)))
-                  .to(get_libtorch_device(device_type, device_index));
+    *tensor = torch::from_blob(data, vshape, vstrides, options);
 
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -294,6 +294,11 @@ int torch_tensor_get_device_index(const torch_tensor_t tensor) {
   return t->device().index();
 }
 
+bool torch_tensor_requires_grad(const torch_tensor_t tensor) {
+  auto t = reinterpret_cast<torch::Tensor *>(tensor);
+  return t->requires_grad();
+}
+
 // =====================================================================================
 // --- Functions for deallocating tensors
 // =====================================================================================

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -156,6 +156,13 @@ EXPORT_C torch_device_t torch_tensor_get_device_type(const torch_tensor_t tensor
  */
 EXPORT_C int torch_tensor_get_device_index(const torch_tensor_t tensor);
 
+/**
+ * Function to determine whether a Torch Tensor requires the autograd module
+ * @param Torch Tensor to interrogate
+ * @return whether the Torch Tensor requires autograd
+ */
+EXPORT_C bool torch_tensor_requires_grad(const torch_tensor_t tensor);
+
 // =============================================================================
 // --- Functions for deallocating tensors
 // =============================================================================

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -1531,9 +1531,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, input%get_rank(), input%get_shape(), input%get_dtype(), &
-                              input%get_device_type(), input%get_device_index())
+                              input%get_device_type(), device_index=input%get_device_index(), &
+                              requires_grad=input%requires_grad())
     else if (input%get_device_type() /= output%get_device_type()) then
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
@@ -1564,10 +1564,10 @@ contains
       stop 1
     end if
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_add_c(output%p,tensor1%p, tensor2%p)
   end function torch_tensor_add
@@ -1588,9 +1588,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_negative_c(output%p, tensor%p)
   end function torch_tensor_negative
@@ -1619,10 +1619,10 @@ contains
     end if
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_subtract_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_subtract
@@ -1640,10 +1640,10 @@ contains
     end if
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_multiply_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_multiply
@@ -1657,9 +1657,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
@@ -1677,9 +1677,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
@@ -1697,9 +1697,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
@@ -1717,9 +1717,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
@@ -1737,9 +1737,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
@@ -1757,9 +1757,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
@@ -1778,9 +1778,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-multiplier
@@ -1798,9 +1798,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-multiplier
@@ -1818,9 +1818,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-multiplier
@@ -1838,9 +1838,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-multiplier
@@ -1858,9 +1858,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-multiplier
@@ -1878,9 +1878,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-multiplier
@@ -1902,10 +1902,10 @@ contains
     end if
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_divide_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_divide
@@ -1919,9 +1919,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-divisor
@@ -1939,9 +1939,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-divisor
@@ -1959,9 +1959,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-divisor
@@ -1979,9 +1979,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-divisor
@@ -1999,9 +1999,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-divisor
@@ -2019,9 +2019,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-divisor
@@ -2051,9 +2051,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int8
@@ -2078,9 +2078,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int16
@@ -2105,9 +2105,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int32
@@ -2132,9 +2132,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int64
@@ -2160,9 +2160,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_real32
@@ -2187,9 +2187,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_real64

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -36,6 +36,7 @@ module ftorch
     procedure :: get_dtype => torch_tensor_get_dtype
     procedure :: get_device_type => torch_tensor_get_device_type
     procedure :: get_device_index => torch_tensor_get_device_index
+    procedure :: requires_grad => torch_tensor_requires_grad
     final :: torch_tensor_delete
   end type torch_tensor
 
@@ -1455,6 +1456,24 @@ contains
     end if
     device_index = torch_tensor_get_device_index_c(self%p)
   end function torch_tensor_get_device_index
+
+  !> Determines whether a tensor requires the autograd module.
+  function torch_tensor_requires_grad(self) result(requires_grad)
+    class(torch_tensor), intent(in) :: self
+    logical :: requires_grad
+
+    interface
+      function torch_tensor_requires_grad_c(tensor) result(requires_grad) &
+          bind(c, name = 'torch_tensor_requires_grad')
+        use, intrinsic :: iso_c_binding, only : c_bool, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+        logical(c_bool) :: requires_grad
+      end function torch_tensor_requires_grad_c
+    end interface
+
+    requires_grad = torch_tensor_requires_grad_c(self%p)
+  end function torch_tensor_requires_grad
 
   ! ============================================================================
   ! --- Procedures for deallocating tensors

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -55,6 +55,7 @@ module ftorch
     procedure :: get_dtype => torch_tensor_get_dtype
     procedure :: get_device_type => torch_tensor_get_device_type
     procedure :: get_device_index => torch_tensor_get_device_index
+    procedure :: requires_grad => torch_tensor_requires_grad
     final :: torch_tensor_delete
   end type torch_tensor
 
@@ -569,6 +570,24 @@ contains
     end if
     device_index = torch_tensor_get_device_index_c(self%p)
   end function torch_tensor_get_device_index
+
+  !> Determines whether a tensor requires the autograd module.
+  function torch_tensor_requires_grad(self) result(requires_grad)
+    class(torch_tensor), intent(in) :: self
+    logical :: requires_grad
+
+    interface
+      function torch_tensor_requires_grad_c(tensor) result(requires_grad) &
+          bind(c, name = 'torch_tensor_requires_grad')
+        use, intrinsic :: iso_c_binding, only : c_bool, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+        logical(c_bool) :: requires_grad
+      end function torch_tensor_requires_grad_c
+    end interface
+
+    requires_grad = torch_tensor_requires_grad_c(self%p)
+  end function torch_tensor_requires_grad
 
   ! ============================================================================
   ! --- Procedures for deallocating tensors

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -645,9 +645,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, input%get_rank(), input%get_shape(), input%get_dtype(), &
-                              input%get_device_type(), input%get_device_index())
+                              input%get_device_type(), device_index=input%get_device_index(), &
+                              requires_grad=input%requires_grad())
     else if (input%get_device_type() /= output%get_device_type()) then
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
@@ -678,10 +678,10 @@ contains
       stop 1
     end if
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_add_c(output%p,tensor1%p, tensor2%p)
   end function torch_tensor_add
@@ -702,9 +702,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_negative_c(output%p, tensor%p)
   end function torch_tensor_negative
@@ -733,10 +733,10 @@ contains
     end if
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_subtract_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_subtract
@@ -754,10 +754,10 @@ contains
     end if
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_multiply_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_multiply
@@ -772,9 +772,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar pre-multiplier
@@ -795,9 +795,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-multiplier
@@ -820,10 +820,10 @@ contains
     end if
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_divide_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_divide
@@ -838,9 +838,9 @@ contains
     type(torch_tensor) :: wrk, output
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
 
     ! Create a tensor with a single entry, the scalar post-divisor
@@ -872,9 +872,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_${PREC}$
@@ -902,9 +902,9 @@ contains
     end interface
 
     if (.not. c_associated(output%p)) then
-      ! TODO: Pass requires_grad argument
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_${PREC}$

--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -80,7 +80,7 @@ contains
 
   ! Unit test for the torch_tensor_empty subroutine and for calling torch_tensor_delete manually or
   ! automatically (via torch_tensor's destructor)
-  @test(testParameters={get_parameters_full()})
+  @test(testparameters={get_parameters_full()})
   subroutine test_torch_tensor_empty(this)
     use ftorch, only: torch_tensor_empty
 

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -165,4 +165,30 @@ contains
 
   end subroutine test_torch_tensor_get_device_index_default
 
+  ! Unit test for the torch_tensor_requires_grad function
+  @test
+  subroutine test_torch_tensor_requires_grad()
+
+    implicit none
+
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    integer, parameter :: dtype = torch_kFloat32
+    logical, parameter :: expected = .true.
+
+    ! Create an empty tensor on the CPU with the default device type
+    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=expected)
+
+    ! Check that torch_tensor_get_device_type can get the device type
+    if (expected .neqv. tensor%requires_grad()) then
+      call torch_tensor_delete(tensor)
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+    call torch_tensor_delete(tensor)
+
+  end subroutine test_torch_tensor_requires_grad
+
 end module test_tensor_interrogation

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -65,7 +65,7 @@ contains
 
   ! Unit test for the torch_tensor_get_rank method of a 1D tensor
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_rank_1D(this)
+  subroutine test_get_rank_1D(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -77,11 +77,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertEqual(ndims, tensor%get_rank())
 
-  end subroutine test_torch_tensor_get_rank_1D
+  end subroutine test_get_rank_1D
 
   ! Unit test for the torch_tensor_get_rank method of a 2D tensor
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_rank_2D(this)
+  subroutine test_get_rank_2D(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 2
@@ -93,11 +93,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertEqual(ndims, tensor%get_rank())
 
-  end subroutine test_torch_tensor_get_rank_2D
+  end subroutine test_get_rank_2D
 
   ! Unit test for the torch_tensor_get_rank method of a 3D tensor
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_rank_3D(this)
+  subroutine test_get_rank_3D(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 3
@@ -109,11 +109,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertEqual(ndims, tensor%get_rank())
 
-  end subroutine test_torch_tensor_get_rank_3D
+  end subroutine test_get_rank_3D
 
   ! Unit test for the torch_tensor_get_shape method of a 1D tensor
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_shape_1D(this)
+  subroutine test_get_shape_1D(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -125,11 +125,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertTrue(all(tensor_shape == tensor%get_shape()))
 
-  end subroutine test_torch_tensor_get_shape_1D
+  end subroutine test_get_shape_1D
 
   ! Unit test for the torch_tensor_get_shape method of a 2D tensor
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_shape_2D(this)
+  subroutine test_get_shape_2D(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 2
@@ -141,11 +141,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertTrue(all(tensor_shape == tensor%get_shape()))
 
-  end subroutine test_torch_tensor_get_shape_2D
+  end subroutine test_get_shape_2D
 
   ! Unit test for the torch_tensor_get_shape method of a 3D tensor
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_shape_3D(this)
+  subroutine test_get_shape_3D(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 3
@@ -157,11 +157,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertTrue(all(tensor_shape == tensor%get_shape()))
 
-  end subroutine test_torch_tensor_get_shape_3D
+  end subroutine test_get_shape_3D
 
   ! Unit test for the torch_tensor_get_dtype function
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_dtype(this)
+  subroutine test_get_dtype(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -174,11 +174,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertEqual(expected, tensor%get_dtype())
 
-  end subroutine test_torch_tensor_get_dtype
+  end subroutine test_get_dtype
 
   ! Unit test for the torch_tensor_get_device_type function applied to a tensor on the CPU
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_device_type(this)
+  subroutine test_get_device_type(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -191,11 +191,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertEqual(expected, tensor%get_device_type())
 
-  end subroutine test_torch_tensor_get_device_type
+  end subroutine test_get_device_type
 
   ! Unit test for the torch_tensor_get_device_index function applied to a tensor on the CPU
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_get_device_index_default(this)
+  subroutine test_get_device_index_default(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -208,11 +208,11 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
     @assertEqual(expected, tensor%get_device_index())
 
-  end subroutine test_torch_tensor_get_device_index_default
+  end subroutine test_get_device_index_default
 
   ! Unit test for the default value of the torch_tensor_requires_grad function
   @test(testparameters={get_parameters_short()})
-  subroutine test_torch_tensor_requires_grad_default(this)
+  subroutine test_requires_grad_default(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -230,11 +230,11 @@ contains
       stop 999
     end if
 
-  end subroutine test_torch_tensor_requires_grad_default
+  end subroutine test_requires_grad_default
 
   ! Unit test for the torch_tensor_requires_grad function
   @test(testparameters={get_parameters_full()})
-  subroutine test_torch_tensor_requires_grad(this)
+  subroutine test_requires_grad(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -253,6 +253,6 @@ contains
       stop 999
     end if
 
-  end subroutine test_torch_tensor_requires_grad
+  end subroutine test_requires_grad
 
 end module test_tensor_interrogation

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -16,12 +16,57 @@ module test_tensor_interrogation
   ! Parameters common across all test cases
   integer, parameter :: device_type = torch_kCPU
 
+  ! Typedef holding a set of parameter values
+  @testParameter
+  type, extends(AbstractTestParameter) :: TestParametersType
+    logical :: requires_grad
+  contains
+    procedure :: toString
+  end type TestParametersType
+
+  ! Typedef for a test case with a particular set of parameters
+  @testCase(constructor=test_case_ctor)
+  type, extends (ParameterizedTestCase) :: TestCaseType
+    type(TestParametersType) :: param
+  end type TestCaseType
+
 contains
 
-  ! Unit test for the torch_tensor_get_rank method of a 1D tensor
-  @test
-  subroutine test_torch_tensor_get_rank_1D()
+  ! Constructor for the test case type
+  function test_case_ctor(param)
+    type(TestCaseType) :: test_case_ctor
+    type(TestParametersType), intent(in) :: param
+    test_case_ctor%param = param
+  end function test_case_ctor
 
+  ! A fixture comprised of a full list of parameter sets
+  function get_parameters_full() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [ &
+      TestParametersType(.false.), &
+      TestParametersType(.true.) &
+    ]
+  end function get_parameters_full
+
+  ! A fixture comprised of a short list of parameter sets
+  function get_parameters_short() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [TestParametersType(.false.)]
+  end function get_parameters_short
+
+  ! Function for representing a parameter set as a string
+  function toString(this) result(string)
+    class(TestParametersType), intent(in) :: this
+    character(:), allocatable :: string
+    character(len=3) :: str
+    write(str,"(l1)") this%requires_grad
+    string = str
+  end function toString
+
+  ! Unit test for the torch_tensor_get_rank method of a 1D tensor
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_rank_1D(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [6]
@@ -35,9 +80,9 @@ contains
   end subroutine test_torch_tensor_get_rank_1D
 
   ! Unit test for the torch_tensor_get_rank method of a 2D tensor
-  @test
-  subroutine test_torch_tensor_get_rank_2D()
-
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_rank_2D(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 2
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [2,3]
@@ -51,9 +96,9 @@ contains
   end subroutine test_torch_tensor_get_rank_2D
 
   ! Unit test for the torch_tensor_get_rank method of a 3D tensor
-  @test
-  subroutine test_torch_tensor_get_rank_3D()
-
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_rank_3D(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 3
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [1,2,3]
@@ -67,9 +112,9 @@ contains
   end subroutine test_torch_tensor_get_rank_3D
 
   ! Unit test for the torch_tensor_get_shape method of a 1D tensor
-  @test
-  subroutine test_torch_tensor_get_shape_1D()
-
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_shape_1D(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [6]
@@ -83,9 +128,9 @@ contains
   end subroutine test_torch_tensor_get_shape_1D
 
   ! Unit test for the torch_tensor_get_shape method of a 2D tensor
-  @test
-  subroutine test_torch_tensor_get_shape_2D()
-
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_shape_2D(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 2
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [2, 3]
@@ -99,9 +144,9 @@ contains
   end subroutine test_torch_tensor_get_shape_2D
 
   ! Unit test for the torch_tensor_get_shape method of a 3D tensor
-  @test
-  subroutine test_torch_tensor_get_shape_3D()
-
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_shape_3D(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 3
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [1, 2, 3]
@@ -115,9 +160,9 @@ contains
   end subroutine test_torch_tensor_get_shape_3D
 
   ! Unit test for the torch_tensor_get_dtype function
-  @test
-  subroutine test_torch_tensor_get_dtype()
-
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_dtype(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
     integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
@@ -132,9 +177,9 @@ contains
   end subroutine test_torch_tensor_get_dtype
 
   ! Unit test for the torch_tensor_get_device_type function applied to a tensor on the CPU
-  @test
-  subroutine test_torch_tensor_get_device_type()
-
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_device_type(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
     integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
@@ -149,9 +194,9 @@ contains
   end subroutine test_torch_tensor_get_device_type
 
   ! Unit test for the torch_tensor_get_device_index function applied to a tensor on the CPU
-  @test
-  subroutine test_torch_tensor_get_device_index_default()
-
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_get_device_index_default(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
     integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
@@ -165,12 +210,10 @@ contains
 
   end subroutine test_torch_tensor_get_device_index_default
 
-  ! Unit test for the torch_tensor_requires_grad function
-  @test
-  subroutine test_torch_tensor_requires_grad()
-
-    implicit none
-
+  ! Unit test for the default value of the torch_tensor_requires_grad function
+  @test(testparameters={get_parameters_short()})
+  subroutine test_torch_tensor_requires_grad_default(this)
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
     integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
@@ -183,11 +226,32 @@ contains
 
     ! Check that torch_tensor_get_device_type can get the device type
     if (expected .neqv. tensor%requires_grad()) then
-      call torch_tensor_delete(tensor)
       print *, "Error :: tensor%requires_grad() returned incorrect value"
       stop 999
     end if
-    call torch_tensor_delete(tensor)
+
+  end subroutine test_torch_tensor_requires_grad_default
+
+  ! Unit test for the torch_tensor_requires_grad function
+  @test(testparameters={get_parameters_full()})
+  subroutine test_torch_tensor_requires_grad(this)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    integer, parameter :: dtype = torch_kFloat32
+    logical :: expected
+
+    ! Create an empty tensor on the CPU with the default device type
+    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=this%param%requires_grad)
+
+    ! Check that torch_tensor_get_device_type can get the device type
+    expected = this%param%requires_grad
+    if (expected .neqv. tensor%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
 
   end subroutine test_torch_tensor_requires_grad
 


### PR DESCRIPTION
Towards #158.
(Refined from #286.)

This PR hooks the `requires_grad` option up properly and provides a `torch_tensor_requires_grad` function (as well as a `torch_tensor%requires_grad` method) to query this. Unit tests are written and the option is also used in the autograd example.