### PR TITLE
Add tests for constructing after destructing

### DIFF
--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -45,20 +45,23 @@ contains
     test_case_ctor%param = param
   end function test_case_ctor
 
-  ! A fixture comprised of a full list of parameter sets
-  function get_parameters_full() result(params)
+  ! A fixture comprised of parameter sets for destructor tests
+  function get_parameters_destruction() result(params)
     type(TestParametersType), allocatable :: params(:)
     params = [ &
       TestParametersType(.false.,.false.,1), &
       TestParametersType(.false.,.false.,2), &
       TestParametersType(.false.,.true.,1), &
-      TestParametersType(.false.,.true.,2), &
-      TestParametersType(.true.,.false.,1), &
-      TestParametersType(.true.,.false.,2), &
-      TestParametersType(.true.,.true.,1), &
-      TestParametersType(.true.,.true.,2) &
+      TestParametersType(.false.,.true.,2) &
     ]
-  end function get_parameters_full
+  end function get_parameters_destruction
+
+  ! A fixture comprised of a short list of parameter sets
+  function get_parameters_requires_grad() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [TestParametersType(.false.,.false.,1)]
+    params = [TestParametersType(.true.,.false.,1)]
+  end function get_parameters_requires_grad
 
   ! A fixture comprised of a short list of parameter sets
   function get_parameters_short() result(params)
@@ -75,10 +78,35 @@ contains
     string = str
   end function toString
 
-  ! Unit test for the torch_tensor_empty subroutine and for calling torch_tensor_delete manually or
-  ! automatically (via torch_tensor's destructor)
-  @test(testparameters={get_parameters_full()})
+  ! Unit test for the torch_tensor_empty subroutine
+  @test(testparameters={get_parameters_requires_grad()})
   subroutine test_torch_tensor_empty(this)
+    use ftorch, only: torch_tensor_empty
+
+    implicit none
+
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 2
+    integer(c_int64_t), dimension(2), parameter :: tensor_shape = [2, 3]
+    integer, parameter :: dtype = torch_kFloat32
+
+    ! Check the tensor pointer is not associated
+    @assertFalse(c_associated(tensor%p))
+
+    ! Create a tensor without any data values assigned
+    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index, &
+                            this%param%requires_grad)
+
+    ! Check the tensor pointer is associated
+    @assertTrue(c_associated(tensor%p))
+
+  end subroutine test_torch_tensor_empty
+
+  ! Unit test for destroying tensors, both manually with torch_tensor_delete and automatically (via
+  ! torch_tensor's destructor)
+  @test(testparameters={get_parameters_destruction()})
+  subroutine test_torch_tensor_destruction(this)
     use ftorch, only: torch_tensor_empty
 
     implicit none
@@ -96,8 +124,7 @@ contains
       @assertFalse(c_associated(tensor%p))
 
       ! Create a tensor without any data values assigned
-      call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index, &
-                              this%param%requires_grad)
+      call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index)
 
       ! Check the tensor pointer is associated
       @assertTrue(c_associated(tensor%p))
@@ -112,11 +139,10 @@ contains
 
     end do
 
-  end subroutine test_torch_tensor_empty
+  end subroutine test_torch_tensor_destruction
 
