### PR TITLE
Implement zeroing of gradients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
   `torch_tensor_get_gradient` in [#286](https://github.com/Cambridge-ICCS/FTorch/pull/286)
 - Zeroing of gradients associated with a tensor implemented in
   [#341](https://github.com/Cambridge-ICCS/FTorch/pull/341).
+- Exposed `retain_graph` argument for `torch_tensor_backward` in
+  [#342](https://github.com/Cambridge-ICCS/FTorch/pull/342).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
   This became demo 1 and the other demo numbers were bumped to account for this.
 - Backpropagation implemented with `torch_tensor_backward` and
   `torch_tensor_get_gradient` in [#286](https://github.com/Cambridge-ICCS/FTorch/pull/286)
+- Zeroing of gradients associated with a tensor implemented in
+  [#341](https://github.com/Cambridge-ICCS/FTorch/pull/341).
 
 ### Changed
 

--- a/pages/autograd.md
+++ b/pages/autograd.md
@@ -77,6 +77,7 @@ call torch_tensor_get_gradient(a, dQda)
 call torch_tensor_from_array(dQdb, out_data3, tensor_layout, torch_kCPU)
 call torch_tensor_get_gradient(b, dQdb)
 ```
+
 #### Zeroing gradients
 
 Having computed gradients of one tensor with respect to its dependencies,
@@ -102,6 +103,12 @@ call torch_tensor_backward(P)
 
 ! ...
 ```
+
+#### Extracting gradients
+
+Note that `torch_tensor_get_gradient` must be called after every call to
+`torch_tensor_backward` or `torch_tensor_zero_grad`, even if the gradient for
+the same tensor is being extracted into the same array.
 
 ### Optimisation
 

--- a/pages/autograd.md
+++ b/pages/autograd.md
@@ -118,7 +118,8 @@ call torch_tensor_backward(P, retain_graph=.true.)
 
 Note that `torch_tensor_get_gradient` must be called after every call to
 `torch_tensor_backward` or `torch_tensor_zero_grad`, even if the gradient for
-the same tensor is being extracted into the same array.
+the same tensor is being extracted into the same array. This is due to the way
+that pointers are handled on the C++ side.
 
 ### Optimisation
 

--- a/pages/autograd.md
+++ b/pages/autograd.md
@@ -78,6 +78,16 @@ call torch_tensor_from_array(dQdb, out_data3, tensor_layout, torch_kCPU)
 call torch_tensor_get_gradient(b, dQdb)
 ```
 
+#### `retain_graph` argument
+
+If you wish to call the backpropagation operator multiple times then you may
+need to make use of the `retain_graph` argument for `torch_tensor_backward`.
+This argument accepts logical values and defaults to `.false.`, for consistency
+with PyTorch and LibTorch. According to the
+[PyTorch docs](https://pytorch.org/docs/stable/generated/torch.Tensor.backward.html),
+`retain_graph=.true.` will not be needed in most cases, but it's useful to have
+for the cases where it is.
+
 #### Zeroing gradients
 
 Having computed gradients of one tensor with respect to its dependencies,
@@ -99,7 +109,7 @@ call torch_tensor_backward(Q)
 call torch_tensor_zero_grad(a)
 call torch_tensor_zero_grad(b)
 
-call torch_tensor_backward(P)
+call torch_tensor_backward(P, retain_graph=.true.)
 
 ! ...
 ```

--- a/pages/autograd.md
+++ b/pages/autograd.md
@@ -71,13 +71,36 @@ to `a` and/or `b`. To do this, we can use the `torch_tensor_get_gradient`
 subroutine. That is, for tensors `dQda` and `dQdb`:
 
 ```fortran
-! Function approach
 call torch_tensor_from_array(dQda, out_data2, tensor_layout, torch_kCPU)
 call torch_tensor_get_gradient(a, dQda)
 
-! Method approach
 call torch_tensor_from_array(dQdb, out_data3, tensor_layout, torch_kCPU)
 call torch_tensor_get_gradient(b, dQdb)
+```
+#### Zeroing gradients
+
+Having computed gradients of one tensor with respect to its dependencies,
+suppose you wish to compute gradients of another tensor. Since the gradient
+values associated with each dependency are accumulated, you should zero the
+gradients before computing the next gradient. This can be achieved using the
+`torch_tensor_zero_grad` subroutine.
+
+Following the example code above:
+
+```fortran
+Q = a * b
+P = a + b
+
+call torch_tensor_backward(Q)
+
+! ...
+
+call torch_tensor_zero_grad(a)
+call torch_tensor_zero_grad(b)
+
+call torch_tensor_backward(P)
+
+! ...
 ```
 
 ### Optimisation

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -383,6 +383,11 @@ void torch_tensor_power_float(torch_tensor_t output, const torch_tensor_t tensor
 // --- Functions related to automatic differentiation functionality for tensors
 // =============================================================================
 
+void torch_tensor_zero_grad(torch_tensor_t tensor) {
+  auto t = reinterpret_cast<torch::Tensor *>(tensor);
+  t->mutable_grad().zero_();
+}
+
 void torch_tensor_backward(const torch_tensor_t tensor,
                            const torch_tensor_t external_gradient) {
   auto t = reinterpret_cast<torch::Tensor *>(tensor);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -389,10 +389,11 @@ void torch_tensor_zero_grad(torch_tensor_t tensor) {
 }
 
 void torch_tensor_backward(const torch_tensor_t tensor,
-                           const torch_tensor_t external_gradient) {
+                           const torch_tensor_t external_gradient,
+                           const bool retain_graph) {
   auto t = reinterpret_cast<torch::Tensor *>(tensor);
   auto g = reinterpret_cast<torch::Tensor *const>(external_gradient);
-  t->backward(*g);
+  t->backward(*g, retain_graph);
 }
 
 void torch_tensor_get_gradient(const torch_tensor_t tensor, torch_tensor_t gradient) {

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -253,7 +253,7 @@ EXPORT_C void torch_tensor_power_float(torch_tensor_t output,
 
 /**
  * Function to reset the gradient values of a Torch Tensor to zero
- * @param Torch Tensor to zero the graident values of
+ * @param Torch Tensor to zero the gradient values of
  */
 EXPORT_C void torch_tensor_zero_grad(torch_tensor_t tensor);
 

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -262,9 +262,11 @@ EXPORT_C void torch_tensor_zero_grad(torch_tensor_t tensor);
  * Note that the Tensor must have the requires_grad attribute set to true.
  * @param Tensor to perform back-propagation on
  * @param Tensor with an external gradient to supply for the back-propagation
+ * @param whether the computational graph should be retained
  */
 EXPORT_C void torch_tensor_backward(const torch_tensor_t tensor,
-                                    const torch_tensor_t external_gradient);
+                                    const torch_tensor_t external_gradient,
+                                    const bool retain_graph);
 
 /**
  * Function to return the grad attribute of a Torch Tensor.

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -252,6 +252,12 @@ EXPORT_C void torch_tensor_power_float(torch_tensor_t output,
 // =============================================================================
 
 /**
+ * Function to reset the gradient values of a Torch Tensor to zero
+ * @param Torch Tensor to zero the graident values of
+ */
+EXPORT_C void torch_tensor_zero_grad(torch_tensor_t tensor);
+
+/**
  * Function to perform back-propagation on a Torch Tensor.
  * Note that the Tensor must have the requires_grad attribute set to true.
  * @param Tensor to perform back-propagation on

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -37,6 +37,7 @@ module ftorch
     procedure :: get_device_type => torch_tensor_get_device_type
     procedure :: get_device_index => torch_tensor_get_device_index
     procedure :: requires_grad => torch_tensor_requires_grad
+    procedure :: zero_grad => torch_tensor_zero_grad
     final :: torch_tensor_delete
   end type torch_tensor
 
@@ -1818,6 +1819,23 @@ contains
   ! ============================================================================
   ! --- Procedures related to automatic differentation functionality for tensors
   ! ============================================================================
+
+  !> Resets a tensor's gradient to zero.
+  subroutine torch_tensor_zero_grad(tensor)
+    use, intrinsic :: iso_c_binding, only : c_associated
+    class(torch_tensor), intent(inout) :: tensor
+
+    interface
+      subroutine torch_tensor_zero_grad_c(tensor) bind(c, name = 'torch_tensor_zero_grad')
+        use, intrinsic :: iso_c_binding, only : c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+      end subroutine torch_tensor_zero_grad_c
+    end interface
+
+    ! TODO: Call torch_tensor_get_gradient to check it exists?
+    call torch_tensor_zero_grad_c(tensor%p)
+  end subroutine torch_tensor_zero_grad
 
   !> Performs back-propagation on a Torch Tensor, given some external gradient.
   subroutine torch_tensor_backward(tensor)

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -1823,7 +1823,7 @@ contains
   !> Resets a tensor's gradient to zero.
   subroutine torch_tensor_zero_grad(tensor)
     use, intrinsic :: iso_c_binding, only : c_associated
-    class(torch_tensor), intent(inout) :: tensor
+    class(torch_tensor), intent(inout) :: tensor  !! Tensor to zero the gradient of
 
     interface
       subroutine torch_tensor_zero_grad_c(tensor) bind(c, name = 'torch_tensor_zero_grad')

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -1838,17 +1838,23 @@ contains
   end subroutine torch_tensor_zero_grad
 
   !> Performs back-propagation on a Torch Tensor, given some external gradient.
-  subroutine torch_tensor_backward(tensor)
-    type(torch_tensor), intent(in) :: tensor  !! Tensor to compute gradients of
+  subroutine torch_tensor_backward(tensor, retain_graph)
+    use, intrinsic :: iso_c_binding, only : c_bool
+    type(torch_tensor), intent(in) :: tensor       !! Tensor to compute gradients of
+    logical, optional, intent(in)  :: retain_graph !! Should the computational graph be retained?
+
+    ! Local arguments
     type(torch_tensor) :: external_gradient   !! External tensor used as an initial scaling of the gradient calculation
+    logical(c_bool) :: retain_graph_value
 
     interface
-      subroutine torch_tensor_backward_c(tensor_c, external_gradient_c) &
+      subroutine torch_tensor_backward_c(tensor_c, external_gradient_c, retain_graph_c) &
           bind(c, name = 'torch_tensor_backward')
-        use, intrinsic :: iso_c_binding, only : c_ptr
+        use, intrinsic :: iso_c_binding, only : c_bool, c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: external_gradient_c
+        logical(c_bool), value, intent(in) :: retain_graph_c
       end subroutine torch_tensor_backward_c
     end interface
 
@@ -1858,8 +1864,15 @@ contains
                            tensor%get_dtype(), tensor%get_device_type(), &
                            device_index=tensor%get_device_index())
 
+    ! Do not retain the graph by default
+    if (present(retain_graph)) then
+      retain_graph_value = retain_graph
+    else
+      retain_graph_value = .false.
+    end if
+
     ! Call back-propagation with the provided external gradient
-    call torch_tensor_backward_c(tensor%p, external_gradient%p)
+    call torch_tensor_backward_c(tensor%p, external_gradient%p, retain_graph_value)
 
     ! Delete the external gradient tensor
     call torch_tensor_delete(external_gradient)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -859,17 +859,23 @@ contains
   end subroutine torch_tensor_zero_grad
 
   !> Performs back-propagation on a Torch Tensor, given some external gradient.
-  subroutine torch_tensor_backward(tensor)
-    type(torch_tensor), intent(in) :: tensor  !! Tensor to compute gradients of
+  subroutine torch_tensor_backward(tensor, retain_graph)
+    use, intrinsic :: iso_c_binding, only : c_bool
+    type(torch_tensor), intent(in) :: tensor       !! Tensor to compute gradients of
+    logical, optional, intent(in)  :: retain_graph !! Should the computational graph be retained?
+
+    ! Local arguments
     type(torch_tensor) :: external_gradient   !! External tensor used as an initial scaling of the gradient calculation
+    logical(c_bool) :: retain_graph_value
 
     interface
-      subroutine torch_tensor_backward_c(tensor_c, external_gradient_c) &
+      subroutine torch_tensor_backward_c(tensor_c, external_gradient_c, retain_graph_c) &
           bind(c, name = 'torch_tensor_backward')
-        use, intrinsic :: iso_c_binding, only : c_ptr
+        use, intrinsic :: iso_c_binding, only : c_bool, c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: external_gradient_c
+        logical(c_bool), value, intent(in) :: retain_graph_c
       end subroutine torch_tensor_backward_c
     end interface
 
@@ -879,8 +885,15 @@ contains
                            tensor%get_dtype(), tensor%get_device_type(), &
                            device_index=tensor%get_device_index())
 
+    ! Do not retain the graph by default
+    if (present(retain_graph)) then
+      retain_graph_value = retain_graph
+    else
+      retain_graph_value = .false.
+    end if
+
     ! Call back-propagation with the provided external gradient
-    call torch_tensor_backward_c(tensor%p, external_gradient%p)
+    call torch_tensor_backward_c(tensor%p, external_gradient%p, retain_graph_value)
 
     ! Delete the external gradient tensor
     call torch_tensor_delete(external_gradient)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -56,6 +56,7 @@ module ftorch
     procedure :: get_device_type => torch_tensor_get_device_type
     procedure :: get_device_index => torch_tensor_get_device_index
     procedure :: requires_grad => torch_tensor_requires_grad
+    procedure :: zero_grad => torch_tensor_zero_grad
     final :: torch_tensor_delete
   end type torch_tensor
 
@@ -839,6 +840,23 @@ contains
   ! ============================================================================
   ! --- Procedures related to automatic differentation functionality for tensors
   ! ============================================================================
+
+  !> Resets a tensor's gradient to zero.
+  subroutine torch_tensor_zero_grad(tensor)
+    use, intrinsic :: iso_c_binding, only : c_associated
+    class(torch_tensor), intent(inout) :: tensor
+
+    interface
+      subroutine torch_tensor_zero_grad_c(tensor) bind(c, name = 'torch_tensor_zero_grad')
+        use, intrinsic :: iso_c_binding, only : c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor
+      end subroutine torch_tensor_zero_grad_c
+    end interface
+
+    ! TODO: Call torch_tensor_get_gradient to check it exists?
+    call torch_tensor_zero_grad_c(tensor%p)
+  end subroutine torch_tensor_zero_grad
 
   !> Performs back-propagation on a Torch Tensor, given some external gradient.
   subroutine torch_tensor_backward(tensor)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -844,7 +844,7 @@ contains
   !> Resets a tensor's gradient to zero.
   subroutine torch_tensor_zero_grad(tensor)
     use, intrinsic :: iso_c_binding, only : c_associated
-    class(torch_tensor), intent(inout) :: tensor
+    class(torch_tensor), intent(inout) :: tensor  !! Tensor to zero the gradient of
 
     interface
       subroutine torch_tensor_zero_grad_c(tensor) bind(c, name = 'torch_tensor_zero_grad')

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -22,6 +22,8 @@ add_pfunit_ctest(
 add_pfunit_ctest(
   test_operator_overloads_autograd TEST_SOURCES
   test_tensor_operator_overloads_autograd.pf LINK_LIBRARIES FTorch::ftorch)
+add_pfunit_ctest(test_tensor_autograd
+  TEST_SOURCES test_tensor_autograd.pf LINK_LIBRARIES FTorch::ftorch)
 
 if("${GPU_DEVICE}" STREQUAL "CUDA")
   check_language(CUDA)

--- a/test/unit/test_tensor_autograd.pf
+++ b/test/unit/test_tensor_autograd.pf
@@ -75,4 +75,50 @@ contains
     end if
 
   end subroutine test_torch_tensor_zero_grad
+
+  @test
+  subroutine test_torch_tensor_retain_graph()
+
+    implicit none
+
+    type(torch_tensor) :: Q, a, dQda
+    real(wp), dimension(2,3), target :: in_data, out_data
+    real(wp), dimension(2,3) :: expected
+
+    ! Create an arbitrary input array
+    in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+    ! Create a tensor based off an input array
+    call torch_tensor_from_array(a, in_data, tensor_layout, device_type, requires_grad=.true.)
+
+    ! Create another empty tensor and assign it to the first using the overloaded assignment
+    ! operator
+    call torch_tensor_empty(Q, ndims, tensor_shape, dtype, device_type)
+    Q = a
+
+    ! Create another tensor based off an output array for the gradient
+    call torch_tensor_from_array(dQda, out_data, tensor_layout, device_type)
+
+    ! Apply back-propagation and retrieve the gradient and check it takes the expected value:
+    !   Q(a) = a => dQ/da = 1
+    call torch_tensor_backward(Q)
+    call torch_tensor_get_gradient(a, dQda)
+    expected(:,:) = 1.0
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_retain_graph1")) then
+      print *, "Error :: incorrect value for first gradient computation"
+      stop 999
+    end if
+
+    ! Zero the gradient and then call back-propagation again and check the computed gradient still
+    ! takes the expected value
+    call a%zero_grad()
+    call torch_tensor_backward(Q, retain_graph=.true.)
+    call torch_tensor_get_gradient(a, dQda)
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_retain_graph3")) then
+      print *, "Error :: incorrect value for second gradient computation"
+      stop 999
+    end if
+
+  end subroutine test_torch_tensor_retain_graph
+
 end module test_tensor_autograd

--- a/test/unit/test_tensor_autograd.pf
+++ b/test/unit/test_tensor_autograd.pf
@@ -1,0 +1,87 @@
+!| Unit tests for FTorch's automatic differentiation functionality.
+!
+!  * License
+!    FTorch is released under an MIT license.
+!    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
+!    file for details.
+module test_tensor_autograd
+  use funit
+  use ftorch, only: assignment(=), ftorch_int, torch_kCPU, torch_kFloat32, torch_tensor, &
+                    torch_tensor_backward, torch_tensor_empty, torch_tensor_from_array, &
+                    torch_tensor_get_gradient
+  use ftorch_test_utils, only: assert_allclose
+  use, intrinsic :: iso_fortran_env, only: sp => real32
+  use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
+
+  implicit none
+
+  public
+
+  ! Set working precision for reals
+  integer, parameter :: wp = sp
+
+  ! All unit tests in this module run on CPU
+  integer, parameter :: device_type = torch_kCPU
+
+  ! All unit tests in this module use 2D arrays with the default layout and float32 precision
+  integer, parameter :: ndims = 2
+  integer(ftorch_int), parameter :: tensor_layout(ndims) = [1, 2]
+  integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
+  integer, parameter :: dtype = torch_kFloat32
+
+contains
+
+  @test
+  subroutine test_torch_tensor_zero_grad()
+
+    implicit none
+
+    type(torch_tensor) :: Q, a, dQda
+    real(wp), dimension(2,3), target :: in_data, out_data
+    real(wp), dimension(2,3) :: expected
+
+    ! Create an arbitrary input array
+    in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+    ! Create a tensor based off an input array
+    call torch_tensor_from_array(a, in_data, tensor_layout, device_type, requires_grad=.true.)
+
+    ! Create another empty tensor and assign it to the first using the overloaded assignment
+    ! operator
+    call torch_tensor_empty(Q, ndims, tensor_shape, dtype, device_type)
+    Q = a
+
+    ! Create another tensor based off an output array for the gradient
+    call torch_tensor_from_array(dQda, out_data, tensor_layout, device_type)
+
+    ! Apply back-propagation and retrieve the gradient and check it takes the expected value:
+    !   Q(a) = a => dQ/da = 1
+    call torch_tensor_backward(Q)
+    call torch_tensor_get_gradient(a, dQda)
+    expected(:,:) = 1.0
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_zero_grad1")) then
+      print *, "Error :: incorrect value for first gradient computation"
+      stop 999
+    end if
+
+    ! Call torch_tensor_zero_grad and check the gradient is indeed reset to zero. Note that we need
+    ! to call torch_tensor_get_gradient again after zeroing out these values.
+    call a%zero_grad()
+    call torch_tensor_get_gradient(a, dQda)
+    expected(:,:) = 0.0
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_zero_grad2")) then
+      print *, "Error :: incorrectly zeroed gradient"
+      stop 999
+    end if
+
+    ! Call back-propagation again and check the computed gradient still takes the expected value
+    call torch_tensor_backward(Q)
+    call torch_tensor_get_gradient(a, dQda)
+    expected(:,:) = 1.0
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_zero_grad3")) then
+      print *, "Error :: incorrect value for second gradient computation"
+      stop 999
+    end if
+
+  end subroutine test_torch_tensor_zero_grad
+end module test_tensor_autograd

--- a/test/unit/test_tensor_autograd.pf
+++ b/test/unit/test_tensor_autograd.pf
@@ -74,14 +74,5 @@ contains
       stop 999
     end if
 
-    ! Call back-propagation again and check the computed gradient still takes the expected value
-    call torch_tensor_backward(Q)
-    call torch_tensor_get_gradient(a, dQda)
-    expected(:,:) = 1.0
-    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_zero_grad3")) then
-      print *, "Error :: incorrect value for second gradient computation"
-      stop 999
-    end if
-
   end subroutine test_torch_tensor_zero_grad
 end module test_tensor_autograd


### PR DESCRIPTION
Closes #336.

This PR adds a subroutine (and corresponding class method) for zeroing the gradients associated with the tensor.

The caveat that had been tripping me up until now is that you need to call `torch_tensor_get_gradient` after zeroing the gradients. It'd be nice if we could find a way round this, but I guess it's okay for now so long as it's documented.