### PR TITLE
Typo correction of is_training variable description in the ftorch API.

### DIFF
--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -1828,7 +1828,7 @@ contains
     integer(c_int), intent(in) :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index  !! device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
-    logical, optional, intent(in) :: is_training    !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: is_training    !! Whether the model is being trained, rather than evaluated
     integer(c_int) :: device_index_value
     logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
     logical :: is_training_value  !! Whether the model is being trained, rather than evaluated

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -849,7 +849,7 @@ contains
     integer(c_int), intent(in) :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer(c_int), optional, intent(in) :: device_index  !! device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
-    logical, optional, intent(in) :: is_training    !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: is_training    !! Whether the model is being trained, rather than evaluated
     integer(c_int) :: device_index_value
     logical :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
     logical :: is_training_value  !! Whether the model is being trained, rather than evaluated


### PR DESCRIPTION
As per the description, I spotted this on a stroll through ftorch.F90 so thought I'd fix.

Seems to have been a copy-paste error.