### PR TITLE
Fix static analysis workflow (failing after #331)

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -20,6 +20,7 @@ on:
       - '**.py'
       - '**.sh'
       - '**CMakeLists.txt'
+      - 'requirements-dev.txt'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -52,7 +53,7 @@ jobs:
           python -m venv ftorch_venv
           . ftorch_venv/bin/activate
           pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       # Run CMake build to get compile commands for clang
       - name: FTorch CMake


### PR DESCRIPTION
* Renames references to requirements.txt to requirements-dev.txt (needed after #331)
* Adds requirements-dev.txt to triggering changed paths