### PR TITLE
Patch docs to provide preprocessor macros to Ford

### DIFF
--- a/FTorch.md
+++ b/FTorch.md
@@ -15,7 +15,8 @@ extra_filetypes: c   //
                  h //
                  py  #
 preprocess: true
-macro: GPU_DEVICE_NONE=0
+macro: UNIX
+       GPU_DEVICE_NONE=0
        GPU_DEVICE_CUDA=1
        GPU_DEVICE_XPU=11
        GPU_DEVICE_MPS=12

--- a/FTorch.md
+++ b/FTorch.md
@@ -14,6 +14,11 @@ extra_filetypes: c   //
                  cpp //
                  h //
                  py  #
+preprocess: true
+macro: GPU_DEVICE_NONE=0
+       GPU_DEVICE_CUDA=1
+       GPU_DEVICE_XPU=11
+       GPU_DEVICE_MPS=12
 sort: alpha
 source: true
 graph: true

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -200,3 +200,6 @@ any further items are contained in `pages/` as markdown files.
 
 Documentation of the C functions in `ctorch.h` is provided
 by [Doxygen](https://www.doxygen.nl/index.html).
+
+Note that we need to define the macros for GPU devices that are passed to `ftorch.F90`
+via the C preprocessor in `FTorch.md` to match those in the CMakeLists.txt.


### PR DESCRIPTION
Definition of macros is required for generating documentation. Currently docs do not build properly as Ford cannot parse ftorch.F90. Also adds a note to the developer docs to remind people this needs keeping in sync.

Note - keep an eye on this in future, if Ford cannot parse a source file it generates a "warning" of the error rather than failing, so future PRs should include a cursory glance over what is generated.