### PR TITLE
Temporarily disable Windows CI

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -3,25 +3,26 @@ name: TestSuiteWindows
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
-  push:
-    branches: [ "main" ]
-
-  # Triggers the workflow on pushes to open pull requests with code changes
-  pull_request:
-    paths:
-      - '.github/workflows/test_suite_windows.yml'
-      - '**.bat'
-      - '**.c'
-      - '**.cpp'
-      - '**.fypp'
-      - '**.f90'
-      - '**.F90'
-      - '**.pf'
-      - '**.py'
-      - '**CMakeLists.txt'
-      - '**requirements.txt'
-      - '**data/*'
+  # TODO: Re-enable when fixing the current issue with the Windows CI (see #300).
+  # # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
+  # push:
+  #   branches: [ "main" ]
+  #
+  # # Triggers the workflow on pushes to open pull requests with code changes
+  # pull_request:
+  #   paths:
+  #     - '.github/workflows/test_suite_windows.yml'
+  #     - '**.bat'
+  #     - '**.c'
+  #     - '**.cpp'
+  #     - '**.fypp'
+  #     - '**.f90'
+  #     - '**.F90'
+  #     - '**.pf'
+  #     - '**.py'
+  #     - '**CMakeLists.txt'
+  #     - '**requirements.txt'
+  #     - '**data/*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The current issue with the Windows CI (#300) is causing those tests to fail. Rather than having those tests run and fail with each commit pushed to a PR, let's just disable the Windows CI for now.