### PR TITLE
Add error handling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
   [#291](https://github.com/Cambridge-ICCS/FTorch/pull/291).
 - Use interface for `torch_tensor_from_array` with default layout in tests and
   examples in [#348](https://github.com/Cambridge-ICCS/FTorch/pull/348).
+- Error handling in `ctorch.cpp` improved in [#347](https://github.com/Cambridge-ICCS/FTorch/pull/347).
 
 ### Removed
 

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -179,7 +179,7 @@ torch_tensor_t torch_empty(int ndim, const int64_t *shape, torch_data_t dtype,
                            torch_device_t device_type, int device_index = -1,
                            const bool requires_grad = false) {
   torch::AutoGradMode enable_grad(requires_grad);
-  torch::Tensor *tensor = nullptr;
+  auto tensor = new torch::Tensor;
   try {
     // This doesn't throw if shape and dimensions are incompatible
     c10::IntArrayRef vshape(shape, ndim);
@@ -187,7 +187,6 @@ torch_tensor_t torch_empty(int ndim, const int64_t *shape, torch_data_t dtype,
                        .dtype(get_libtorch_dtype(dtype))
                        .device(get_libtorch_device(device_type, device_index))
                        .requires_grad(requires_grad);
-    tensor = new torch::Tensor;
     *tensor = torch::empty(vshape, options);
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
@@ -205,7 +204,7 @@ torch_tensor_t torch_zeros(int ndim, const int64_t *shape, torch_data_t dtype,
                            torch_device_t device_type, int device_index = -1,
                            const bool requires_grad = false) {
   torch::AutoGradMode enable_grad(requires_grad);
-  torch::Tensor *tensor = nullptr;
+  auto tensor = new torch::Tensor;
   try {
     // This doesn't throw if shape and dimensions are incompatible
     c10::IntArrayRef vshape(shape, ndim);
@@ -213,7 +212,6 @@ torch_tensor_t torch_zeros(int ndim, const int64_t *shape, torch_data_t dtype,
                        .dtype(get_libtorch_dtype(dtype))
                        .device(get_libtorch_device(device_type, device_index))
                        .requires_grad(requires_grad);
-    tensor = new torch::Tensor;
     *tensor = torch::zeros(vshape, options);
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
@@ -231,7 +229,7 @@ torch_tensor_t torch_ones(int ndim, const int64_t *shape, torch_data_t dtype,
                           torch_device_t device_type, int device_index = -1,
                           const bool requires_grad = false) {
   torch::AutoGradMode enable_grad(requires_grad);
-  torch::Tensor *tensor = nullptr;
+  auto tensor = new torch::Tensor;
   try {
     // This doesn't throw if shape and dimensions are incompatible
     c10::IntArrayRef vshape(shape, ndim);
@@ -239,7 +237,6 @@ torch_tensor_t torch_ones(int ndim, const int64_t *shape, torch_data_t dtype,
                        .dtype(get_libtorch_dtype(dtype))
                        .device(get_libtorch_device(device_type, device_index))
                        .requires_grad(requires_grad);
-    tensor = new torch::Tensor;
     *tensor = torch::ones(vshape, options);
   } catch (const torch::Error &e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
@@ -260,7 +257,7 @@ torch_tensor_t torch_from_blob(void *data, int ndim, const int64_t *shape,
                                torch_device_t device_type, int device_index = -1,
                                const bool requires_grad = false) {
   torch::AutoGradMode enable_grad(requires_grad);
-  torch::Tensor *tensor = nullptr;
+  auto tensor = new torch::Tensor;
 
   try {
     // This doesn't throw if shape and dimensions are incompatible
@@ -270,7 +267,6 @@ torch_tensor_t torch_from_blob(void *data, int ndim, const int64_t *shape,
                        .dtype(get_libtorch_dtype(dtype))
                        .device(get_libtorch_device(device_type, device_index))
                        .requires_grad(requires_grad);
-    tensor = new torch::Tensor;
     *tensor = torch::from_blob(data, vshape, vstrides, options);
 
   } catch (const torch::Error &e) {

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -143,10 +143,17 @@ const torch_device_t get_ftorch_device(torch::DeviceType device_type) {
 // --- Functions for validating tensors
 // =============================================================================
 
-// Check if a tensor is valid and defined
-void validate_tensor(const torch::Tensor *t, const std::string &name) {
-  if (!t || !t->defined()) {
-    throw std::invalid_argument(name + " is null or undefined.");
+// Check if a tensor is valid
+void validate_tensor_not_null(const torch::Tensor *t, const std::string &name) {
+  if (!t) {
+    throw std::invalid_argument(name + " is null.");
+  }
+}
+
+// Check if a tensor is defined
+void validate_tensor_defined(const torch::Tensor *t, const std::string &name) {
+  if (!t->defined()) {
+    throw std::invalid_argument(name + " is undefined.");
   }
 }
 
@@ -437,8 +444,9 @@ void torch_tensor_get_gradient(const torch_tensor_t tensor, torch_tensor_t gradi
     auto g = reinterpret_cast<torch::Tensor *>(gradient);
 
     // Check if the tensors are valid and defined
-    validate_tensor(t, "Input tensor");
-    validate_tensor(g, "Output gradient");
+    validate_tensor_not_null(t, "Input tensor");
+    validate_tensor_defined(t, "Input tensor");
+    validate_tensor_not_null(g, "Output gradient");
     // Check input has requires_grad set and can generate a valid gradient tensor
     validate_requires_grad(t, "Input tensor");
     validate_gradient_defined(t, "Input tensor");

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -347,6 +347,7 @@ void torch_tensor_delete(torch_tensor_t tensor) {
 
 void torch_tensor_zero(torch_tensor_t tensor) {
   auto t = reinterpret_cast<torch::Tensor *>(tensor);
+  validate_tensor(t, "Input tensor");
   t->zero_();
 }
 
@@ -357,6 +358,8 @@ void torch_tensor_zero(torch_tensor_t tensor) {
 void torch_tensor_assign(torch_tensor_t output, const torch_tensor_t input) {
   auto out = reinterpret_cast<torch::Tensor *>(output);
   auto in = reinterpret_cast<torch::Tensor *const>(input);
+  validate_tensor(out, "Output tensor");
+  validate_tensor(in, "Input tensor");
   torch::AutoGradMode enable_grad(in->requires_grad());
   // NOTE: The following line ensures that the output tensor continues to point to a
   //       Fortran array if it was set up to do so using torch_tensor_from_array. If
@@ -438,10 +441,8 @@ void torch_tensor_backward(const torch_tensor_t tensor,
 
   try {
     // Check if the tensors are valid and defined
-    validate_tensor_not_null(t, "Input tensor");
-    validate_tensor_defined(t, "Input tensor");
-    validate_tensor_not_null(g, "External gradient");
-    validate_tensor_defined(g, "External gradient");
+    validate_tensor(t, "Input tensor");
+    validate_tensor(g, "External gradient");
 
     // Perform backwards step
     t->backward(*g, retain_graph);
@@ -457,8 +458,7 @@ void torch_tensor_get_gradient(const torch_tensor_t tensor, torch_tensor_t gradi
     auto g = reinterpret_cast<torch::Tensor *>(gradient);
 
     // Check if the tensors are valid and defined
-    validate_tensor_not_null(t, "Input tensor");
-    validate_tensor_defined(t, "Input tensor");
+    validate_tensor(t, "Input tensor");
     validate_tensor_not_null(g, "Output gradient");
     // Check input has requires_grad set and can generate a valid gradient tensor
     validate_requires_grad(t, "Input tensor");

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -434,7 +434,20 @@ void torch_tensor_backward(const torch_tensor_t tensor,
                            const bool retain_graph) {
   auto t = reinterpret_cast<torch::Tensor *>(tensor);
   auto g = reinterpret_cast<torch::Tensor *const>(external_gradient);
-  t->backward(*g, retain_graph);
+
+  try {
+    // Check if the tensors are valid and defined
+    validate_tensor_not_null(t, "Input tensor");
+    validate_tensor_defined(t, "Input tensor");
+    validate_tensor_not_null(g, "External gradient");
+    validate_tensor_defined(g, "External gradient");
+
+    // Perform backwards step
+    t->backward(*g, retain_graph);
+  } catch (const std::exception &e) {
+    std::cerr << "Error in torch_tensor_backward: " << e.what() << std::endl;
+    std::terminate();
+  }
 }
 
 void torch_tensor_get_gradient(const torch_tensor_t tensor, torch_tensor_t gradient) {


### PR DESCRIPTION
This PR intends to improve the handling of errors in C++ to make things a little more instructive for users when things go wrong, rather than just having a bare stacktrace.

Currently there is some handling within FTorch to check tensors are created.
This adds handling on the C++ side to try and tell users why something has failed.

It is unclear how to test for this with pFUnit. At the moment I write some code, break it accordingly, and check I see the error expected...

Implemented:

- [x] generic error handling routines to be used throughout `ctorch.cpp`
    - These have not been made public or added to `ctorch.h` as designed to be used internally
- [x] generic routines to check tensors:
  - tensor is defined
  - tensor has requires_grad
  - gradient is defined for a tensor
- [x] usage of these throughout `ctorch.cpp`

Checking is not performed for getters (interrogation functions) or overloads (other than assign) as I felt probably unnecessary here.

This will introduce some overheads, but probably useful to have in for now as not expected to be significant and will help users in the development stage. Could consider a build with error handling off based on preprocessor flags in future if really desired.