-  ! Unit test for the torch_tensor_zeros subroutine and for calling torch_tensor_delete manually or
-  ! automatically (via torch_tensor's destructor)
-  @test(testParameters={get_parameters_full()})
+  ! Unit test for the torch_tensor_zeros subroutine
+  @test(testParameters={get_parameters_requires_grad()})
   subroutine test_torch_tensor_zeros(this)
     use ftorch, only: torch_tensor_zeros
     use, intrinsic :: iso_fortran_env, only: sp => real32
@@ -135,53 +161,37 @@ contains
     real(wp), dimension(2,3), target :: out_data
     real(wp), dimension(2,3) :: expected
     logical :: test_pass
-    integer :: i
 
-    do i = 1, this%param%iterations
+    ! Check the tensor pointer is not associated
+    @assertFalse(c_associated(tensor1%p))
 
-      ! Check the tensor pointer is not associated
-      @assertFalse(c_associated(tensor1%p))
+    ! Create a tensor of zeros
+    call torch_tensor_zeros(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
+                            this%param%requires_grad)
 
-      ! Create a tensor of zeros
-      call torch_tensor_zeros(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
-                              this%param%requires_grad)
+    ! Check the tensor pointer is associated
+    @assertTrue(c_associated(tensor1%p))
 
-      ! Check the tensor pointer is associated
-      @assertTrue(c_associated(tensor1%p))
+    ! Create a tensor based off an output array
+    call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
 
-      ! Create a tensor based off an output array
-      call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
+    ! Set the values of the second tensor to match those of the first using the overloaded
+    ! assignment operator
+    tensor2 = tensor1
 
-      ! Set the values of the second tensor to match those of the first using the overloaded
-      ! assignment operator
-      tensor2 = tensor1
+    ! Check that the tensor values are all zero
+    expected(:,:) = 0.0
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_zeros")
 
-      ! Check that the tensor values are all zero
-      expected(:,:) = 0.0
-      test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_zeros")
-
-      if (.not. test_pass) then
-        print *, "Error :: incorrect output from torch_tensor_zeros subroutine"
-        stop 999
-      end if
-
-      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
-        ! Call torch_tensor_delete manually
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-
-        ! Check torch_tensor_delete does indeed free the memory
-        @assertFalse(c_associated(tensor1%p))
-        @assertFalse(c_associated(tensor2%p))
-      end if
-
-    end do
+    if (.not. test_pass) then
+      print *, "Error :: incorrect output from torch_tensor_zeros subroutine"
+      stop 999
+    end if
 
   end subroutine test_torch_tensor_zeros
 
-  ! Unit test for the torch_tensor_ones subroutine and for calling torch_tensor_delete manually or
-  ! automatically (via torch_tensor's destructor)
-  @test(testParameters={get_parameters_full()})
+  ! Unit test for the torch_tensor_ones subroutine
+  @test(testParameters={get_parameters_requires_grad()})
   subroutine test_torch_tensor_ones(this)
     use ftorch, only: torch_tensor_ones
     use, intrinsic :: iso_fortran_env, only: sp => real32
@@ -200,53 +210,37 @@ contains
     real(wp), dimension(2,3), target :: out_data
     real(wp), dimension(2,3) :: expected
     logical :: test_pass
-    integer :: i
 
-    do i = 1, this%param%iterations
+    ! Check the tensor pointer is not associated
+    @assertFalse(c_associated(tensor1%p))
 
-      ! Check the tensor pointer is not associated
-      @assertFalse(c_associated(tensor1%p))
+    ! Create tensor of ones
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
+                          this%param%requires_grad)
 
-      ! Create tensor of ones
-      call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
-                            this%param%requires_grad)
+    ! Check the tensor pointer is associated
+    @assertTrue(c_associated(tensor1%p))
 
-      ! Check the tensor pointer is associated
-      @assertTrue(c_associated(tensor1%p))
+    ! Create a tensor based off an output array
+    call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
 
-      ! Create a tensor based off an output array
-      call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
+    ! Set the values of the second tensor to match those of the first using the overloaded
+    ! assignment operator
+    tensor2 = tensor1
 
-      ! Set the values of the second tensor to match those of the first using the overloaded
-      ! assignment operator
-      tensor2 = tensor1
+    ! Check that the tensor values are all one
+    expected(:,:) = 1.0
+    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_ones")
 
-      ! Check that the tensor values are all one
-      expected(:,:) = 1.0
-      test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_ones")
-
-      if (.not. test_pass) then
-        print *, "Error :: incorrect output from torch_tensor_ones subroutine"
-        stop 999
-      end if
-
-      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
-        ! Call torch_tensor_delete manually
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-
-        ! Check torch_tensor_delete does indeed free the memory
-        @assertFalse(c_associated(tensor1%p))
-        @assertFalse(c_associated(tensor2%p))
-      end if
-
-    end do
+    if (.not. test_pass) then
+      print *, "Error :: incorrect output from torch_tensor_ones subroutine"
+      stop 999
+    end if
 
   end subroutine test_torch_tensor_ones
 
-  ! Unit test for the torch_tensor_from_array subroutine in the 1D case and for calling
-  ! torch_tensor_delete manually or automatically (via torch_tensor's destructor)
-  @test(testParameters={get_parameters_full()})
+  ! Unit test for the torch_tensor_from_array subroutine in the 1D case
+  @test(testParameters={get_parameters_requires_grad()})
   subroutine test_torch_from_array_1d(this)
     use, intrinsic :: iso_fortran_env, only: sp => real32
 
@@ -262,49 +256,34 @@ contains
     real(wp), dimension(6), target :: in_data
     real(wp), dimension(6), target :: out_data
     logical :: test_pass
-    integer :: i
 
-    do i = 1, this%param%iterations
+    ! Create an arbitrary input array
+    in_data(:) = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
-      ! Create an arbitrary input array
-      in_data(:) = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    ! Check the tensor pointer is not associated
+    @assertFalse(c_associated(tensor1%p))
 
-      ! Check the tensor pointer is not associated
-      @assertFalse(c_associated(tensor1%p))
+    ! Create a tensor based off an input array
+    call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type, device_index, &
+                                this%param%requires_grad)
 
-      ! Create a tensor based off an input array
-      call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type, device_index, &
-                                  this%param%requires_grad)
+    ! Check the tensor pointer is associated
+    @assertTrue(c_associated(tensor1%p))
 
