### PR TITLE
Versioning and Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,19 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
 
 ### Added
 
+- `requires_grad` property hooked up to `torch_tensor` in [#288](https://github.com/Cambridge-ICCS/FTorch/pull/288)
+- MPI example added in [#270](https://github.com/Cambridge-ICCS/FTorch/pull/270)
+- Changelog file and guidance for versioning added in [#313](https://github.com/Cambridge-ICCS/FTorch/pull/313)
 
 ### Changed
 
 - fortitude dependency version increased to 0.7.0
+- Examples reordered to be more logical in [#317](https://github.com/Cambridge-ICCS/FTorch/pull/317)
+- scalar multiplication/division of tensors reworked to require the scalar to first be mapped to a `torch_tensor` in [#289](https://github.com/Cambridge-ICCS/FTorch/pull/289)
 
 ### Removed
 
+- Windows CI disabled until GitHub runner issues resolved in [50ea6d7](https://github.com/Cambridge-ICCS/FTorch/commit/50ea6d78d79ebe638ebe597e745c015549f12a61)
 
 ### Patch Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All [notable](https://cambridge-iccs.github.io/FTorch/page/developer.html#versioning-and-changelog)
+changes to the project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+For specific details see the [FTorch online documentation](https://cambridge-iccs.github.io/FTorch/page/developer.html#versioning-and-changelog).
 
-## [Unreleased]
+## [Unreleased](https://github.com/Cambridge-ICCS/FTorch/compare/v1.0.0...HEAD)
 
 ### Added
 
@@ -17,7 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
-## [1.0.0] - 2025-03-05
+### Patch Releases
+
+
+## [1.0.0](https://github.com/Cambridge-ICCS/FTorch/releases/tag/v1.0.0) - 2025-03-05
 
 ### Added
 
@@ -35,6 +40,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation:
   - README.md and associated files in repository
   - Online API and comprehensive docs build using [FORD](https://forddocs.readthedocs.io/)
-
-[unreleased]: https://github.com/Cambridge-ICCS/FTorch/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/Cambridge-ICCS/FTorch/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+
+### Changed
+
+- fortitude dependency version increased to 0.7.0
+
+### Removed
+
+
+## [1.0.0] - 2025-03-05
+
+### Added
+
+- First release of FTorch accompanying pulication in JOSS
+- MIT License
+- Notable features of the library include:
+  - Representation of Torch tensors and models in Fortran
+  - Ability to run inference of Torch models from Fortran
+  - Early implementation of autograd features for Torch tensors in Fortran
+- Comprehensive examples suite showcasing usage
+- Testing suites:
+  - Unit, using [pFUnit](https://github.com/Goddard-Fortran-Ecosystem/pFUnit)
+  - Integration, based on examples
+- Code quality and static analysis checks
+- Documentation:
+  - README.md and associated files in repository
+  - Online API and comprehensive docs build using [FORD](https://forddocs.readthedocs.io/)
+
+[unreleased]: https://github.com/Cambridge-ICCS/FTorch/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/Cambridge-ICCS/FTorch/releases/tag/v1.0.0

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -1,0 +1,3 @@
+title: FTorch Changelog
+
+{!CHANGELOG.md!}

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -175,6 +175,23 @@ checks on all opened pull requests before they are merged.
 
 ## Documentation
 
+### Versioning and Changelog
+
+FTorch has follows [semantic versioning](https://semver.org/).
+
+- Major releases for API changes
+- Minor releases periodically for new features
+- Patches for bug fixes
+
+New minor releases are made when deemed appropriate by maintainers by adding a tag to
+the commit and greating a corresponding GitHub Release.
+
+A log of notable changes to the software is kept in `CHANGELOG.md`.
+This follows the conventions of [Keep a Changelog](https://keepachangelog.com/) and should
+be updated by contributors and maintainers as part of a pull request when appropriate.
+
+### API Documentation
+
 The API documentation for FTorch is generated using 
 [FORD](https://forddocs.readthedocs.io/en/latest/).
 For detailed information refer to the 

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -183,12 +183,26 @@ FTorch has follows [semantic versioning](https://semver.org/).
 - Minor releases periodically for new features
 - Patches for bug fixes
 
-New minor releases are made when deemed appropriate by maintainers by adding a tag to
-the commit and greating a corresponding GitHub Release.
+The project version should be updated accordingly through the `PACKAGE_VERSION` in
+CMakeLists.txt for each new release.
 
 A log of notable changes to the software is kept in `CHANGELOG.md`.
 This follows the conventions of [Keep a Changelog](https://keepachangelog.com/) and should
 be updated by contributors and maintainers as part of a pull request when appropriate.
+<br>
+"Notable" includes new features, bugfixes, dependency updates etc.
+<br>
+"Notable" does not cover typo corrections documentation rephrasing and restyling,
+or correction of other minor infelicities that do not impact the user or developer
+
+New minor releases are made when deemed appropriate by maintainers by adding a tag to
+the commit and creating a corresponding GitHub Release.
+The minor number of the version should be incremented, the entry for the version
+finalised in the changelog, and a clean log for 'Unreleased' changed created.
+
+New patch releases are made whenever a bugfix is merged.
+The patch number of the version should be incremented, and a note made under the current
+'Unreleased' header in the changelog.
 
 ### API Documentation
 

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -198,11 +198,11 @@ or correction of other minor infelicities that do not impact the user or develop
 New minor releases are made when deemed appropriate by maintainers by adding a tag to
 the commit and creating a corresponding GitHub Release.
 The minor number of the version should be incremented, the entry for the version
-finalised in the changelog, and a clean log for 'Unreleased' changed created.
+finalised in the changelog, and a clean log for 'Unreleased' changes created.
 
 New patch releases are made whenever a bugfix is merged.
-The patch number of the version should be incremented, and a note made under the current
-'Unreleased' header in the changelog.
+The patch number of the version should be incremented, a tag attached to the commit,
+and a note made under the current 'Unreleased' patches header in the changelog.
 
 ### API Documentation
 

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -192,8 +192,8 @@ be updated by contributors and maintainers as part of a pull request when approp
 <br>
 "Notable" includes new features, bugfixes, dependency updates etc.
 <br>
-"Notable" does not cover typo corrections documentation rephrasing and restyling,
-or correction of other minor infelicities that do not impact the user or developer
+"Notable" does not cover typo corrections, documentation rephrasing and restyling,
+or correction of other minor infelicities that do not impact the user or developer.
 
 New minor releases are made when deemed appropriate by maintainers by adding a tag to
 the commit and creating a corresponding GitHub Release.

--- a/pages/updates.md
+++ b/pages/updates.md
@@ -1,9 +1,20 @@
 title: Recent API Changes
 
+In the build-up to the release of version 1.0.0 of FTorch the library API went through
+a number of iterations, some of which were breaking.
+The changes required to migrate from these older versions to version 1.0.0 are detailed
+on this page.
+
+For more recent updates after the release of version 1.0.0 please refer to the ongoing
+changelog, either on [GitHub](https://github.com/Cambridge-ICCS/FTorch/blob/main/CHANGELOG.md)
+on [this website](page/changelog.html).
+
+[TOC]
+
 ## February 2025
 
 If you use a version of FTorch from before commit
-[c85185e](c85185e6c261606c212dd11fee734663d610b695)
+[c85185e](https://github.com/Cambridge-ICCS/FTorch/commit/c85185e6c261606c212dd11fee734663d610b695)
 (February 2025) you will notice that the main `CMakeLists.txt` file has moved
 from `src/` to the root level of the FTorch repository. This move was mainly to
 simplify the development experience, such that the examples could be built as
@@ -26,7 +37,7 @@ cmake .. <CMAKE_ARGUMENTS>
 ## January 2025
 
 If you use a version of FTorch from before commit
-[c488f20](c488f20d8d49a15f98176c39a6c8e8db8e708f51)
+[c488f20](https://github.com/Cambridge-ICCS/FTorch/commit/c488f20d8d49a15f98176c39a6c8e8db8e708f51)
 (January 2025) you may notice that the `device_type` argument for
 `torch_model_load` changed from being optional to being compulsory. This is
 because the optional argument defaulted to `torch_kCPU`, which is not suitable
@@ -47,10 +58,6 @@ This is because a number of breaking changes were made to the FTorch API in prep
 for implementing new functionalities.
 
 This page describes how to migrate from code (pre-e92ad9e) to the most recent version.
-
-If you are already using a more recent version there is no need to read this page.
-
-[TOC]
 
 ### Why?
 


### PR DESCRIPTION
Aims to address #312 

This PR adds a Changelog following https://keepachangelog.com/en/1.0.0/ and sets out guidance for how we should version the project in the future moving forward from 1.0.0

I do not intend this to be fully correct, but wanted to start the discussion so we can move towards something we agree on that is workable and get it in, as I feel it is important now.