### PR TITLE
Add Codespace for running FTorch Online

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/base:jammy
+
+RUN sudo apt update && sudo apt -y upgrade
+RUN sudo apt-get install -y gfortran

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/devcontainers/base:jammy
 
 RUN sudo apt update && sudo apt -y upgrade
-RUN sudo apt-get install -y gfortran
+RUN sudo apt install -y gfortran
+RUN sudo apt install -y python3-venv

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/base:jammy
 
 RUN sudo apt update && sudo apt -y upgrade
-RUN sudo apt install -y gfortran
-RUN sudo apt install -y python3-venv
+RUN sudo apt install -y cmake gfortran python3-venv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,18 @@
 	// "postCreateCommand": [],
 
 	// Configure tool-specific properties.
-	// "customizations": {}
+  "customizations": {
+      // Configure properties specific to VS Code see https://containers.dev/supporting.html
+      "vscode": {
+        // Set *default* container specific settings.json values on container create.
+        "settings": {},
+        "extensions": [
+          "fortran-lang.linter-gfortran",
+          "ms-vscode.cpptools-extension-pack",
+          "charliermarsh.ruff"
+        ],
+      }
+  }
 
 	// Uncomment to connect as root instead. https://containers.dev/implementors/json_reference/#remoteUser.
 	// "remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+// For format details, see https://containers.dev/implementors/json_reference/.
+// For config options, see the README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "FTorch",
+	"build": { "dockerfile": "Dockerfile" },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {}
+
+	// Uncomment to connect as root instead. https://containers.dev/implementors/json_reference/#remoteUser.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,12 @@
           "ms-vscode.cpptools-extension-pack",
           "charliermarsh.ruff"
         ],
+      },
+      // Define the landing page in the codespace to be the codespace README
+      "codespaces": {
+        "openFiles": [
+          "codespace/README.md",
+        ]
       }
   }
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ tests and examples.
 
 #### GitHub Codespace
 