-      ! Check the tensor pointer is associated
-      @assertTrue(c_associated(tensor1%p))
+    ! Create a tensor based off an output array
+    call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
 
-      ! Create a tensor based off an output array
-      call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
+    ! Set the values of the second tensor to match those of the first using the overloaded
+    ! assignment operator
+    tensor2 = tensor1
 
-      ! Set the values of the second tensor to match those of the first using the overloaded
-      ! assignment operator
-      tensor2 = tensor1
+    ! Compare the data in the tensor to the input data
+    test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")
 
-      ! Compare the data in the tensor to the input data
-      test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")
-
-      if (.not. test_pass) then
-        print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
-        stop 999
-      end if
-
-      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
-        ! Call torch_tensor_delete manually
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-
-        ! Check torch_tensor_delete does indeed free the memory
-        @assertFalse(c_associated(tensor1%p))
-        @assertFalse(c_associated(tensor2%p))
-      end if
-
-    end do
+    if (.not. test_pass) then
+      print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
+      stop 999
+    end if
 
   end subroutine test_torch_from_array_1d
 
@@ -404,9 +383,8 @@ contains
 
   end subroutine test_torch_from_array_3d
 
-  ! Unit test for the torch_tensor_from_blob subroutine and for calling torch_tensor_delete
-  ! manually or automatically (via torch_tensor's destructor)
-  @test(testParameters={get_parameters_full()})
+  ! Unit test for the torch_tensor_from_blob subroutine
+  @test(testParameters={get_parameters_requires_grad()})
   subroutine test_torch_from_blob(this)
     use ftorch, only: torch_tensor_from_blob
     use, intrinsic :: iso_fortran_env, only: sp => real32
@@ -426,49 +404,34 @@ contains
     real(wp), dimension(2,3), target :: in_data
     real(wp), dimension(2,3), target :: out_data
     logical :: test_pass
-    integer :: i
 
-    do i = 1, this%param%iterations
+    ! Create an arbitrary input array
+    in_data = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2,3])
 
-      ! Create an arbitrary input array
-      in_data = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2,3])
+    ! Check the tensor pointer is not associated
+    @assertFalse(c_associated(tensor1%p))
 
-      ! Check the tensor pointer is not associated
-      @assertFalse(c_associated(tensor1%p))
+    ! Create a tensor based off an input array
+    call torch_tensor_from_blob(tensor1, c_loc(in_data), ndims, tensor_shape, layout, dtype, &
+                                device_type, device_index, this%param%requires_grad)
 
-      ! Create a tensor based off an input array
-      call torch_tensor_from_blob(tensor1, c_loc(in_data), ndims, tensor_shape, layout, dtype, &
-                                  device_type, device_index, this%param%requires_grad)
+    ! Check the tensor pointer is associated
+    @assertTrue(c_associated(tensor1%p))
 
-      ! Check the tensor pointer is associated
-      @assertTrue(c_associated(tensor1%p))
+    ! Create a tensor based off an output array
+    call torch_tensor_from_array(tensor2, out_data, layout, device_type, device_index)
 
-      ! Create a tensor based off an output array
-      call torch_tensor_from_array(tensor2, out_data, layout, device_type, device_index)
+    ! Set the values of the second tensor to match those of the first using the overloaded
+    ! assignment operator
+    tensor2 = tensor1
 
-      ! Set the values of the second tensor to match those of the first using the overloaded
-      ! assignment operator
-      tensor2 = tensor1
+    ! Compare the data in the tensor to the input data
+    test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_blob")
 
-      ! Compare the data in the tensor to the input data
-      test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_blob")
-
-      if (.not. test_pass) then
-        print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
-        stop 999
-      end if
-
-      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
-        ! Call torch_tensor_delete manually
-        call torch_tensor_delete(tensor1)
-        call torch_tensor_delete(tensor2)
-
-        ! Check torch_tensor_delete does indeed free the memory
-        @assertFalse(c_associated(tensor1%p))
-        @assertFalse(c_associated(tensor2%p))
-      end if
-
-    end do
+    if (.not. test_pass) then
+      print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
+      stop 999
+    end if
 
   end subroutine test_torch_from_blob
 

--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -24,6 +24,7 @@ module test_tensor_constructors_destructors
   type, extends(AbstractTestParameter) :: TestParametersType
     logical :: requires_grad  ! Value used for the requires_grad argument
     logical :: auto_delete    ! torch_tensor_delete is called when .false., otherwise the finalizer
+                              !   will call it when a tensor goes out of scope
     integer :: iterations     ! Number of times to construct/destruct a tensor
   contains
     procedure :: toString

--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -22,8 +22,9 @@ module test_tensor_constructors_destructors
   ! Typedef holding a set of parameter values
   @testParameter
   type, extends(AbstractTestParameter) :: TestParametersType
