### PR TITLE
Implement `torch_tensor_zero`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
   This became demo 1 and the other demo numbers were bumped to account for this.
 - Backpropagation implemented with `torch_tensor_backward` and
   `torch_tensor_get_gradient` in [#286](https://github.com/Cambridge-ICCS/FTorch/pull/286)
-- Implemented `torch_tensor_zero_` and class method alias in
+- Implemented `torch_tensor_zero` and class method alias in
   [#338](https://github.com/Cambridge-ICCS/FTorch/pull/338).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
   This became demo 1 and the other demo numbers were bumped to account for this.
 - Backpropagation implemented with `torch_tensor_backward` and
   `torch_tensor_get_gradient` in [#286](https://github.com/Cambridge-ICCS/FTorch/pull/286)
+- Implemented `torch_tensor_zero_` and class method alias in
+  [#338](https://github.com/Cambridge-ICCS/FTorch/pull/338).
 
 ### Changed
 

--- a/pages/tensor.md
+++ b/pages/tensor.md
@@ -71,6 +71,12 @@ this can also be applied to arrays of tensors. Calling this subroutine manually
 is optional as it is called as a destructor when the `torch_tensor` goes out of
 scope anyway.
 
+### Tensor manipulation
+
+We provide a subroutine for manipulating the data values associated with a
+`torch_tensor` object: `torch_tensor_zero_`. It has an alias as a class method:
+`torch_tensor%zero_`.
+
 ### Operator overloading
 
 Mathematical operators involving Tensors are overloaded, so that we can compute

--- a/pages/tensor.md
+++ b/pages/tensor.md
@@ -74,8 +74,8 @@ scope anyway.
 ### Tensor manipulation
 
 We provide a subroutine for manipulating the data values associated with a
-`torch_tensor` object: `torch_tensor_zero_`. It has an alias as a class method:
-`torch_tensor%zero_`.
+`torch_tensor` object: `torch_tensor_zero`. It has an alias as a class method:
+`torch_tensor%zero`.
 
 ### Operator overloading
 

--- a/pages/tensor.md
+++ b/pages/tensor.md
@@ -73,9 +73,11 @@ scope anyway.
 
 ### Tensor manipulation
 
-We provide a subroutine for manipulating the data values associated with a
-`torch_tensor` object: `torch_tensor_zero`. It has an alias as a class method:
-`torch_tensor%zero`.
+We provide the following subroutines for manipulating the data values associated
+with a `torch_tensor` object:
+
+* `torch_tensor_zero` (aliased as class method `torch_tensor%zero`), which
+  sets all the data entries associated with a tensor to zero.
 
 ### Operator overloading
 

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -312,7 +312,7 @@ void torch_tensor_delete(torch_tensor_t tensor) {
 // --- Functions for manipulating tensors
 // =====================================================================================
 
-void torch_tensor_zero_(torch_tensor_t tensor) {
+void torch_tensor_zero(torch_tensor_t tensor) {
   auto t = reinterpret_cast<torch::Tensor *>(tensor);
   t->zero_();
 }

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -309,6 +309,15 @@ void torch_tensor_delete(torch_tensor_t tensor) {
 }
 
 // =====================================================================================
+// --- Functions for manipulating tensors
+// =====================================================================================
+
+void torch_tensor_zero_(torch_tensor_t tensor) {
+  auto t = reinterpret_cast<torch::Tensor *>(tensor);
+  t->zero_();
+}
+
+// =====================================================================================
 // --- Operator overloads acting on tensors
 // =====================================================================================
 

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -181,7 +181,7 @@ EXPORT_C void torch_tensor_delete(torch_tensor_t tensor);
  * Function to reset the values of a Torch Tensor to zero
  * @param Torch Tensor to zero
  */
-EXPORT_C void torch_tensor_zero_(torch_tensor_t tensor);
+EXPORT_C void torch_tensor_zero(torch_tensor_t tensor);
 
 // =============================================================================
 // --- Operator overloads acting on tensors

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -179,7 +179,7 @@ EXPORT_C void torch_tensor_delete(torch_tensor_t tensor);
 
 /**
  * Function to reset the values of a Torch Tensor to zero
- * @param Torch Tensor to zero
+ * @param Torch Tensor to zero the values of
  */
 EXPORT_C void torch_tensor_zero(torch_tensor_t tensor);
 

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -173,6 +173,16 @@ EXPORT_C bool torch_tensor_requires_grad(const torch_tensor_t tensor);
  */
 EXPORT_C void torch_tensor_delete(torch_tensor_t tensor);
 
+// =====================================================================================
+// --- Functions for manipulating tensors
+// =====================================================================================
+
+/**
+ * Function to reset the values of a Torch Tensor to zero
+ * @param Torch Tensor to zero
+ */
+EXPORT_C void torch_tensor_zero_(torch_tensor_t tensor);
+
 // =============================================================================
 // --- Operator overloads acting on tensors
 // =============================================================================

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -37,7 +37,7 @@ module ftorch
     procedure :: get_device_type => torch_tensor_get_device_type
     procedure :: get_device_index => torch_tensor_get_device_index
     procedure :: requires_grad => torch_tensor_requires_grad
-    procedure :: zero_ => torch_tensor_zero_
+    procedure :: zero => torch_tensor_zero
     final :: torch_tensor_delete
   end type torch_tensor
 
@@ -1499,24 +1499,24 @@ contains
   ! ============================================================================
 
   !> Fills a tensor with the scalar value 0.
-  subroutine torch_tensor_zero_(tensor)
+  subroutine torch_tensor_zero(tensor)
     use, intrinsic :: iso_c_binding, only : c_associated
-    class(torch_tensor), intent(inout) :: tensor
+    class(torch_tensor), intent(inout) :: tensor !! Tensor whose values are to be zeroed
 
     interface
-      subroutine torch_tensor_zero__c(tensor) bind(c, name = 'torch_tensor_zero_')
+      subroutine torch_tensor_zero_c(tensor) bind(c, name = 'torch_tensor_zero')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor
-      end subroutine torch_tensor_zero__c
+      end subroutine torch_tensor_zero_c
     end interface
 
     if (.not. c_associated(tensor%p)) then
       write(*,*) "Error :: tensor must be constructed before zeroing values"
       stop 1
     end if
-    call torch_tensor_zero__c(tensor%p)
-  end subroutine torch_tensor_zero_
+    call torch_tensor_zero_c(tensor%p)
+  end subroutine torch_tensor_zero
 
   ! ============================================================================
   ! --- Overloaded operators acting on tensors

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -37,6 +37,7 @@ module ftorch
     procedure :: get_device_type => torch_tensor_get_device_type
     procedure :: get_device_index => torch_tensor_get_device_index
     procedure :: requires_grad => torch_tensor_requires_grad
+    procedure :: zero_ => torch_tensor_zero_
     final :: torch_tensor_delete
   end type torch_tensor
 
@@ -1492,6 +1493,30 @@ contains
       tensor%p = c_null_ptr
     end if
   end subroutine torch_tensor_delete
+
+  ! ============================================================================
+  ! --- Procedures for manipulating tensors
+  ! ============================================================================
+
+  !> Fills a tensor with the scalar value 0.
+  subroutine torch_tensor_zero_(tensor)
+    use, intrinsic :: iso_c_binding, only : c_associated
+    class(torch_tensor), intent(inout) :: tensor
+
+    interface
+      subroutine torch_tensor_zero__c(tensor) bind(c, name = 'torch_tensor_zero_')
+        use, intrinsic :: iso_c_binding, only : c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+      end subroutine torch_tensor_zero__c
+    end interface
+
+    if (.not. c_associated(tensor%p)) then
+      write(*,*) "Error :: tensor must be constructed before zeroing values"
+      stop 1
+    end if
+    call torch_tensor_zero__c(tensor%p)
+  end subroutine torch_tensor_zero_
 
   ! ============================================================================
   ! --- Overloaded operators acting on tensors

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -56,7 +56,7 @@ module ftorch
     procedure :: get_device_type => torch_tensor_get_device_type
     procedure :: get_device_index => torch_tensor_get_device_index
     procedure :: requires_grad => torch_tensor_requires_grad
-    procedure :: zero_ => torch_tensor_zero_
+    procedure :: zero => torch_tensor_zero
     final :: torch_tensor_delete
   end type torch_tensor
 
@@ -624,24 +624,24 @@ contains
   ! ============================================================================
 
   !> Fills a tensor with the scalar value 0.
-  subroutine torch_tensor_zero_(tensor)
+  subroutine torch_tensor_zero(tensor)
     use, intrinsic :: iso_c_binding, only : c_associated
-    class(torch_tensor), intent(inout) :: tensor
+    class(torch_tensor), intent(inout) :: tensor !! Tensor whose values are to be zeroed
 
     interface
-      subroutine torch_tensor_zero__c(tensor) bind(c, name = 'torch_tensor_zero_')
+      subroutine torch_tensor_zero_c(tensor) bind(c, name = 'torch_tensor_zero')
         use, intrinsic :: iso_c_binding, only : c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor
-      end subroutine torch_tensor_zero__c
+      end subroutine torch_tensor_zero_c
     end interface
 
     if (.not. c_associated(tensor%p)) then
       write(*,*) "Error :: tensor must be constructed before zeroing values"
       stop 1
     end if
-    call torch_tensor_zero__c(tensor%p)
-  end subroutine torch_tensor_zero_
+    call torch_tensor_zero_c(tensor%p)
+  end subroutine torch_tensor_zero
 
   ! ============================================================================
   ! --- Overloaded operators acting on tensors

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -56,6 +56,7 @@ module ftorch
     procedure :: get_device_type => torch_tensor_get_device_type
     procedure :: get_device_index => torch_tensor_get_device_index
     procedure :: requires_grad => torch_tensor_requires_grad
+    procedure :: zero_ => torch_tensor_zero_
     final :: torch_tensor_delete
   end type torch_tensor
 
@@ -617,6 +618,30 @@ contains
       tensor%p = c_null_ptr
     end if
   end subroutine torch_tensor_delete
+
+  ! ============================================================================
+  ! --- Procedures for manipulating tensors
+  ! ============================================================================
+
+  !> Fills a tensor with the scalar value 0.
+  subroutine torch_tensor_zero_(tensor)
+    use, intrinsic :: iso_c_binding, only : c_associated
+    class(torch_tensor), intent(inout) :: tensor
+
+    interface
+      subroutine torch_tensor_zero__c(tensor) bind(c, name = 'torch_tensor_zero_')
+        use, intrinsic :: iso_c_binding, only : c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+      end subroutine torch_tensor_zero__c
+    end interface
+
+    if (.not. c_associated(tensor%p)) then
+      write(*,*) "Error :: tensor must be constructed before zeroing values"
+      stop 1
+    end if
+    call torch_tensor_zero__c(tensor%p)
+  end subroutine torch_tensor_zero_
 
   ! ============================================================================
   ! --- Overloaded operators acting on tensors

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -16,6 +16,8 @@ add_pfunit_ctest(
   test_tensor_constructors_destructors.pf LINK_LIBRARIES FTorch::ftorch)
 add_pfunit_ctest(test_tensor_interrogation
   TEST_SOURCES test_tensor_interrogation.pf LINK_LIBRARIES FTorch::ftorch)
+add_pfunit_ctest(test_tensor_manipulation
+  TEST_SOURCES test_tensor_manipulation.pf LINK_LIBRARIES FTorch::ftorch)
 add_pfunit_ctest(
   test_operator_overloads TEST_SOURCES test_tensor_operator_overloads.pf
   LINK_LIBRARIES FTorch::ftorch)

--- a/test/unit/test_tensor_manipulation.pf
+++ b/test/unit/test_tensor_manipulation.pf
@@ -1,0 +1,56 @@
+!| Unit tests for FTorch's tensor manipulation functionality.
+!
+!  * License
+!    FTorch is released under an MIT license.
+!    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
+!    file for details.
+module test_tensor_manipulation
+  use funit
+  use ftorch, only: assignment(=), torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_from_array
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+
+  implicit none
+
+  public
+
+  integer, parameter :: device_type = torch_kCPU
+
+contains
+
+  @test
+  subroutine test_torch_tensor_zero_()
+    use, intrinsic :: iso_fortran_env, only: sp => real32
+
+    ! Set working precision for reals
+    integer, parameter :: wp = sp
+
+    type(torch_tensor) :: tensor
+    integer, parameter :: ndims = 2
+    integer, parameter :: tensor_layout(ndims) = [1, 2]
+    integer, parameter :: dtype = torch_kFloat32
+    real(wp), dimension(2,3), target :: in_data
+    real(wp), dimension(2,3) :: expected
+    logical :: test_pass
+
+    ! Create an arbitrary input array
+    in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+    ! Create a tensor based off an input array
+    call torch_tensor_from_array(tensor, in_data, tensor_layout, device_type)
+
+    ! Call the torch_tensor_zero_ subroutine using its class method alias
+    call tensor%zero_()
+
+    ! Compare the data in the tensor to the input array
+    expected(:,:) = 0.0
+    test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_zero_")
+
+    if (.not. test_pass) then
+      print *, "Error :: incorrect output from torch_tensor_zero_"
+      stop 999
+    end if
+
+  end subroutine test_torch_tensor_zero_
+
+end module test_tensor_manipulation

--- a/test/unit/test_tensor_manipulation.pf
+++ b/test/unit/test_tensor_manipulation.pf
@@ -19,7 +19,7 @@ module test_tensor_manipulation
 contains
 
   @test
-  subroutine test_torch_tensor_zero_()
+  subroutine test_torch_tensor_zero()
     use, intrinsic :: iso_fortran_env, only: sp => real32
 
     ! Set working precision for reals
@@ -39,18 +39,18 @@ contains
     ! Create a tensor based off an input array
     call torch_tensor_from_array(tensor, in_data, tensor_layout, device_type)
 
-    ! Call the torch_tensor_zero_ subroutine using its class method alias
-    call tensor%zero_()
+    ! Call the torch_tensor_zero subroutine using its class method alias
+    call tensor%zero()
 
     ! Compare the data in the tensor to the input array
     expected(:,:) = 0.0
-    test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_zero_")
+    test_pass = assert_allclose(in_data, expected, test_name="test_torch_tensor_zero")
 
     if (.not. test_pass) then
-      print *, "Error :: incorrect output from torch_tensor_zero_"
+      print *, "Error :: incorrect output from torch_tensor_zero"
       stop 999
     end if
 
-  end subroutine test_torch_tensor_zero_
+  end subroutine test_torch_tensor_zero
 
 end module test_tensor_manipulation


### PR DESCRIPTION
While working on #336, I wrapped the `Tensor.zero_` method and thought it might be useful.

To support this, I added a unit test module for tensor manipulation.