### PR TITLE
Fortitude v0.7

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           . ftorch_venv/bin/activate
-          fortitude check --ignore=E001,T041 src/ftorch.F90
+          fortitude check src/ftorch.F90
           fortitude check src/ftorch_test_utils.f90
 
       # Apply C++ and C linter and formatter, clang

--- a/fortitude.toml
+++ b/fortitude.toml
@@ -1,4 +1,5 @@
 [check]
 # Ignored Rules and justification:
-#   T041: assumed size - we require assumed size for library functionality when passing data to C/C++
-ignore = ["T041"]
+#   C003: 'implicit none' missing 'external' - this is a Fortran 2013 feature and we support older standards
+#   C071: assumed size - we require assumed size for library functionality when passing data to C/C++
+ignore = ["C003", "C071"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ruff==0.7.3
-fortitude-lint==0.6.0
+fortitude-lint==0.7.0
 clang-format==19.1.3
 clang-tidy==19.1.0
 cmakelang

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -13,6 +13,8 @@ module ftorch
 
   implicit none
 
+  public
+
   ! Set integer size for FTorch library
   integer, parameter :: ftorch_int = int32
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -32,6 +32,8 @@ module ftorch
 
   implicit none
 
+  public
+
   ! Set integer size for FTorch library
   integer, parameter :: ftorch_int = int32
 

--- a/src/ftorch_test_utils.f90
+++ b/src/ftorch_test_utils.f90
@@ -11,6 +11,8 @@ module ftorch_test_utils
 
   implicit none
 
+  public
+
   interface assert_isclose
     module procedure assert_isclose_real32
     module procedure assert_isclose_real64

--- a/src/ftorch_test_utils.fypp
+++ b/src/ftorch_test_utils.fypp
@@ -19,6 +19,8 @@ module ftorch_test_utils
 
   implicit none
 
+  public
+
   interface assert_isclose
     #:for PREC in PRECISIONS
     module procedure assert_isclose_${PREC}$

--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -39,7 +39,7 @@ contains
   ! Constructor for the test case type
   function test_case_ctor(param)
     type(TestCaseType) :: test_case_ctor
-    type(TestParametersType) :: param
+    type(TestParametersType), intent(in) :: param
     test_case_ctor%param = param
   end function test_case_ctor
 
@@ -396,7 +396,7 @@ contains
     ! assignment operator
     tensor2 = tensor1
 
-    ! Compare the data in the tensor to the input data 
+    ! Compare the data in the tensor to the input data
     test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_blob")
 
     if (.not. test_pass) then

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -22,8 +22,6 @@ contains
   @test
   subroutine test_torch_tensor_get_rank_1D()
 
-    implicit none
-
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [6]
@@ -39,8 +37,6 @@ contains
   ! Unit test for the torch_tensor_get_rank method of a 2D tensor
   @test
   subroutine test_torch_tensor_get_rank_2D()
-
-    implicit none
 
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 2
@@ -58,8 +54,6 @@ contains
   @test
   subroutine test_torch_tensor_get_rank_3D()
 
-    implicit none
-
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 3
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [1,2,3]
@@ -75,8 +69,6 @@ contains
   ! Unit test for the torch_tensor_get_shape method of a 1D tensor
   @test
   subroutine test_torch_tensor_get_shape_1D()
-
-    implicit none
 
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -94,8 +86,6 @@ contains
   @test
   subroutine test_torch_tensor_get_shape_2D()
 
-    implicit none
-
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 2
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [2, 3]
@@ -112,8 +102,6 @@ contains
   @test
   subroutine test_torch_tensor_get_shape_3D()
 
-    implicit none
-
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 3
     integer(kind=c_int64_t), parameter :: tensor_shape(ndims) = [1, 2, 3]
@@ -129,8 +117,6 @@ contains
   ! Unit test for the torch_tensor_get_dtype function
   @test
   subroutine test_torch_tensor_get_dtype()
-
-    implicit none
 
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
@@ -149,8 +135,6 @@ contains
   @test
   subroutine test_torch_tensor_get_device_type()
 
-    implicit none
-
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1
     integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
@@ -167,8 +151,6 @@ contains
   ! Unit test for the torch_tensor_get_device_index function applied to a tensor on the CPU
   @test
   subroutine test_torch_tensor_get_device_index_default()
-
-    implicit none
 
     type(torch_tensor) :: tensor
     integer, parameter :: ndims = 1

--- a/test/unit/test_tensor_operator_overloads.pf
+++ b/test/unit/test_tensor_operator_overloads.pf
@@ -50,7 +50,7 @@ contains
   ! Constructor for the test case type
   function test_case_ctor(param)
     type(TestCaseType) :: test_case_ctor
-    type(TestParametersType) :: param
+    type(TestParametersType), intent(in) :: param
     test_case_ctor%param = param
   end function test_case_ctor
 
@@ -66,8 +66,6 @@ contains
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_assign(this)
     use, intrinsic :: iso_fortran_env, only: sp => real32
-
-    implicit none
 
     ! Set working precision for reals
     integer, parameter :: wp = sp
@@ -115,8 +113,6 @@ contains
   subroutine test_torch_tensor_add(this)
     use ftorch, only: operator(+)
     use, intrinsic :: iso_fortran_env, only: sp => real32
-
-    implicit none
 
     ! Set working precision for reals
     integer, parameter :: wp = sp
@@ -171,8 +167,6 @@ contains
   subroutine test_torch_tensor_subtract(this)
     use ftorch, only: operator(-)
     use, intrinsic :: iso_fortran_env, only: sp => real32
-
-    implicit none
 
     ! Set working precision for reals
     integer, parameter :: wp = sp
@@ -232,8 +226,6 @@ contains
     use ftorch_test_utils, only: assert_allclose
     use, intrinsic :: iso_fortran_env, only: sp => real32
     use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
-
-    implicit none
 
     ! Set working precision for reals
     integer, parameter :: wp = sp
@@ -338,8 +330,6 @@ contains
     use ftorch, only: operator(*)
     use, intrinsic :: iso_fortran_env, only: sp => real32
 
-    implicit none
-
     ! Set working precision for reals
     integer, parameter :: wp = sp
 
@@ -393,8 +383,6 @@ contains
   subroutine test_torch_tensor_divide(this)
     use ftorch, only: operator(/)
     use, intrinsic :: iso_fortran_env, only: sp => real32
-
-    implicit none
 
     ! Set working precision for reals
     integer, parameter :: wp = sp
@@ -450,8 +438,6 @@ contains
     use ftorch, only: operator(/)
     use, intrinsic :: iso_fortran_env, only: sp => real32
 
-    implicit none
-
     ! Set working precision for reals
     integer, parameter :: wp = sp
 
@@ -501,8 +487,6 @@ contains
   subroutine test_torch_tensor_square(this)
     use ftorch, only: operator(**)
     use, intrinsic :: iso_fortran_env, only: sp => real32
-
-    implicit none
 
     ! Set working precision for reals
     integer, parameter :: wp = sp
@@ -556,8 +540,6 @@ contains
     use ftorch, only: operator(**)
     use, intrinsic :: iso_fortran_env, only: sp => real32
     use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
-
-    implicit none
 
     ! Set working precision for reals
     integer, parameter :: wp = sp


### PR DESCRIPTION
This PR updates to use the latest version of the Fortran fortitude linter which included a few API changes

Notably it adds:

- Ignoring of `C003` 'implicit none' missing 'external' as this is a f2013 feature and we want to support back to f2008.
- Adding an explicit `public` statement to the ftorch and test utils modules.
  - This is correct for the test utils, but I think we should have a discussion about whether everything in the ftorch module should be public.