### PR TITLE
Add Park and Chung paper and add other details

### DIFF
--- a/FTorch.md
+++ b/FTorch.md
@@ -83,16 +83,17 @@ Projects using FTorch
 The following projects make use of FTorch.  
 If you use our library in your work please let us know.
 
-* [M2LInES CAM-ML](https://github.com/m2lines/CAM-ML) -
-  Using FTorch to couple a neural net parameterisation of convection to the CAM
-  atmospheric model in CESM.
 * [DataWave CAM-GW](https://github.com/DataWaveProject/CAM/) -
   Using FTorch to couple neural net parameterisations of gravity waves to the CAM
   atmospheric model.
 * [MiMA Machine Learning](https://github.com/DataWaveProject/MiMA-machine-learning) -
-  Using FTorch to couple a neural net parameterisation of gravity waves to the MiMA
-  atmospheric model.
+  Implementing a neural net parameterisation of gravity waves in the MiMA atmospheric model.
+  Demonstrates that nets trained near-identically offline can display greatly varied behaviours when coupled online.
   See Mansfield and Sheshadri (2024) - [DOI: 10.1029/2024MS004292](https://doi.org/10.1029/2024MS004292)
 * [Convection parameterisations in ICON](https://github.com/EyringMLClimateGroup/heuer23_ml_convection_parameterization) -
-  Implementing machine learnt convection parameterisations in the ICON atmospheric model.
-  See Heuer et al (2023) - [DOI: 10.48550/arXiv.2311.03251](https://doi.org/10.48550/arXiv.2311.03251)
+  Implementing machine-learnt convection parameterisations in the ICON atmospheric model
+  showing that best online performance occurs when causal relations are eliminated from the net.
+  See Heuer et al (2024) - [DOI: 10.1029/2024MS004398](https://doi.org/10.1029/2024MS004398)
+* In the [GloSea6 Seasonal Forecasting Model](https://www.metoffice.gov.uk/research/climate/seasonal-to-decadal/gpc-outlooks/user-guide/global-seasonal-forecasting-system-glosea6) -
+  Replacing a BiCGStab bottleneck in the code with a deep learning approach to speed up execution without compromising model accuracy.
+  See Park and Chung (2025) - [DOI: 10.3390/atmos16010060](https://doi.org/10.3390/atmos16010060)

--- a/README.md
+++ b/README.md
@@ -304,11 +304,12 @@ for a full list of contributors.
 ## Used by
 The following projects make use of this code or derivatives in some way:
 
-* [M2LInES CAM-ML](https://github.com/m2lines/CAM-ML)
 * [DataWave CAM-GW](https://github.com/DataWaveProject/CAM/)
 * [DataWave - MiMA ML](https://github.com/DataWaveProject/MiMA-machine-learning)\
   See Mansfield and Sheshadri (2024) - [DOI: 10.1029/2024MS004292](https://doi.org/10.1029/2024MS004292)
 * [Convection parameterisations in ICON](https://github.com/EyringMLClimateGroup/heuer23_ml_convection_parameterization)\
-  See Heuer et al. (2023) - [DOI: 10.48550/arXiv.2311.03251](https://doi.org/10.48550/arXiv.2311.03251)
+  See Heuer et al. (2024) - [DOI: 10.1029/2024MS004398](https://doi.org/10.1029/2024MS004398)
+* To replace a BiCGStab bottleneck in the GloSea6 Seasonal Forecasting model\
+  See Park and Chung (2025) - [DOI: 10.3390/atmos16010060](https://doi.org/10.3390/atmos16010060)
 
 Are we missing anyone? Let us know.


### PR DESCRIPTION
Adds the recent paper by Park and Chung as discussed.

Also updates the link and DOI for Heuer et al to the published version, removes CAM-ML as not actively using FTorch at the moment, and adds a brief description of what the papers show to the online docs.