-    logical :: requires_grad
-    logical :: auto_delete
+    logical :: requires_grad  ! Value used for the requires_grad argument
+    logical :: auto_delete    ! torch_tensor_delete is called when .false., otherwise the finalizer
+    integer :: iterations     ! Number of times to construct/destruct a tensor
   contains
     procedure :: toString
   end type TestParametersType
@@ -44,37 +45,32 @@ contains
   end function test_case_ctor
 
   ! A fixture comprised of a full list of parameter sets
+  ! NOTE: It doesn't make sense to have auto_delete and iterations > 1 so we won't consider those
+  !       cases
   function get_parameters_full() result(params)
     type(TestParametersType), allocatable :: params(:)
     params = [ &
-      TestParametersType(.false.,.false.), &
-      TestParametersType(.true.,.false.), &
-      TestParametersType(.false.,.true.), &
-      TestParametersType(.true.,.true.) &
+      TestParametersType(.false.,.false.,1), &
+      TestParametersType(.false.,.false.,2), &
+      TestParametersType(.false.,.true.,1), &
+      TestParametersType(.true.,.false.,1), &
+      TestParametersType(.true.,.false.,2), &
+      TestParametersType(.true.,.true.,1) &
     ]
   end function get_parameters_full
-
-  ! A fixture for checking requires_grad being true and false
-  function get_parameters_requires_grad() result(params)
-    type(TestParametersType), allocatable :: params(:)
-    params = [ &
-      TestParametersType(.false.,.false.), &
-      TestParametersType(.true.,.false.) &
-    ]
-  end function get_parameters_requires_grad
 
   ! A fixture comprised of a short list of parameter sets
   function get_parameters_short() result(params)
     type(TestParametersType), allocatable :: params(:)
-    params = [TestParametersType(.false.,.false.)]
+    params = [TestParametersType(.false.,.false.,1)]
   end function get_parameters_short
 
   ! Function for representing a parameter set as a string
   function toString(this) result(string)
     class(TestParametersType), intent(in) :: this
     character(:), allocatable :: string
-    character(len=3) :: str
-    write(str,"(l1,',',l1)") this%requires_grad, this%auto_delete
+    character(len=5) :: str
+    write(str,"(l1,',',l1,',',i1)") this%requires_grad, this%auto_delete, this%iterations
     string = str
   end function toString
 
@@ -91,29 +87,34 @@ contains
     integer, parameter :: ndims = 2
     integer(c_int64_t), dimension(2), parameter :: tensor_shape = [2, 3]
     integer, parameter :: dtype = torch_kFloat32
+    integer :: i
 
-    ! Check the tensor pointer is not associated
-    @assertFalse(c_associated(tensor%p))
+    do i = 1, this%param%iterations
 
-    ! Create a tensor without any data values assigned
-    call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index, &
-                            this%param%requires_grad)
-
-    ! Check the tensor pointer is associated
-    @assertTrue(c_associated(tensor%p))
-
-    if (.not. this%param%auto_delete) then
-      ! Call torch_tensor_delete manually
-      call torch_tensor_delete(tensor)
-
-      ! Check torch_tensor_delete does indeed free the memory
+      ! Check the tensor pointer is not associated
       @assertFalse(c_associated(tensor%p))
-    end if
+
+      ! Create a tensor without any data values assigned
+      call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index, &
+                              this%param%requires_grad)
+
+      ! Check the tensor pointer is associated
+      @assertTrue(c_associated(tensor%p))
+
+      if (.not. this%param%auto_delete) then
+        ! Call torch_tensor_delete manually
+        call torch_tensor_delete(tensor)
+
+        ! Check torch_tensor_delete does indeed free the memory
+        @assertFalse(c_associated(tensor%p))
+      end if
+
+    end do
 
   end subroutine test_torch_tensor_empty
 
   ! Unit test for the torch_tensor_zeros subroutine
-  @test(testParameters={get_parameters_requires_grad()})
+  @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_zeros(this)
     use ftorch, only: torch_tensor_zeros
     use, intrinsic :: iso_fortran_env, only: sp => real32
@@ -162,7 +163,7 @@ contains
   end subroutine test_torch_tensor_zeros
 
   ! Unit test for the torch_tensor_ones subroutine
-  @test(testParameters={get_parameters_requires_grad()})
+  @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_ones(this)
     use ftorch, only: torch_tensor_ones
     use, intrinsic :: iso_fortran_env, only: sp => real32
@@ -211,7 +212,7 @@ contains
   end subroutine test_torch_tensor_ones
 
   ! Unit test for the torch_tensor_from_array subroutine in the 1D case
-  @test(testParameters={get_parameters_requires_grad()})
+  @test(testParameters={get_parameters_full()})
   subroutine test_torch_from_array_1d(this)
     use, intrinsic :: iso_fortran_env, only: sp => real32
 
@@ -355,7 +356,7 @@ contains
   end subroutine test_torch_from_array_3d
 
   ! Unit test for the torch_tensor_from_blob subroutine
