### PR TITLE
Mention test changes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
 - `requires_grad` property hooked up to `torch_tensor` in [#288](https://github.com/Cambridge-ICCS/FTorch/pull/288)
 - MPI example added in [#270](https://github.com/Cambridge-ICCS/FTorch/pull/270)
 - Changelog file and guidance for versioning added in [#313](https://github.com/Cambridge-ICCS/FTorch/pull/313)
+- The unit tests for constructing and destroying tensors were separated out in
+  [#319](https://github.com/Cambridge-ICCS/FTorch/pull/319)
 
 ### Changed
 


### PR DESCRIPTION
I forgot to mention the changes that came with #319 in the newly added changelog.

Going forward, we should add changes to the changelog in the PR that introduces them, where possible.