### PR TITLE
Expose `retain_graph` argument for `backward`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
   `torch_tensor_get_gradient` in [#286](https://github.com/Cambridge-ICCS/FTorch/pull/286)
 - Zeroing of gradients associated with a tensor implemented in
   [#341](https://github.com/Cambridge-ICCS/FTorch/pull/341).
+- Exposed `retain_graph` argument for `torch_tensor_backward` in
+  [#342](https://github.com/Cambridge-ICCS/FTorch/pull/342).
 
 ### Changed
 

--- a/pages/autograd.md
+++ b/pages/autograd.md
@@ -78,6 +78,13 @@ call torch_tensor_from_array(dQdb, out_data3, tensor_layout, torch_kCPU)
 call torch_tensor_get_gradient(b, dQdb)
 ```
 
+#### `retain_graph` argument
+
+If you wish to call the backpropagation operator multiple times then it's likely
+you will need to make use of the `retain_graph` argument for
+`torch_tensor_backward`. This argument accepts logical values and defaults to
+`.false.`, for consistency with PyTorch and LibTorch.
+
 #### Zeroing gradients
 
 Having computed gradients of one tensor with respect to its dependencies,
@@ -99,7 +106,7 @@ call torch_tensor_backward(Q)
 call torch_tensor_zero_grad(a)
 call torch_tensor_zero_grad(b)
 
-call torch_tensor_backward(P)
+call torch_tensor_backward(P, retain_graph=.true.)
 
 ! ...
 ```

--- a/pages/autograd.md
+++ b/pages/autograd.md
@@ -80,10 +80,13 @@ call torch_tensor_get_gradient(b, dQdb)
 
 #### `retain_graph` argument
 
-If you wish to call the backpropagation operator multiple times then it's likely
-you will need to make use of the `retain_graph` argument for
-`torch_tensor_backward`. This argument accepts logical values and defaults to
-`.false.`, for consistency with PyTorch and LibTorch.
+If you wish to call the backpropagation operator multiple times then you may
+need to make use of the `retain_graph` argument for `torch_tensor_backward`.
+This argument accepts logical values and defaults to `.false.`, for consistency
+with PyTorch and LibTorch. According to the
+[PyTorch docs](https://pytorch.org/docs/stable/generated/torch.Tensor.backward.html),
+`retain_graph=.true.` will not be needed in most cases, but it's useful to have
+for the cases where it is.
 
 #### Zeroing gradients
 

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -389,10 +389,11 @@ void torch_tensor_zero_grad(torch_tensor_t tensor) {
 }
 
 void torch_tensor_backward(const torch_tensor_t tensor,
-                           const torch_tensor_t external_gradient) {
+                           const torch_tensor_t external_gradient,
+                           const bool retain_graph) {
   auto t = reinterpret_cast<torch::Tensor *>(tensor);
   auto g = reinterpret_cast<torch::Tensor *const>(external_gradient);
-  t->backward(*g);
+  t->backward(*g, retain_graph);
 }
 
 void torch_tensor_get_gradient(const torch_tensor_t tensor, torch_tensor_t gradient) {

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -262,9 +262,11 @@ EXPORT_C void torch_tensor_zero_grad(torch_tensor_t tensor);
  * Note that the Tensor must have the requires_grad attribute set to true.
  * @param Tensor to perform back-propagation on
  * @param Tensor with an external gradient to supply for the back-propagation
+ * @param whether the computational graph should be retained
  */
 EXPORT_C void torch_tensor_backward(const torch_tensor_t tensor,
-                                    const torch_tensor_t external_gradient);
+                                    const torch_tensor_t external_gradient,
+                                    const bool retain_graph);
 
 /**
  * Function to return the grad attribute of a Torch Tensor.

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -1838,17 +1838,23 @@ contains
   end subroutine torch_tensor_zero_grad
 
   !> Performs back-propagation on a Torch Tensor, given some external gradient.
-  subroutine torch_tensor_backward(tensor)
-    type(torch_tensor), intent(in) :: tensor  !! Tensor to compute gradients of
+  subroutine torch_tensor_backward(tensor, retain_graph)
+    use, intrinsic :: iso_c_binding, only : c_bool
+    type(torch_tensor), intent(in) :: tensor       !! Tensor to compute gradients of
+    logical, optional, intent(in)  :: retain_graph !! Should the computational graph be retained?
+
+    ! Local arguments
     type(torch_tensor) :: external_gradient   !! External tensor used as an initial scaling of the gradient calculation
+    logical(c_bool) :: retain_graph_value
 
     interface
-      subroutine torch_tensor_backward_c(tensor_c, external_gradient_c) &
+      subroutine torch_tensor_backward_c(tensor_c, external_gradient_c, retain_graph_c) &
           bind(c, name = 'torch_tensor_backward')
-        use, intrinsic :: iso_c_binding, only : c_ptr
+        use, intrinsic :: iso_c_binding, only : c_bool, c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: external_gradient_c
+        logical(c_bool), value, intent(in) :: retain_graph_c
       end subroutine torch_tensor_backward_c
     end interface
 
@@ -1858,8 +1864,15 @@ contains
                            tensor%get_dtype(), tensor%get_device_type(), &
                            device_index=tensor%get_device_index())
 
+    ! Do not retain the graph by default
+    if (present(retain_graph)) then
+      retain_graph_value = retain_graph
+    else
+      retain_graph_value = .false.
+    end if
+
     ! Call back-propagation with the provided external gradient
-    call torch_tensor_backward_c(tensor%p, external_gradient%p)
+    call torch_tensor_backward_c(tensor%p, external_gradient%p, retain_graph_value)
 
     ! Delete the external gradient tensor
     call torch_tensor_delete(external_gradient)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -859,17 +859,23 @@ contains
   end subroutine torch_tensor_zero_grad
 
   !> Performs back-propagation on a Torch Tensor, given some external gradient.
-  subroutine torch_tensor_backward(tensor)
-    type(torch_tensor), intent(in) :: tensor  !! Tensor to compute gradients of
+  subroutine torch_tensor_backward(tensor, retain_graph)
+    use, intrinsic :: iso_c_binding, only : c_bool
+    type(torch_tensor), intent(in) :: tensor       !! Tensor to compute gradients of
+    logical, optional, intent(in)  :: retain_graph !! Should the computational graph be retained?
+
+    ! Local arguments
     type(torch_tensor) :: external_gradient   !! External tensor used as an initial scaling of the gradient calculation
+    logical(c_bool) :: retain_graph_value
 
     interface
-      subroutine torch_tensor_backward_c(tensor_c, external_gradient_c) &
+      subroutine torch_tensor_backward_c(tensor_c, external_gradient_c, retain_graph_c) &
           bind(c, name = 'torch_tensor_backward')
-        use, intrinsic :: iso_c_binding, only : c_ptr
+        use, intrinsic :: iso_c_binding, only : c_bool, c_ptr
         implicit none
         type(c_ptr), value, intent(in) :: tensor_c
         type(c_ptr), value, intent(in) :: external_gradient_c
+        logical(c_bool), value, intent(in) :: retain_graph_c
       end subroutine torch_tensor_backward_c
     end interface
 
@@ -879,8 +885,15 @@ contains
                            tensor%get_dtype(), tensor%get_device_type(), &
                            device_index=tensor%get_device_index())
 
+    ! Do not retain the graph by default
+    if (present(retain_graph)) then
+      retain_graph_value = retain_graph
+    else
+      retain_graph_value = .false.
+    end if
+
     ! Call back-propagation with the provided external gradient
-    call torch_tensor_backward_c(tensor%p, external_gradient%p)
+    call torch_tensor_backward_c(tensor%p, external_gradient%p, retain_graph_value)
 
     ! Delete the external gradient tensor
     call torch_tensor_delete(external_gradient)

--- a/test/unit/test_tensor_autograd.pf
+++ b/test/unit/test_tensor_autograd.pf
@@ -75,4 +75,50 @@ contains
     end if
 
   end subroutine test_torch_tensor_zero_grad
+
+  @test
+  subroutine test_torch_tensor_retain_graph()
+
+    implicit none
+
+    type(torch_tensor) :: Q, a, dQda
+    real(wp), dimension(2,3), target :: in_data, out_data
+    real(wp), dimension(2,3) :: expected
+
+    ! Create an arbitrary input array
+    in_data(:,:) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+
+    ! Create a tensor based off an input array
+    call torch_tensor_from_array(a, in_data, tensor_layout, device_type, requires_grad=.true.)
+
+    ! Create another empty tensor and assign it to the first using the overloaded assignment
+    ! operator
+    call torch_tensor_empty(Q, ndims, tensor_shape, dtype, device_type)
+    Q = a
+
+    ! Create another tensor based off an output array for the gradient
+    call torch_tensor_from_array(dQda, out_data, tensor_layout, device_type)
+
+    ! Apply back-propagation and retrieve the gradient and check it takes the expected value:
+    !   Q(a) = a => dQ/da = 1
+    call torch_tensor_backward(Q)
+    call torch_tensor_get_gradient(a, dQda)
+    expected(:,:) = 1.0
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_retain_graph1")) then
+      print *, "Error :: incorrect value for first gradient computation"
+      stop 999
+    end if
+
+    ! Zero the gradient and then call back-propagation again and check the computed gradient still
+    ! takes the expected value
+    call a%zero_grad()
+    call torch_tensor_backward(Q, retain_graph=.true.)
+    call torch_tensor_get_gradient(a, dQda)
+    if (.not. assert_allclose(out_data, expected, test_name="test_torch_tensor_retain_graph3")) then
+      print *, "Error :: incorrect value for second gradient computation"
+      stop 999
+    end if
+
+  end subroutine test_torch_tensor_retain_graph
+
 end module test_tensor_autograd


### PR DESCRIPTION
Closes #340.

> As mentioned in #320, we need to expose the `retain_graph` optional argument of the backpropagation operator in order to be able to run it multiple times.

Note that the branch used in this PR is based off the one from #341 so that one will need to be merged first.