-  @test(testParameters={get_parameters_requires_grad()})
+  @test(testParameters={get_parameters_full()})
   subroutine test_torch_from_blob(this)
     use ftorch, only: torch_tensor_from_blob
     use, intrinsic :: iso_fortran_env, only: sp => real32

--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -103,44 +103,6 @@ contains
 
   end subroutine test_torch_tensor_empty
 
-  ! Unit test for destroying tensors, both manually with torch_tensor_delete and automatically (via
-  ! torch_tensor's destructor)
-  @test(testparameters={get_parameters_destruction()})
-  subroutine test_torch_tensor_destruction(this)
-    use ftorch, only: torch_tensor_empty
-
-    implicit none
-
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor
-    integer, parameter :: ndims = 2
-    integer(c_int64_t), dimension(2), parameter :: tensor_shape = [2, 3]
-    integer, parameter :: dtype = torch_kFloat32
-    integer :: i
-
-    do i = 1, this%param%iterations
-
-      ! Check the tensor pointer is not associated
-      @assertFalse(c_associated(tensor%p))
-
-      ! Create a tensor without any data values assigned
-      call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index)
-
-      ! Check the tensor pointer is associated
-      @assertTrue(c_associated(tensor%p))
-
-      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
-        ! Call torch_tensor_delete manually
-        call torch_tensor_delete(tensor)
-
-        ! Check torch_tensor_delete does indeed free the memory
-        @assertFalse(c_associated(tensor%p))
-      end if
-
-    end do
-
-  end subroutine test_torch_tensor_destruction
-
   ! Unit test for the torch_tensor_zeros subroutine
   @test(testParameters={get_parameters_requires_grad()})
   subroutine test_torch_tensor_zeros(this)
@@ -416,5 +378,43 @@ contains
     end if
 
   end subroutine test_torch_from_blob
+
+  ! Unit test for destroying tensors, both manually with torch_tensor_delete and automatically (via
+  ! torch_tensor's destructor)
+  @test(testparameters={get_parameters_destruction()})
+  subroutine test_torch_tensor_destruction(this)
+    use ftorch, only: torch_tensor_empty
+
+    implicit none
+
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 2
+    integer(c_int64_t), dimension(2), parameter :: tensor_shape = [2, 3]
+    integer, parameter :: dtype = torch_kFloat32
+    integer :: i
+
+    do i = 1, this%param%iterations
+
+      ! Check the tensor pointer is not associated
+      @assertFalse(c_associated(tensor%p))
+
+      ! Create a tensor without any data values assigned
+      call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, device_index)
+
+      ! Check the tensor pointer is associated
+      @assertTrue(c_associated(tensor%p))
+
+      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
+        ! Call torch_tensor_delete manually
+        call torch_tensor_delete(tensor)
+
+        ! Check torch_tensor_delete does indeed free the memory
+        @assertFalse(c_associated(tensor%p))
+      end if
+
+    end do
+
+  end subroutine test_torch_tensor_destruction
 
 end module test_tensor_constructors_destructors

--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -160,7 +160,6 @@ contains
     integer, parameter :: dtype = torch_kFloat32
     real(wp), dimension(2,3), target :: out_data
     real(wp), dimension(2,3) :: expected
-    logical :: test_pass
 
     ! Check the tensor pointer is not associated
     @assertFalse(c_associated(tensor1%p))
@@ -181,9 +180,7 @@ contains
 
     ! Check that the tensor values are all zero
     expected(:,:) = 0.0
-    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_zeros")
-
-    if (.not. test_pass) then
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_zeros")) then
       print *, "Error :: incorrect output from torch_tensor_zeros subroutine"
       stop 999
     end if
@@ -209,14 +206,13 @@ contains
     integer, parameter :: dtype = torch_kFloat32
     real(wp), dimension(2,3), target :: out_data
     real(wp), dimension(2,3) :: expected
-    logical :: test_pass
 
     ! Check the tensor pointer is not associated
     @assertFalse(c_associated(tensor1%p))
 
     ! Create tensor of ones
     call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
-                          this%param%requires_grad)
+                           this%param%requires_grad)
 
     ! Check the tensor pointer is associated
     @assertTrue(c_associated(tensor1%p))
@@ -230,9 +226,7 @@ contains
 
     ! Check that the tensor values are all one
     expected(:,:) = 1.0
-    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_ones")
-
-    if (.not. test_pass) then
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_ones")) then
       print *, "Error :: incorrect output from torch_tensor_ones subroutine"
       stop 999
     end if
@@ -255,7 +249,6 @@ contains
     integer, parameter :: tensor_layout(ndims) = [1]
     real(wp), dimension(6), target :: in_data
     real(wp), dimension(6), target :: out_data
-    logical :: test_pass
 
     ! Create an arbitrary input array
     in_data(:) = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
