### PR TITLE
Use fork of pFUnit with CMake version bumped to resolve failing install in workflows

### DIFF
--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -73,10 +73,10 @@ jobs:
           export FC=/usr/bin/gfortran
           export MPIF90=/usr/bin/mpif90
           # TODO: Avoid version pinning (needed because version appears in install path)
-          git clone -b v4.10.0 https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          git clone -b update_cmake_minimum https://github.com/jatkinson1000/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
-          cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake ..
           make -j 4 install
 
       - name: Build FTorch
@@ -86,7 +86,7 @@ jobs:
           export Torch_DIR=${VIRTUAL_ENV}/lib/python${VN}/site-packages
           export BUILD_DIR=$(pwd)/build
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR=$(pwd)/pFUnit/build/installed/PFUNIT-4.10
+          export PFUNIT_DIR=$(pwd)/pFUnit/build/installed/PFUNIT-4.11
           mkdir ${BUILD_DIR}
           cd ${BUILD_DIR}
           cmake .. \

--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -73,6 +73,7 @@ jobs:
           export FC=/usr/bin/gfortran
           export MPIF90=/usr/bin/mpif90
           # TODO: Avoid version pinning (needed because version appears in install path)
+          # TODO: Revert back to clone from Goddard pFUnit once PR to resolve CMake issues is resolved See #352
           git clone -b update_cmake_minimum https://github.com/jatkinson1000/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build

--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -76,7 +76,7 @@ jobs:
           git clone -b v4.10.0 https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
-          cmake ..
+          cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           make -j 4 install
 
       - name: Build FTorch


### PR DESCRIPTION
This resolves the failing CMake fPUnit workflows by forcing a compatible version at build time in the workflow.

I am about to open a PR to pFUnit to resolve it more generally at their level and will see if it fixes the issue here.