### PR TITLE
Cut down unit test code using destructor

### DIFF
--- a/test/unit/test_tensor_constructors.pf
+++ b/test/unit/test_tensor_constructors.pf
@@ -133,21 +133,14 @@ contains
     ! Check that the tensor values are all zero
     expected(:,:) = 0.0
     test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_zeros")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: incorrect output from torch_tensor_zeros subroutine"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_zeros
 
@@ -187,21 +180,14 @@ contains
     ! Check that the tensor values are all one
     expected(:,:) = 1.0
     test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_ones")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: incorrect output from torch_tensor_ones subroutine"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_ones
 
@@ -244,21 +230,14 @@ contains
     ! Compare the data in the tensor to the input data
     expected(:) = in_data
     test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_from_array")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor)
-      end subroutine clean_up
 
   end subroutine test_torch_from_array_1d
 
@@ -301,21 +280,14 @@ contains
     ! Compare the data in the tensor to the input data
     expected(:,:) = in_data
     test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_from_array")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor)
-      end subroutine clean_up
 
   end subroutine test_torch_from_array_2d
 
@@ -357,21 +329,14 @@ contains
     ! Compare the data in the tensor to the input data
     expected(:,:,:) = in_data
     test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_from_array")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor)
-      end subroutine clean_up
 
   end subroutine test_torch_from_array_3d
 
@@ -417,21 +382,14 @@ contains
     ! Compare the data in the tensor to the input data 
     expected(:,:) = in_data
     test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_from_blob")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor)
-      end subroutine clean_up
 
   end subroutine test_torch_from_blob
 

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -6,8 +6,7 @@
 !    file for details.
 module test_tensor_interrogation
   use funit
-  use ftorch, only: torch_kFloat32, torch_kCPU, torch_tensor, torch_tensor_delete, &
-                    torch_tensor_empty
+  use ftorch, only: torch_kFloat32, torch_kCPU, torch_tensor, torch_tensor_empty
   use iso_c_binding, only: c_int64_t
 
   implicit none
@@ -33,12 +32,7 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
     ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%get_rank()) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_rank() returned incorrect rank for 1D tensor"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertEqual(ndims, tensor%get_rank())
 
   end subroutine test_torch_tensor_get_rank_1D
 
@@ -56,12 +50,7 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
     ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%get_rank()) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_rank() returned incorrect rank for 2D tensor"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertEqual(ndims, tensor%get_rank())
 
   end subroutine test_torch_tensor_get_rank_2D
 
@@ -79,12 +68,7 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_rank can correctly
     ! identify its rank
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (ndims /= tensor%get_rank()) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_rank() returned incorrect rank for 3D tensor"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertEqual(ndims, tensor%get_rank())
 
   end subroutine test_torch_tensor_get_rank_3D
 
@@ -102,12 +86,7 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
     ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%get_shape())) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_shape() returned incorrect shape for 1D tensor"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertTrue(all(tensor_shape == tensor%get_shape()))
 
   end subroutine test_torch_tensor_get_shape_1D
 
@@ -125,12 +104,7 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
     ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%get_shape())) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_shape() returned incorrect shape for 2D tensor"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertTrue(all(tensor_shape == tensor%get_shape()))
 
   end subroutine test_torch_tensor_get_shape_2D
 
@@ -148,12 +122,7 @@ contains
     ! Create a tensor with uninitialised values and check torch_tensor_get_shape can correctly
     ! identify its shape
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-    if (.not. all(tensor_shape == tensor%get_shape())) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_shape() returned incorrect shape for 3D tensor"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertTrue(all(tensor_shape == tensor%get_shape()))
 
   end subroutine test_torch_tensor_get_shape_3D
 
@@ -169,16 +138,10 @@ contains
     integer, parameter :: dtype = torch_kFloat32
     integer, parameter :: expected = torch_kFloat32
 
-    ! Create an empty tensor for 32-bit floats
+    ! Create an empty tensor for 32-bit floats and check that torch_tensor_get_dtype can get the
+    ! device type
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-
-    ! Check that torch_tensor_get_dtype can get the device type
-    if (expected /= tensor%get_dtype()) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_dtype() returned incorrect dtype"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertEqual(expected, tensor%get_dtype())
 
   end subroutine test_torch_tensor_get_dtype
 
@@ -194,16 +157,10 @@ contains
     integer, parameter :: dtype = torch_kFloat32
     integer, parameter :: expected = torch_kCPU
 