@@ -265,7 +258,7 @@ contains
 
     ! Create a tensor based off an input array
     call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type, device_index, &
-                                this%param%requires_grad)
+                                 this%param%requires_grad)
 
     ! Check the tensor pointer is associated
     @assertTrue(c_associated(tensor1%p))
@@ -278,9 +271,7 @@ contains
     tensor2 = tensor1
 
     ! Compare the data in the tensor to the input data
-    test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")
-
-    if (.not. test_pass) then
+    if (.not. assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")) then
       print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
       stop 999
     end if
@@ -303,7 +294,6 @@ contains
     integer, parameter :: tensor_layout(ndims) = [1, 2]
     real(wp), dimension(2,3), target :: in_data
     real(wp), dimension(2,3), target :: out_data
-    logical :: test_pass
 
     ! Create an arbitrary input array
     in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2,3])
@@ -326,9 +316,7 @@ contains
     tensor2 = tensor1
 
     ! Compare the data in the tensor to the input data
-    test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")
-
-    if (.not. test_pass) then
+    if (.not. assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")) then
       print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
       stop 999
     end if
@@ -351,7 +339,6 @@ contains
     integer, parameter :: tensor_layout(ndims) = [1, 2, 3]
     real(wp), dimension(1,2,3), target :: in_data
     real(wp), dimension(1,2,3), target :: out_data
-    logical :: test_pass
 
     ! Create an arbitrary input array
     in_data(:,:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [1,2,3])
@@ -374,9 +361,7 @@ contains
     tensor2 = tensor1
 
     ! Compare the data in the tensor to the input data
-    test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")
-
-    if (.not. test_pass) then
+    if (.not. assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")) then
       print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
       stop 999
     end if
@@ -403,7 +388,6 @@ contains
     integer, parameter :: dtype = torch_kFloat32
     real(wp), dimension(2,3), target :: in_data
     real(wp), dimension(2,3), target :: out_data
-    logical :: test_pass
 
     ! Create an arbitrary input array
     in_data = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2,3])
@@ -426,9 +410,7 @@ contains
     tensor2 = tensor1
 
     ! Compare the data in the tensor to the input data