-It is possible to try FTorch through an interactive browser sesison using GitHub
+It is possible to try FTorch through an interactive browser session using GitHub
 Codespace. Full instructions are in the
 [`codespace/`](https://github.com/Cambridge-ICCS/FTorch/tree/main/codespace) directory.
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ an environment to build FTorch in we provide guidance and environment files in
 are not minimal and will install Python, PyTorch, and modules required for running the
 tests and examples.
 
+#### GitHub Codespace
+
+It is possible to try FTorch through an interactive browser sesison using GitHub
+Codespace. Full instructions are in the
+[`codespace/`](https://github.com/Cambridge-ICCS/FTorch/tree/main/codespace) directory.
+
 ### Library installation
 
 For detailed installation instructions please see the

--- a/codespace/README.md
+++ b/codespace/README.md
@@ -8,7 +8,7 @@ the cloud.
 
 ## Getting Started
 
-All GitHub users have a certain number of hours of credit for using Codespaces.
+All GitHub users have a certain number of hours of credit for using codespaces.
 This can be extended if you have GitHub Education.
 
 To launch a codespace for FTorch navigate to the
@@ -47,10 +47,10 @@ respective `README`s.
 
 Note:
 
-- You do not need to create a new venv for each exercise, instead use the one that is
-  active following installation above.
+- You do not need to create a new virtual environment for each exercise, instead use
+  the one that is active following installation above.
 - You should link to the FTorch installation at `/workspaces/FTorch/bin/` when
-  specifiying a `CMAKE_PREFIX_PATH`.
+  specifying a `CMAKE_PREFIX_PATH`.
 
 
 ## Setup

--- a/codespace/README.md
+++ b/codespace/README.md
@@ -1,6 +1,6 @@
 # Codespace for FTorch
 
-If you want to try out FTorch from your browaser in an configured environment
+If you want to try out FTorch from your browser in a configured environment
 you can use a [GitHub Codespace](https://github.com/features/codespaces).
 This allows you to work in a VSCode Web session running code on from a container in
 the cloud.
@@ -27,10 +27,11 @@ dependencies installed and a copy of the FTorch repository cloned.
 
 ## Installing FTorch
 
-To install FTorch you can run the script in this directory:
+To install FTorch you can execute the script in the `codespace/` directory from the
+terminal:
 
 ```sh
-source build_FTorch.sh
+source codespace/build_FTorch.sh
 ```
 
 > [!NOTE]  

--- a/codespace/README.md
+++ b/codespace/README.md
@@ -1,0 +1,61 @@
+# Codespace for FTorch
+
+If you want to try out FTorch from your browaser in an configured environment
+you can use a [GitHub Codespace](https://github.com/features/codespaces).
+This allows you to work in a VSCode Web session running code on from a container in
+the cloud.
+
+
+## Getting Started
+
+All GitHub users have a certain number of hours of credit for using Codespaces.
+This can be extended if you have GitHub Education.
+
+To launch a codespace for FTorch navigate to the
+[repository on Github](https://github.com/Cambridge-ICCS/FTorch) and click the down
+arrow on the 'code button'.
+Select 'Codespaces' and then 'Create codespace on main'.
+This will open a new window and start up the interactive VSCode session.
+
+Once the container is set up you will be dropped into a VSCode session with
+dependencies installed and a copy of the FTorch repository cloned.
+
+> [!NOTE]  
+> Firefox users with enhanced tracking protection will need to disable this for
+> the codespace.
+
+
+## Installing FTorch
+
+To install FTorch you can run the script in this directory:
+
+```sh
+source build_FTorch.sh
+```
+
+> [!NOTE]  
+> By using `source` this will run in your current terminal, allowing the modified
+> `LD_LIBRARY_PATH` to persist and leaving in the virtual environment with `torch`
+> installed.
+
+
+## Examples
+
+You can now navigate to the examples and build them following the instructions in their
+respective `README`s.
+
+Note:
+
+- You do not need to create a new venv for each exercise, instead use the one that is
+  active following installation above.
+- You should link to the FTorch installation at `/workspaces/FTorch/bin/` when
+  specifiying a `CMAKE_PREFIX_PATH`.
+
+
+## Setup
+
+The codespace configuration is defined in the `.devcontainer/` directory under the root
+of FTorch.
+This contains a `Dockerfile` defining the Docker container we will work in - a base
+container with CMake, gfortran, and python installed - and `devcontainer.json` defining
+the codespace.

--- a/codespace/build_FTorch.sh
+++ b/codespace/build_FTorch.sh
@@ -4,10 +4,6 @@
 # It should be run from the top of the repository i.e. `FTorch/`
 # ---
 
-# Create a build directory to build FTorch in using CMake
-mkdir build
-cd build || exit
-
 # Set up a virtual environment an install neccessary Python dependencies
 #   We will specify the cpu-only version of PyTorch to match the codespace hardware
 python3 -m venv venv
@@ -19,6 +15,10 @@ pip install torch --index-url https://download.pytorch.org/whl/cpu
 # This is typically `FTorch/build/venv/lib/python3.xx/site-packages/`
 PYTHON_PATH=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
 
+# Create a build directory to build FTorch in using CMake
+mkdir build
+cd build || exit
+
 # Build FTorch using CMake
 #   We will build in `Release`, linking to the libtorch installed in the virtual
 #   environment, and installing the final library into FTorch/bin/
@@ -29,7 +29,7 @@ cmake .. \
 cmake --build . --target install
 
 # Add LibTorch libraries to the paths to be searched for dynamic linking at runtime
-export LD_LIBRARY_PATH=$LIBTORCH_PATH/torch/lib
+export LD_LIBRARY_PATH=$PYTHON_PATH/torch/lib
 
 # return user to the root of the project
 cd ../

--- a/codespace/build_FTorch.sh
+++ b/codespace/build_FTorch.sh
@@ -6,11 +6,12 @@
 
 # Create a build directory to build FTorch in using CMake
 mkdir build
-cd build
+cd build || exit
 
 # Set up a virtual environment an install neccessary Python dependencies
 #   We will specify the cpu-only version of PyTorch to match the codespace hardware
 python3 -m venv venv
+# shellcheck source=/dev/null
 source venv/bin/activate
 pip install torch --index-url https://download.pytorch.org/whl/cpu
 
@@ -23,7 +24,7 @@ PYTHON_PATH=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))"
 #   environment, and installing the final library into FTorch/bin/
 cmake .. \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_PREFIX_PATH=$PYTHON_PATH/torch \
+  -DCMAKE_PREFIX_PATH="$PYTHON_PATH"/torch \
   -DCMAKE_INSTALL_PREFIX=/workspaces/FTorch/bin
 cmake --build . --target install
 

--- a/codespace/build_FTorch.sh
+++ b/codespace/build_FTorch.sh
@@ -1,5 +1,8 @@
-# Navigate to the root directory of FTorch
-cd ../
+#!/bin/bash
+# ---
+# Script to build and install FTorch into a codespace environment
+# It should be run from the top of the repository i.e. `FTorch/`
+# ---
 
 # Create a build directory to build FTorch in using CMake
 mkdir build
@@ -26,3 +29,6 @@ cmake --build . --target install
 
 # Add LibTorch libraries to the paths to be searched for dynamic linking at runtime
 export LD_LIBRARY_PATH=$LIBTORCH_PATH/torch/lib
+
+# return user to the root of the project
+cd ../

--- a/codespace/build_FTorch.sh
+++ b/codespace/build_FTorch.sh
@@ -1,0 +1,28 @@
+# Navigate to the root directory of FTorch
+cd ../
+
+# Create a build directory to build FTorch in using CMake
+mkdir build
+cd build
+
+# Set up a virtual environment an install neccessary Python dependencies
+#   We will specify the cpu-only version of PyTorch to match the codespace hardware
+python3 -m venv venv
+source venv/bin/activate
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Extract the location of the installed packages in the venv
+# This is typically `FTorch/build/venv/lib/python3.xx/site-packages/`
+PYTHON_PATH=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
+
+# Build FTorch using CMake
+#   We will build in `Release`, linking to the libtorch installed in the virtual
+#   environment, and installing the final library into FTorch/bin/
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH=$PYTHON_PATH/torch \
+  -DCMAKE_INSTALL_PREFIX=/workspaces/FTorch/bin
+cmake --build . --target install
+
+# Add LibTorch libraries to the paths to be searched for dynamic linking at runtime
+export LD_LIBRARY_PATH=$LIBTORCH_PATH/torch/lib


### PR DESCRIPTION
This PR adds integration with GitHub Codespaces for running demonstrations and workshops.

Done via a devcontainer and Dockerfile

To launch go to this branch on the FTorch page, click "code" -> "Codespaces" -> "Create Codespace on codespace"

This will drop you into a codespace session within VSCode in browser.

From here we can build FTorch using:

```sh
mkdir build
cd build
python3 -m venv venv
source venv/bin/activate
pip install torch --index-url https://download.pytorch.org/whl/cpu
cmake .. \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_PREFIX_PATH=/workspaces/FTorch/build/venv/lib/python3.10/site-packages/torch \
  -DCMAKE_INSTALL_PREFIX=/workspaces/FTorch/bin
cmake --build . --target install
```
Note we need to specify the CPU wheel for pytorch, otherwise we get a bunch of CUDA infrastructure and then complaints about missing cuda when trying to build and link against libtorch.

I can then build and run exercise 1 with:
```sh
export LD_LIBRARY_PATH=/workspaces/FTorch/build/venv/lib/python3.10/site-packages/torch/lib

cd /workspaces/FTorch/examples/1_Tensor/
mkdir build && cd build
cmake .. -DCMAKE_PREFIX_PATH=/workspaces/FTorch/bin -DCMAKE_BUILD_TYPE=Release
cmake --build .
./tensor_manipulation
```

Note that I seem to need to set the LD_LIBRARY_PATH, otherwise I am unable to locate the libtorch.so and others when building exercises. Relates to issues seen elsewhere by myself and @niccolozanotti 

This seems to be a viable option for teaching (assuming all students and teachers have sufficient hours on codespaces 120 default, 180 pro).
Further questions:

- How much do we pre-install?
  - we could install torch in a venv and even pre-build FTorch if we wished to dive direct into the exercises.
- Other devcontainer options?
  - currently I have it very minimal.
- Do we also place this in the workshop repo, or just teach directly from here?
  - I think all the workshop examples are now here, so probably best to teach from here.