-    ! Create an empty tensor on the CPU with the default device type
+    ! Create an empty tensor on the CPU with the default device type and check that
+    ! torch_tensor_get_device_type can get the device type
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-
-    ! Check that torch_tensor_get_device_type can get the device type
-    if (expected /= tensor%get_device_type()) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_device_type() returned incorrect device type"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertEqual(expected, tensor%get_device_type())
 
   end subroutine test_torch_tensor_get_device_type
 
@@ -219,16 +176,10 @@ contains
     integer, parameter :: dtype = torch_kFloat32
     integer, parameter :: expected = -1
 
-    ! Create an empty tensor on the CPU with the default device index
+    ! Create an empty tensor on the CPU with the default device index and check that
+    ! torch_tensor_get_device_index can get the device index
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-
-    ! Check that torch_tensor_get_device_index can get the device index
-    if (expected /= tensor%get_device_index()) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: tensor%get_device_index() returned incorrect CPU device index"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertEqual(expected, tensor%get_device_index())
 
   end subroutine test_torch_tensor_get_device_index_default
 

--- a/test/unit/test_tensor_interrogation_cuda.pf
+++ b/test/unit/test_tensor_interrogation_cuda.pf
@@ -6,8 +6,7 @@
 !    file for details.
 module test_tensor_interrogation_cuda
   use funit
-  use ftorch, only: torch_kFloat32, torch_kCUDA, torch_tensor, torch_tensor_delete, &
-                    torch_tensor_empty
+  use ftorch, only: torch_kFloat32, torch_kCUDA, torch_tensor, torch_tensor_empty
   use iso_c_binding, only: c_int64_t
 
   implicit none
@@ -31,16 +30,10 @@ contains
     integer, parameter :: dtype = torch_kFloat32
     integer, parameter :: expected = torch_kCUDA
 
-    ! Create an empty tensor on the CUDAD device
+    ! Create an empty tensor on the CUDA device and check that torch_tensor_get_device_type can get
+    ! the device type
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-
-    ! Check that torch_tensor_get_device_type can get the device type
-    if (expected /= tensor%get_device_type()) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_device_type returned incorrect device type"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertEqual(expected, tensor%get_device_type())
 
   end subroutine test_torch_tensor_get_device_type
 
@@ -57,16 +50,10 @@ contains
     integer, parameter :: dtype = torch_kFloat32
     integer, parameter :: expected = 0
 
-    ! Create an empty tensor on the CUDA device with the default device index
+    ! Create an empty tensor on the CUDA device with the default device index and check that
+    ! torch_tensor_get_device_index can get the device index
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type)
-
-    ! Check that torch_tensor_get_device_index can get the device index
-    if (expected /= tensor%get_device_index()) then
-      call torch_tensor_delete(tensor)
-      print *, "Error :: torch_tensor_get_device_index returned incorrect CUDA device index"
-      stop 999
-    end if
-    call torch_tensor_delete(tensor)
+    @assertEqual(expected, tensor%get_device_index())
 
   end subroutine test_torch_tensor_get_device_index_default
 

--- a/test/unit/test_tensor_operator_overloads.pf
+++ b/test/unit/test_tensor_operator_overloads.pf
@@ -82,6 +82,7 @@ contains
     real(wp), dimension(2,3), target :: in_data
     real(wp), dimension(:,:), pointer :: out_data
     real(wp), dimension(2,3) :: expected
+    logical :: test_pass
 
     ! Create an arbitrary input array
     in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
@@ -95,7 +96,6 @@ contains
     ! Check input array is unchanged by the assignment
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     if (.not. assert_allclose(in_data, expected, test_name="test_torch_tensor_assign")) then
-      call clean_up()
       print *, "Error :: input array was changed during assignment"
       stop 999
     end if
@@ -103,22 +103,15 @@ contains
     ! Extract Fortran array from the assigned tensor and compare the data in the tensor to the input
     ! array
     call torch_tensor_to_array(tensor2, out_data, shape(in_data))
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_assign")) then
-      call clean_up()
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_assign")
+
+    ! Nullifying pointers used in the unit test
+    nullify(out_data)
+
+    if (.not. test_pass) then
       print *, "Error :: incorrect output from overloaded assignment operator"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_assign
 
@@ -141,6 +134,7 @@ contains
     real(wp), dimension(2,3), target :: in_data1, in_data2
     real(wp), dimension(:,:), pointer :: out_data
     real(wp), dimension(2,3) :: expected