-    test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_blob")
-
-    if (.not. test_pass) then
+    if (.not. assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_blob")) then
       print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
       stop 999
     end if

--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -46,17 +46,17 @@ contains
   end function test_case_ctor
 
   ! A fixture comprised of a full list of parameter sets
-  ! NOTE: It doesn't make sense to have auto_delete and iterations > 1 so we won't consider those
-  !       cases
   function get_parameters_full() result(params)
     type(TestParametersType), allocatable :: params(:)
     params = [ &
       TestParametersType(.false.,.false.,1), &
       TestParametersType(.false.,.false.,2), &
       TestParametersType(.false.,.true.,1), &
+      TestParametersType(.false.,.true.,2), &
       TestParametersType(.true.,.false.,1), &
       TestParametersType(.true.,.false.,2), &
-      TestParametersType(.true.,.true.,1) &
+      TestParametersType(.true.,.true.,1), &
+      TestParametersType(.true.,.true.,2) &
     ]
   end function get_parameters_full
 
@@ -102,7 +102,7 @@ contains
       ! Check the tensor pointer is associated
       @assertTrue(c_associated(tensor%p))
 
-      if (.not. this%param%auto_delete) then
+      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
         ! Call torch_tensor_delete manually
         call torch_tensor_delete(tensor)
 
@@ -114,7 +114,8 @@ contains
 
   end subroutine test_torch_tensor_empty
 
-  ! Unit test for the torch_tensor_zeros subroutine
+  ! Unit test for the torch_tensor_zeros subroutine and for calling torch_tensor_delete manually or
+  ! automatically (via torch_tensor's destructor)
   @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_zeros(this)
     use ftorch, only: torch_tensor_zeros
@@ -134,36 +135,52 @@ contains
     real(wp), dimension(2,3), target :: out_data
     real(wp), dimension(2,3) :: expected
     logical :: test_pass
+    integer :: i
 
-    ! Check the tensor pointer is not associated
-    @assertFalse(c_associated(tensor1%p))
+    do i = 1, this%param%iterations
 
-    ! Create a tensor of zeros
-    call torch_tensor_zeros(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
-                            this%param%requires_grad)
+      ! Check the tensor pointer is not associated
+      @assertFalse(c_associated(tensor1%p))
 
-    ! Check the tensor pointer is associated
-    @assertTrue(c_associated(tensor1%p))
+      ! Create a tensor of zeros
+      call torch_tensor_zeros(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
+                              this%param%requires_grad)
 
-    ! Create a tensor based off an output array
-    call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
+      ! Check the tensor pointer is associated
+      @assertTrue(c_associated(tensor1%p))
 
-    ! Set the values of the second tensor to match those of the first using the overloaded
-    ! assignment operator
-    tensor2 = tensor1
+      ! Create a tensor based off an output array
+      call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
 
-    ! Check that the tensor values are all zero
-    expected(:,:) = 0.0
-    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_zeros")
+      ! Set the values of the second tensor to match those of the first using the overloaded
+      ! assignment operator
+      tensor2 = tensor1
 
-    if (.not. test_pass) then
-      print *, "Error :: incorrect output from torch_tensor_zeros subroutine"
-      stop 999
-    end if
+      ! Check that the tensor values are all zero
+      expected(:,:) = 0.0
+      test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_zeros")
+
+      if (.not. test_pass) then
+        print *, "Error :: incorrect output from torch_tensor_zeros subroutine"
+        stop 999
+      end if
+
+      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
+        ! Call torch_tensor_delete manually
+        call torch_tensor_delete(tensor1)
+        call torch_tensor_delete(tensor2)
+
+        ! Check torch_tensor_delete does indeed free the memory
+        @assertFalse(c_associated(tensor1%p))
+        @assertFalse(c_associated(tensor2%p))
+      end if
+
+    end do
 
   end subroutine test_torch_tensor_zeros
 
-  ! Unit test for the torch_tensor_ones subroutine
+  ! Unit test for the torch_tensor_ones subroutine and for calling torch_tensor_delete manually or
+  ! automatically (via torch_tensor's destructor)
   @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_ones(this)
     use ftorch, only: torch_tensor_ones
@@ -183,36 +200,52 @@ contains
     real(wp), dimension(2,3), target :: out_data
     real(wp), dimension(2,3) :: expected
     logical :: test_pass
+    integer :: i
 
-    ! Check the tensor pointer is not associated
-    @assertFalse(c_associated(tensor1%p))
+    do i = 1, this%param%iterations
 
-    ! Create tensor of ones
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
-                           this%param%requires_grad)
+      ! Check the tensor pointer is not associated
+      @assertFalse(c_associated(tensor1%p))
 
-    ! Check the tensor pointer is associated
-    @assertTrue(c_associated(tensor1%p))
+      ! Create tensor of ones
+      call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, device_index, &
+                            this%param%requires_grad)
 
-    ! Create a tensor based off an output array
-    call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
+      ! Check the tensor pointer is associated
+      @assertTrue(c_associated(tensor1%p))
 
-    ! Set the values of the second tensor to match those of the first using the overloaded
-    ! assignment operator
-    tensor2 = tensor1
+      ! Create a tensor based off an output array
+      call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
 
-    ! Check that the tensor values are all one
-    expected(:,:) = 1.0
-    test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_ones")
+      ! Set the values of the second tensor to match those of the first using the overloaded
+      ! assignment operator
+      tensor2 = tensor1
 
-    if (.not. test_pass) then
-      print *, "Error :: incorrect output from torch_tensor_ones subroutine"
-      stop 999
-    end if
+      ! Check that the tensor values are all one
+      expected(:,:) = 1.0
+      test_pass = assert_allclose(out_data, expected, test_name="test_torch_tensor_ones")
+
+      if (.not. test_pass) then
+        print *, "Error :: incorrect output from torch_tensor_ones subroutine"
+        stop 999
+      end if
+
+      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
+        ! Call torch_tensor_delete manually
+        call torch_tensor_delete(tensor1)
+        call torch_tensor_delete(tensor2)
+
+        ! Check torch_tensor_delete does indeed free the memory
+        @assertFalse(c_associated(tensor1%p))
+        @assertFalse(c_associated(tensor2%p))
+      end if
+
+    end do
 
   end subroutine test_torch_tensor_ones
 
-  ! Unit test for the torch_tensor_from_array subroutine in the 1D case
+  ! Unit test for the torch_tensor_from_array subroutine in the 1D case and for calling
+  ! torch_tensor_delete manually or automatically (via torch_tensor's destructor)
   @test(testParameters={get_parameters_full()})
   subroutine test_torch_from_array_1d(this)
     use, intrinsic :: iso_fortran_env, only: sp => real32
@@ -229,34 +262,49 @@ contains
     real(wp), dimension(6), target :: in_data
     real(wp), dimension(6), target :: out_data
     logical :: test_pass
+    integer :: i
 
-    ! Create an arbitrary input array
-    in_data(:) = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    do i = 1, this%param%iterations
 
-    ! Check the tensor pointer is not associated
-    @assertFalse(c_associated(tensor1%p))
+      ! Create an arbitrary input array
+      in_data(:) = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
-    ! Create a tensor based off an input array
-    call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type, device_index, &
-                                 this%param%requires_grad)
+      ! Check the tensor pointer is not associated
+      @assertFalse(c_associated(tensor1%p))
 
-    ! Check the tensor pointer is associated
-    @assertTrue(c_associated(tensor1%p))
+      ! Create a tensor based off an input array
+      call torch_tensor_from_array(tensor1, in_data, tensor_layout, device_type, device_index, &
+                                  this%param%requires_grad)
 
-    ! Create a tensor based off an output array
-    call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
+      ! Check the tensor pointer is associated
+      @assertTrue(c_associated(tensor1%p))
 
-    ! Set the values of the second tensor to match those of the first using the overloaded
-    ! assignment operator
-    tensor2 = tensor1
+      ! Create a tensor based off an output array
+      call torch_tensor_from_array(tensor2, out_data, tensor_layout, device_type, device_index)
 
-    ! Compare the data in the tensor to the input data
-    test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")
+      ! Set the values of the second tensor to match those of the first using the overloaded
+      ! assignment operator
+      tensor2 = tensor1
 
-    if (.not. test_pass) then
-      print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
-      stop 999
-    end if
+      ! Compare the data in the tensor to the input data
+      test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_array")
+
+      if (.not. test_pass) then
+        print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
+        stop 999
+      end if
+
+      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
+        ! Call torch_tensor_delete manually
+        call torch_tensor_delete(tensor1)
+        call torch_tensor_delete(tensor2)
+
+        ! Check torch_tensor_delete does indeed free the memory
+        @assertFalse(c_associated(tensor1%p))
+        @assertFalse(c_associated(tensor2%p))
+      end if
+
+    end do
 
   end subroutine test_torch_from_array_1d
 
@@ -356,7 +404,8 @@ contains
 
   end subroutine test_torch_from_array_3d
 
-  ! Unit test for the torch_tensor_from_blob subroutine
+  ! Unit test for the torch_tensor_from_blob subroutine and for calling torch_tensor_delete
+  ! manually or automatically (via torch_tensor's destructor)
   @test(testParameters={get_parameters_full()})
   subroutine test_torch_from_blob(this)
     use ftorch, only: torch_tensor_from_blob
@@ -377,34 +426,49 @@ contains
     real(wp), dimension(2,3), target :: in_data
     real(wp), dimension(2,3), target :: out_data
     logical :: test_pass
+    integer :: i
 
-    ! Create an arbitrary input array
-    in_data = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2,3])
+    do i = 1, this%param%iterations
 
