### PR TITLE
Add a standalone `SimpleNet` example build to the CI

### DIFF
--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -108,3 +108,17 @@ jobs:
         run: |
           . ftorch/bin/activate
           ./run_test_suite.sh --verbose --integration-only
+
+      - name: Standalone SimpleNet example build
+        run: |
+          . ftorch/bin/activate
+          export FTORCH_BUILD_DIR="$(pwd)/build"
+          cd examples/1_SimpleNet
+          export BUILD_DIR="$(pwd)/build"
+          mkdir "${BUILD_DIR}"
+          cd "${BUILD_DIR}"
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}" \
+            -DCMAKE_Fortran_FLAGS="-std=${{ matrix.std }}"
+          cmake --build .

--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -83,16 +83,15 @@ jobs:
         run: |
           . ftorch/bin/activate
           VN=$(python -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
-          export Torch_DIR=${VIRTUAL_ENV}/lib/python${VN}/site-packages
-          export BUILD_DIR=$(pwd)/build
+          export Torch_DIR="${VIRTUAL_ENV}/lib/python${VN}/site-packages"
+          export BUILD_DIR="$(pwd)/build"
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR=$(pwd)/pFUnit/build/installed/PFUNIT-4.10
-          mkdir ${BUILD_DIR}
-          cd ${BUILD_DIR}
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-4.10"
+          mkdir "${BUILD_DIR}"
+          cd "${BUILD_DIR}"
           cmake .. \
-            -DPython_EXECUTABLE="$(which python)" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} \
+            -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}" \
             -DCMAKE_BUILD_TESTS=TRUE \
             -DCMAKE_PREFIX_PATH="${PFUNIT_DIR};${Torch_DIR}" \
             -DCMAKE_Fortran_FLAGS="-std=${{ matrix.std }}"


### PR DESCRIPTION
This PR adds an additional build step for one of the examples to check that we can build it with CMake separately from FTorch without needing to set `LD_LIBRARY_PATH` etc.