+    logical :: test_pass
 
     ! Create two arbitrary input arrays
     in_data1(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
@@ -156,13 +150,11 @@ contains
     ! Check input arrays are unchanged by the addition
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     if (.not. assert_allclose(in_data1, expected, test_name="test_torch_tensor_add")) then
-      call clean_up()
       print *, "Error :: first input array was changed during addition"
       stop 999
     end if
     expected(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
     if (.not. assert_allclose(in_data2, expected, test_name="test_torch_tensor_add")) then
-      call clean_up()
       print *, "Error :: second input array was changed during addition"
       stop 999
     end if
@@ -171,23 +163,15 @@ contains
     ! of the input arrays
     call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
     expected(:,:) = in_data1 + in_data2
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_add")) then
-      call clean_up()
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_add")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
+    if (.not. test_pass) then
       print *, "Error :: incorrect output from overloaded addition operator"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-        call torch_tensor_delete(tensor3)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_add
 
@@ -210,6 +194,7 @@ contains
     real(wp), dimension(2,3), target :: in_data1, in_data2
     real(wp), dimension(:,:), pointer :: out_data
     real(wp), dimension(2,3) :: expected
+    logical :: test_pass
 
     ! Create two arbitrary input arrays
     in_data1(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
@@ -226,13 +211,11 @@ contains
     ! Check input arrays are unchanged by the subtraction
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     if (.not. assert_allclose(in_data1, expected, test_name="test_torch_tensor_subtract")) then
-      call clean_up()
       print *, "Error :: first input array was changed during subtraction"
       stop 999
     end if
     expected(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
     if (.not. assert_allclose(in_data2, expected, test_name="test_torch_tensor_subtract")) then
-      call clean_up()
       print *, "Error :: second input array was changed during subtraction"
       stop 999
     end if
@@ -241,23 +224,15 @@ contains
     ! difference of the input arrays
     call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
     expected(:,:) = in_data1 - in_data2
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_subtract")) then
-      call clean_up()
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_subtract")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
+    if (.not. test_pass) then
       print *, "Error :: incorrect output from overloaded subtraction operator"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-        call torch_tensor_delete(tensor3)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_subtract
 
@@ -300,7 +275,6 @@ contains
     ! Check input arrays are unchanged by the negation
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     if (.not. assert_allclose(in_data, expected, test_name="test_torch_tensor_negative")) then
-      call clean_up()
       print *, "Error :: first input array was changed during subtraction"
       stop 999
     end if
@@ -309,22 +283,15 @@ contains
     ! negative of the input array
     call torch_tensor_to_array(tensor2, out_data, shape(in_data))
     expected(:,:) = -in_data
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_negative")) then
-      call clean_up()
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_negative")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
+    if (.not. test_pass) then
       print *, "Error :: incorrect output from overloaded subtraction operator"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_negative
 
@@ -345,6 +312,7 @@ contains
     real(wp), dimension(2,3), target :: in_data1, in_data2
     real(wp), dimension(:,:), pointer :: out_data
     real(wp), dimension(2,3) :: expected
+    logical :: test_pass
 
     ! Create two arbitrary input arrays
     in_data1(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
@@ -361,13 +329,11 @@ contains
     ! Check input arrays are unchanged by the multiplication
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     if (.not. assert_allclose(in_data1, expected, test_name="test_torch_tensor_multiply")) then
-      call clean_up()
       print *, "Error :: first input array was changed during multiplication"
       stop 999
     end if
     expected(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
     if (.not. assert_allclose(in_data2, expected, test_name="test_torch_tensor_multiply")) then
-      call clean_up()
       print *, "Error :: second input array was changed during multiplication"
       stop 999
     end if
@@ -376,23 +342,15 @@ contains
     ! product of the input arrays
     call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
     expected(:,:) = in_data1 * in_data2
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_multiply")) then
-      call clean_up()
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_multiply")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
+    if (.not. test_pass) then
       print *, "Error :: incorrect output from overloaded multiplication operator"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-        call torch_tensor_delete(tensor3)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_multiply
 
@@ -436,7 +394,6 @@ contains
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_scalar_multiply")
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: input array was changed during scalar multiplication"
       stop 999
     end if
@@ -446,22 +403,14 @@ contains
     call torch_tensor_to_array(tensor2, out_data, shape(in_data))
     expected(:,:) = scalar * in_data
     test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_scalar_multiply")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: incorrect output from overloaded scalar multiplication operator"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_scalar_multiply
 
@@ -484,6 +433,7 @@ contains
     real(wp), dimension(2,3), target :: in_data1, in_data2
     real(wp), dimension(:,:), pointer :: out_data
     real(wp), dimension(2,3) :: expected
+    logical :: test_pass
 
     ! Create two arbitrary input arrays
     in_data1(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
@@ -499,13 +449,11 @@ contains
     ! Check input arrays are unchanged by the division
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     if (.not. assert_allclose(in_data1, expected, test_name="test_torch_tensor_divide")) then
-      call clean_up()
       print *, "Error :: first input array was changed during division"
       stop 999
     end if
     expected(:,:) = reshape([7.0, 8.0, 9.0, 10.0, 11.0, 12.0], [2, 3])
     if (.not. assert_allclose(in_data2, expected, test_name="test_torch_tensor_divide")) then
-      call clean_up()
       print *, "Error :: second input array was changed during division"
       stop 999
     end if
@@ -514,23 +462,15 @@ contains
     ! quotient of the input arrays
     call torch_tensor_to_array(tensor3, out_data, shape(in_data1))
     expected(:,:) = in_data1 / in_data2
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_divide")) then
-      call clean_up()
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_divide")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
+    if (.not. test_pass) then
       print *, "Error :: incorrect output from overloaded division operator"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-        call torch_tensor_delete(tensor3)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_divide
 
@@ -570,7 +510,6 @@ contains
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_scalar_divide")
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: input array was changed during scalar division"
       stop 999
     end if
@@ -580,22 +519,14 @@ contains
     call torch_tensor_to_array(tensor2, out_data, shape(in_data))
     expected(:,:) = in_data / scalar
     test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_scalar_divide")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
     if (.not. test_pass) then
-      call clean_up()
       print *, "Error :: incorrect output from overloaded scalar division operator"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_scalar_divide
 
@@ -618,6 +549,7 @@ contains
     real(wp), dimension(2,3), target :: in_data
     real(wp), dimension(:,:), pointer :: out_data
     real(wp), dimension(2,3) :: expected
+    logical :: test_pass
 
     ! Create an arbitrary input array
     in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
@@ -636,7 +568,6 @@ contains
     ! Check input array is unchanged by pre-multiplication
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     if (.not. assert_allclose(in_data, expected, test_name="test_torch_tensor_square")) then
-      call clean_up()
       print *, "Error :: input array was changed during exponentation (square)"
       stop 999
     end if
@@ -645,22 +576,15 @@ contains
     ! squared input array
     call torch_tensor_to_array(tensor2, out_data, shape(in_data))
     expected(:,:) = in_data ** 2
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_square")) then
-      call clean_up()
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_square")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
+    if (.not. test_pass) then
       print *, "Error :: incorrect output from overloaded exponentation operator (square)"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_square
 
@@ -684,6 +608,7 @@ contains
     real(wp), dimension(2,3), target :: in_data
     real(wp), dimension(:,:), pointer :: out_data
     real(wp), dimension(2,3) :: expected
+    logical :: test_pass
 
     ! Create an arbitrary input array
     in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
@@ -698,7 +623,6 @@ contains
     ! Check input array is unchanged by taking the square root
     expected(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
     if (.not. assert_allclose(in_data, expected, test_name="test_torch_tensor_sqrt")) then
-      call clean_up()
       print *, "Error :: input array was changed during exponentation (square root)"
       stop 999
     end if
@@ -707,22 +631,15 @@ contains
     ! square root of the input array
     call torch_tensor_to_array(tensor2, out_data, shape(in_data))
     expected(:,:) = in_data ** 0.5
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_sqrt")) then
-      call clean_up()
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_sqrt")
+
+    ! Nullify pointers used in the unit test
+    nullify(out_data)
+
+    if (.not. test_pass) then
       print *, "Error :: incorrect output from overloaded exponentiation operator (square root)"
       stop 999
     end if
-
-    call clean_up()
-
-    contains
-
-      ! Subroutine for freeing memory and nullifying pointers used in the unit test
-      subroutine clean_up()
-        nullify(out_data)
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-      end subroutine clean_up
 
   end subroutine test_torch_tensor_sqrt
 


### PR DESCRIPTION
This PR tidies up the unit tests considerably in light of #297.

There's no longer any need to call `torch_tensor_delete` (except for the test of it). I also spotted a way to refactor the error raising so that we don't need all the `clean_up` subroutines.

In some cases, we can use the inbuilt pFUnit assertions, which is nice.