-    ! Check the tensor pointer is not associated
-    @assertFalse(c_associated(tensor1%p))
+      ! Create an arbitrary input array
+      in_data = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2,3])
 
-    ! Create a tensor based off an input array
-    call torch_tensor_from_blob(tensor1, c_loc(in_data), ndims, tensor_shape, layout, dtype, &
-                                device_type, device_index, this%param%requires_grad)
+      ! Check the tensor pointer is not associated
+      @assertFalse(c_associated(tensor1%p))
 
-    ! Check the tensor pointer is associated
-    @assertTrue(c_associated(tensor1%p))
+      ! Create a tensor based off an input array
+      call torch_tensor_from_blob(tensor1, c_loc(in_data), ndims, tensor_shape, layout, dtype, &
+                                  device_type, device_index, this%param%requires_grad)
 
-    ! Create a tensor based off an output array
-    call torch_tensor_from_array(tensor2, out_data, layout, device_type, device_index)
+      ! Check the tensor pointer is associated
+      @assertTrue(c_associated(tensor1%p))
 
-    ! Set the values of the second tensor to match those of the first using the overloaded
-    ! assignment operator
-    tensor2 = tensor1
+      ! Create a tensor based off an output array
+      call torch_tensor_from_array(tensor2, out_data, layout, device_type, device_index)
 
-    ! Compare the data in the tensor to the input data
-    test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_blob")
+      ! Set the values of the second tensor to match those of the first using the overloaded
+      ! assignment operator
+      tensor2 = tensor1
 
-    if (.not. test_pass) then
-      print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
-      stop 999
-    end if
+      ! Compare the data in the tensor to the input data
+      test_pass = assert_allclose(out_data, in_data, test_name="test_torch_tensor_from_blob")
+
+      if (.not. test_pass) then
+        print *, "Error :: incorrect output from torch_tensor_from_array subroutine"
+        stop 999
+      end if
+
+      if (i < this%param%iterations .or. .not. this%param%auto_delete) then
+        ! Call torch_tensor_delete manually
+        call torch_tensor_delete(tensor1)
+        call torch_tensor_delete(tensor2)
+
+        ! Check torch_tensor_delete does indeed free the memory
+        @assertFalse(c_associated(tensor1%p))
+        @assertFalse(c_associated(tensor2%p))
+      end if
+
+    end do
 
   end subroutine test_torch_from_blob
 


### PR DESCRIPTION
Closes #318.

This test extends the fixtures in the existing unit tests for the constructors and destructors to cover the case where `torch_tensor_delete` is called and then a constructor is applied to the same tensor.