### PR TITLE
Run test suite with `ctest`

### DIFF
--- a/examples/1_Tensor/CMakeLists.txt
+++ b/examples/1_Tensor/CMakeLists.txt
@@ -30,6 +30,7 @@ if(CMAKE_BUILD_TESTS)
     NAME example1_tensor_manipulation
     COMMAND tensor_manipulation
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  set_tests_properties(example1_tensor_manipulation PROPERTIES PASS_REGULAR_EXPRESSION
+  set_tests_properties(example1_tensor_manipulation
+                       PROPERTIES PASS_REGULAR_EXPRESSION
                        "Tensor manipulation example ran successfully")
 endif()

--- a/examples/1_Tensor/CMakeLists.txt
+++ b/examples/1_Tensor/CMakeLists.txt
@@ -27,9 +27,9 @@ if(CMAKE_BUILD_TESTS)
 
   # 1. Check the Fortran example runs and its outputs meet expectations
   add_test(
-    NAME tensor_manipulation
+    NAME example1_tensor_manipulation
     COMMAND tensor_manipulation
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  set_tests_properties(tensor_manipulation PROPERTIES PASS_REGULAR_EXPRESSION
+  set_tests_properties(example1_tensor_manipulation PROPERTIES PASS_REGULAR_EXPRESSION
                        "Tensor manipulation example ran successfully")
 endif()

--- a/examples/2_SimpleNet/CMakeLists.txt
+++ b/examples/2_SimpleNet/CMakeLists.txt
@@ -25,9 +25,13 @@ target_link_libraries(simplenet_infer_fortran PRIVATE FTorch::ftorch)
 if(CMAKE_BUILD_TESTS)
   include(CTest)
 
+  add_test(NAME example2_requirements
+           COMMAND ${Python_EXECUTABLE} -m pip install -q -r
+                   ${PROJECT_SOURCE_DIR}/requirements.txt)
+
   # 1. Check the PyTorch model runs and its outputs meet expectations
-  add_test(NAME example2_simplenet COMMAND ${Python_EXECUTABLE}
-                                  ${PROJECT_SOURCE_DIR}/simplenet.py)
+  add_test(NAME example2_simplenet
+           COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py)
 
   # 2. Check the model is saved to file in the expected location with the
   #   pt2ts.py script

--- a/examples/2_SimpleNet/CMakeLists.txt
+++ b/examples/2_SimpleNet/CMakeLists.txt
@@ -26,13 +26,13 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
-  add_test(NAME simplenet COMMAND ${Python_EXECUTABLE}
+  add_test(NAME example2_simplenet COMMAND ${Python_EXECUTABLE}
                                   ${PROJECT_SOURCE_DIR}/simplenet.py)
 
   # 2. Check the model is saved to file in the expected location with the
   #   pt2ts.py script
   add_test(
-    NAME pt2ts
+    NAME example2_pt2ts
     COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --filepath
             ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -40,7 +40,7 @@ if(CMAKE_BUILD_TESTS)
   # 3. Check the model can be loaded from file and run in Python and that its
   #   outputs meet expectations
   add_test(
-    NAME simplenet_infer_python
+    NAME example2_simplenet_infer_python
     COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet_infer_python.py
             --filepath ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -48,12 +48,12 @@ if(CMAKE_BUILD_TESTS)
   # 4. Check the model can be loaded from file and run in Fortran and that its
   #   outputs meet expectations
   add_test(
-    NAME simplenet_infer_fortran
+    NAME example2_simplenet_infer_fortran
     COMMAND
       simplenet_infer_fortran ${PROJECT_BINARY_DIR}/saved_simplenet_model_cpu.pt
       # Command line argument: model file
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(
-    simplenet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-                                       "SimpleNet example ran successfully")
+    example2_simplenet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+    "SimpleNet example ran successfully")
 endif()

--- a/examples/3_ResNet/CMakeLists.txt
+++ b/examples/3_ResNet/CMakeLists.txt
@@ -27,14 +27,14 @@ if(CMAKE_BUILD_TESTS)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
   add_test(
-    NAME resnet18
+    NAME example3_resnet18
     COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/resnet18.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
   # 2. Check the model is saved to file in the expected location with the
   #   pt2ts.py script
   add_test(
-    NAME pt2ts
+    NAME example3_pt2ts
     COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --filepath
             ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -42,13 +42,13 @@ if(CMAKE_BUILD_TESTS)
   # 3. Check the model can be loaded from file and run in Fortran and that its
   #   outputs meet expectations
   add_test(
-    NAME resnet_infer_fortran
+    NAME example3_resnet_infer_fortran
     COMMAND
       resnet_infer_fortran ${PROJECT_BINARY_DIR}/saved_resnet18_model_cpu.pt
       ${PROJECT_SOURCE_DIR}/data
       # Command line arguments: model file and data directory filepath
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(
-    resnet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-                                    "ResNet18 example ran successfully")
+    example3_resnet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+    "ResNet18 example ran successfully")
 endif()

--- a/examples/3_ResNet/CMakeLists.txt
+++ b/examples/3_ResNet/CMakeLists.txt
@@ -25,6 +25,10 @@ target_link_libraries(resnet_infer_fortran PRIVATE FTorch::ftorch)
 if(CMAKE_BUILD_TESTS)
   include(CTest)
 
+  add_test(NAME example3_requirements
+           COMMAND ${Python_EXECUTABLE} -m pip install -q -r
+                   ${PROJECT_SOURCE_DIR}/requirements.txt)
+
   # 1. Check the PyTorch model runs and its outputs meet expectations
   add_test(
     NAME example3_resnet18

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -26,13 +26,13 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
-  add_test(NAME multiionet COMMAND ${Python_EXECUTABLE}
-                                   ${PROJECT_SOURCE_DIR}/multiionet.py)
+  add_test(NAME example4_multiionet
+           COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet.py)
 
   # 2. Check the model is saved to file in the expected location with the
   #   pt2ts.py script
   add_test(
-    NAME pt2ts
+    NAME example4_pt2ts
     COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --filepath
             ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -40,7 +40,7 @@ if(CMAKE_BUILD_TESTS)
   # 3. Check the model can be loaded from file and run in Python and that its
   #   outputs meet expectations
   add_test(
-    NAME multiionet_infer_python
+    NAME example4_multiionet_infer_python
     COMMAND
       ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet_infer_python.py
       --filepath ${PROJECT_BINARY_DIR}
@@ -49,12 +49,12 @@ if(CMAKE_BUILD_TESTS)
   # 4. Check the model can be loaded from file and run in Fortran and that its
   #   outputs meet expectations
   add_test(
-    NAME multiionet_infer_fortran
+    NAME example4_multiionet_infer_fortran
     COMMAND
       multiionet_infer_fortran ${PROJECT_BINARY_DIR}/saved_multiio_model_cpu.pt
       # Command line argument: model file
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(
-    multiionet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-                                        "MultiIO example ran successfully")
+    example4_multiionet_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+    "MultiIO example ran successfully")
 endif()

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -25,6 +25,10 @@ target_link_libraries(multiionet_infer_fortran PRIVATE FTorch::ftorch)
 if(CMAKE_BUILD_TESTS)
   include(CTest)
 
+  add_test(NAME example4_requirements
+           COMMAND ${Python_EXECUTABLE} -m pip install -q -r
+                   ${PROJECT_SOURCE_DIR}/requirements.txt)
+
   # 1. Check the PyTorch model runs and its outputs meet expectations
   add_test(NAME example4_multiionet
            COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/multiionet.py)

--- a/examples/5_Looping/CMakeLists.txt
+++ b/examples/5_Looping/CMakeLists.txt
@@ -18,11 +18,17 @@ find_package(FTorch)
 message(STATUS "Building with Fortran PyTorch coupling")
 
 # Fortran example - bad
-add_executable(example5_simplenet_infer_fortran_bad bad/simplenet_infer_fortran.f90)
-target_link_libraries(example5_simplenet_infer_fortran_bad PRIVATE FTorch::ftorch)
-target_sources(example5_simplenet_infer_fortran_bad PRIVATE bad/fortran_ml_mod.f90)
+add_executable(example5_simplenet_infer_fortran_bad
+               bad/simplenet_infer_fortran.f90)
+target_link_libraries(example5_simplenet_infer_fortran_bad
+                      PRIVATE FTorch::ftorch)
+target_sources(example5_simplenet_infer_fortran_bad
+               PRIVATE bad/fortran_ml_mod.f90)
 
 # Fortran example - good
-add_executable(example5_simplenet_infer_fortran_good good/simplenet_infer_fortran.f90)
-target_link_libraries(example5_simplenet_infer_fortran_good PRIVATE FTorch::ftorch)
-target_sources(example5_simplenet_infer_fortran_good PRIVATE good/fortran_ml_mod.f90)
+add_executable(example5_simplenet_infer_fortran_good
+               good/simplenet_infer_fortran.f90)
+target_link_libraries(example5_simplenet_infer_fortran_good
+                      PRIVATE FTorch::ftorch)
+target_sources(example5_simplenet_infer_fortran_good
+               PRIVATE good/fortran_ml_mod.f90)

--- a/examples/5_Looping/CMakeLists.txt
+++ b/examples/5_Looping/CMakeLists.txt
@@ -18,11 +18,11 @@ find_package(FTorch)
 message(STATUS "Building with Fortran PyTorch coupling")
 
 # Fortran example - bad
-add_executable(simplenet_infer_fortran_bad bad/simplenet_infer_fortran.f90)
-target_link_libraries(simplenet_infer_fortran_bad PRIVATE FTorch::ftorch)
-target_sources(simplenet_infer_fortran_bad PRIVATE bad/fortran_ml_mod.f90)
+add_executable(example5_simplenet_infer_fortran_bad bad/simplenet_infer_fortran.f90)
+target_link_libraries(example5_simplenet_infer_fortran_bad PRIVATE FTorch::ftorch)
+target_sources(example5_simplenet_infer_fortran_bad PRIVATE bad/fortran_ml_mod.f90)
 
 # Fortran example - good
-add_executable(simplenet_infer_fortran_good good/simplenet_infer_fortran.f90)
-target_link_libraries(simplenet_infer_fortran_good PRIVATE FTorch::ftorch)
-target_sources(simplenet_infer_fortran_good PRIVATE good/fortran_ml_mod.f90)
+add_executable(example5_simplenet_infer_fortran_good good/simplenet_infer_fortran.f90)
+target_link_libraries(example5_simplenet_infer_fortran_good PRIVATE FTorch::ftorch)
+target_sources(example5_simplenet_infer_fortran_good PRIVATE good/fortran_ml_mod.f90)

--- a/examples/6_MultiGPU/CMakeLists.txt
+++ b/examples/6_MultiGPU/CMakeLists.txt
@@ -35,6 +35,10 @@ target_link_libraries(multigpu_infer_fortran PRIVATE FTorch::ftorch)
 if(CMAKE_BUILD_TESTS)
   include(CTest)
 
+  add_test(NAME example6_requirements
+           COMMAND ${Python_EXECUTABLE} -m pip install -q -r
+                   ${PROJECT_SOURCE_DIR}/requirements.txt)
+
   if("${GPU_DEVICE}" STREQUAL "CUDA")
     # 1a. Check the PyTorch model runs on a CUDA device and its outputs meet
     # expectations

--- a/examples/6_MultiGPU/CMakeLists.txt
+++ b/examples/6_MultiGPU/CMakeLists.txt
@@ -38,14 +38,14 @@ if(CMAKE_BUILD_TESTS)
   if("${GPU_DEVICE}" STREQUAL "CUDA")
     # 1a. Check the PyTorch model runs on a CUDA device and its outputs meet
     # expectations
-    add_test(NAME simplenet
+    add_test(NAME example6_simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type cuda)
 
     # 2a. Check the model is saved to file in the expected location with the
     # pt2ts.py script
     add_test(
-      NAME pt2ts
+      NAME example6_pt2ts
       COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --device_type
               cuda --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -53,7 +53,7 @@ if(CMAKE_BUILD_TESTS)
     # 3a. Check the model can be loaded from file and run on two CUDA devices in
     # Python and that its outputs meet expectations
     add_test(
-      NAME multigpu_infer_python
+      NAME example6_multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type cuda
               --filepath ${PROJECT_BINARY_DIR}
@@ -62,27 +62,27 @@ if(CMAKE_BUILD_TESTS)
     # 4a. Check the model can be loaded from file and run on two CUDA devices in
     # Fortran and that its outputs meet expectations
     add_test(
-      NAME multigpu_infer_fortran
+      NAME example6_multigpu_infer_fortran
       COMMAND multigpu_infer_fortran cuda
               ${PROJECT_BINARY_DIR}/saved_multigpu_model_cuda.pt
       # Command line arguments for device type and model file
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     set_tests_properties(
-      multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-                                        "MultiGPU example ran successfully")
+      example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+      "MultiGPU example ran successfully")
   endif()
 
   if("${GPU_DEVICE}" STREQUAL "XPU")
     # 1b. Check the PyTorch model runs on an XPU device and its outputs meet
     # expectations
-    add_test(NAME simplenet
+    add_test(NAME example6_simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type xpu)
 
     # 2b. Check the model is saved to file in the expected location with the
     # pt2ts.py script
     add_test(
-      NAME pt2ts
+      NAME example6_pt2ts
       COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --device_type
               xpu --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -90,7 +90,7 @@ if(CMAKE_BUILD_TESTS)
     # 3b. Check the model can be loaded from file and run on two XPU devices in
     # Python and that its outputs meet expectations
     add_test(
-      NAME multigpu_infer_python
+      NAME example6_multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type xpu
               --filepath ${PROJECT_BINARY_DIR}
@@ -99,26 +99,26 @@ if(CMAKE_BUILD_TESTS)
     # 4b. Check the model can be loaded from file and run on two XPU devices in
     # Fortran and that its outputs meet expectations
     add_test(
-      NAME multigpu_infer_fortran
+      NAME example6_multigpu_infer_fortran
       COMMAND multigpu_infer_fortran xpu
               ${PROJECT_BINARY_DIR}/saved_multigpu_model_xpu.pt
       # Command line arguments for device type and model file
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     set_tests_properties(
-      multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-                                        "MultiGPU example ran successfully")
+      example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+      "MultiGPU example ran successfully")
   endif()
 
   if("${GPU_DEVICE}" STREQUAL "MPS")
     # 1c. Check the PyTorch model runs on an MPS device and its outputs meet
     # expectations
-    add_test(NAME simplenet
+    add_test(NAME example6_simplenet
              COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/simplenet.py
                      --device_type mps)
     # 2c. Check the model is saved to file in the expected location with the
     # pt2ts.py script
     add_test(
-      NAME pt2ts
+      NAME example6_pt2ts
       COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --device_type
               mps --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -126,7 +126,7 @@ if(CMAKE_BUILD_TESTS)
     # 3c. Check the model can be loaded from file and run on one MPS device in
     # Python and that its outputs meet expectations
     add_test(
-      NAME multigpu_infer_python
+      NAME example6_multigpu_infer_python
       COMMAND ${Python_EXECUTABLE}
               ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type mps
               --filepath ${PROJECT_BINARY_DIR}
@@ -135,13 +135,13 @@ if(CMAKE_BUILD_TESTS)
     # 4c. Check the model can be loaded from file and run on one MPS device in
     # Fortran and that its outputs meet expectations
     add_test(
-      NAME multigpu_infer_fortran
+      NAME example6_multigpu_infer_fortran
       COMMAND multigpu_infer_fortran mps
               ${PROJECT_BINARY_DIR}/saved_multigpu_model_mps.pt
       # Command line arguments for device type and model file
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     set_tests_properties(
-      multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-                                        "MultiGPU example ran successfully")
+      example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+      "MultiGPU example ran successfully")
   endif()
 endif()

--- a/examples/7_MPI/CMakeLists.txt
+++ b/examples/7_MPI/CMakeLists.txt
@@ -28,13 +28,13 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the PyTorch model runs and its outputs meet expectations
-  add_test(NAME simplenet COMMAND ${Python_EXECUTABLE}
-                                  ${PROJECT_SOURCE_DIR}/simplenet.py)
+  add_test(NAME example7_simplenet COMMAND ${Python_EXECUTABLE}
+                                           ${PROJECT_SOURCE_DIR}/simplenet.py)
 
   # 2. Check the model is saved to file in the expected location with the
   #   pt2ts.py script
   add_test(
-    NAME pt2ts
+    NAME example7_pt2ts
     COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/pt2ts.py --filepath
             ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -42,25 +42,25 @@ if(CMAKE_BUILD_TESTS)
   # 3. Check the model can be loaded from file and run with MPI in Python and
   #   that its outputs meet expectations
   add_test(
-    NAME mpi_infer_python
+    NAME example7_mpi_infer_python
     COMMAND
       ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${Python_EXECUTABLE}
       ${PROJECT_SOURCE_DIR}/mpi_infer_python.py --filepath ${PROJECT_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(
-    mpi_infer_python PROPERTIES PASS_REGULAR_EXPRESSION
-                                "MPI Python example ran successfully")
+    example7_mpi_infer_python PROPERTIES PASS_REGULAR_EXPRESSION
+    "MPI Python example ran successfully")
 
   # 4. Check the model can be loaded from file and run with MPI in Fortran and
   #   that its outputs meet expectations
   add_test(
-    NAME mpi_infer_fortran
+    NAME example7_mpi_infer_fortran
     COMMAND
       ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./mpi_infer_fortran
       ${PROJECT_BINARY_DIR}/saved_simplenet_model_cpu.pt
       # Command line argument: model file
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(
-    mpi_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-                                 "MPI Fortran example ran successfully")
+    example7_mpi_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+    "MPI Fortran example ran successfully")
 endif()

--- a/examples/7_MPI/CMakeLists.txt
+++ b/examples/7_MPI/CMakeLists.txt
@@ -27,6 +27,10 @@ target_link_libraries(mpi_infer_fortran PRIVATE MPI::MPI_Fortran)
 if(CMAKE_BUILD_TESTS)
   include(CTest)
 
+  add_test(NAME example7_requirements
+           COMMAND ${Python_EXECUTABLE} -m pip install -q -r
+                   ${PROJECT_SOURCE_DIR}/requirements.txt)
+
   # 1. Check the PyTorch model runs and its outputs meet expectations
   add_test(NAME example7_simplenet COMMAND ${Python_EXECUTABLE}
                                            ${PROJECT_SOURCE_DIR}/simplenet.py)

--- a/examples/8_Autograd/CMakeLists.txt
+++ b/examples/8_Autograd/CMakeLists.txt
@@ -25,6 +25,10 @@ target_link_libraries(autograd PRIVATE FTorch::ftorch)
 if(CMAKE_BUILD_TESTS)
   include(CTest)
 
+  add_test(NAME example8_requirements
+           COMMAND ${Python_EXECUTABLE} -m pip install -q -r
+                   ${PROJECT_SOURCE_DIR}/requirements.txt)
+
   # 1. Check the Python Autograd script runs successfully
   add_test(NAME example8_pyautograd COMMAND ${Python_EXECUTABLE}
                                             ${PROJECT_SOURCE_DIR}/autograd.py)

--- a/examples/8_Autograd/CMakeLists.txt
+++ b/examples/8_Autograd/CMakeLists.txt
@@ -26,14 +26,14 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the Python Autograd script runs successfully
-  add_test(NAME pyautograd COMMAND ${Python_EXECUTABLE}
-                                   ${PROJECT_SOURCE_DIR}/autograd.py)
+  add_test(NAME example8_pyautograd COMMAND ${Python_EXECUTABLE}
+                                            ${PROJECT_SOURCE_DIR}/autograd.py)
 
   # 2. Check the Fortran Autograd script runs successfully
   add_test(
-    NAME fautograd
+    NAME example8_fautograd
     COMMAND autograd
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  set_tests_properties(fautograd PROPERTIES PASS_REGULAR_EXPRESSION
-                                            "Autograd example ran successfully")
+  set_tests_properties(example8_fautograd PROPERTIES PASS_REGULAR_EXPRESSION
+                       "Autograd example ran successfully")
 endif()

--- a/run_test_suite.sh
+++ b/run_test_suite.sh
@@ -82,16 +82,5 @@ fi
 
 # Run integration tests
 if [ "${RUN_INTEGRATION}" = true ]; then
-  if [ -e "${BUILD_DIR}/examples/6_MultiGPU" ]; then
-    EXAMPLES="1_Tensor 2_SimpleNet 3_ResNet 4_MultiIO 6_MultiGPU 7_MPI 8_Autograd"
-  else
-    EXAMPLES="1_Tensor 2_SimpleNet 3_ResNet 4_MultiIO 7_MPI 8_Autograd"
-  fi
-  export PIP_REQUIRE_VIRTUALENV=true
-  for EXAMPLE in ${EXAMPLES}; do
-    python -m pip -q install -r examples/"${EXAMPLE}"/requirements.txt
-    cd "${BUILD_DIR}"/examples/"${EXAMPLE}"
-    ctest "${CTEST_ARGS}"
-    cd -
-  done
+  ctest -R example ${CTEST_ARGS}
 fi

--- a/run_test_suite.sh
+++ b/run_test_suite.sh
@@ -73,11 +73,11 @@ else
   CTEST_ARGS=""
 fi
 
+cd "${BUILD_DIR}"
+
 # Run unit tests
 if [ "${RUN_UNIT}" = true ]; then
-  cd "${BUILD_DIR}/test/unit"
-  ctest "${CTEST_ARGS}"
-  cd -
+  ctest -R unittest ${CTEST_ARGS}
 fi
 
 # Run integration tests

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -12,20 +12,20 @@ message(STATUS "Building with Fortran PyTorch coupling")
 find_package(PFUNIT REQUIRED)
 
 add_pfunit_ctest(
-  test_tensor_constructors_destructors TEST_SOURCES
-  test_tensor_constructors_destructors.pf LINK_LIBRARIES FTorch::ftorch)
-add_pfunit_ctest(test_tensor_interrogation
-  TEST_SOURCES test_tensor_interrogation.pf LINK_LIBRARIES FTorch::ftorch)
-add_pfunit_ctest(test_tensor_manipulation
-  TEST_SOURCES test_tensor_manipulation.pf LINK_LIBRARIES FTorch::ftorch)
+  unittest_tensor_constructors_destructors TEST_SOURCES
+  unittest_tensor_constructors_destructors.pf LINK_LIBRARIES FTorch::ftorch)
+add_pfunit_ctest(unittest_tensor_interrogation
+  TEST_SOURCES unittest_tensor_interrogation.pf LINK_LIBRARIES FTorch::ftorch)
+add_pfunit_ctest(unittest_tensor_manipulation
+  TEST_SOURCES unittest_tensor_manipulation.pf LINK_LIBRARIES FTorch::ftorch)
 add_pfunit_ctest(
-  test_operator_overloads TEST_SOURCES test_tensor_operator_overloads.pf
+  unittest_operator_overloads TEST_SOURCES unittest_tensor_operator_overloads.pf
   LINK_LIBRARIES FTorch::ftorch)
 add_pfunit_ctest(
-  test_operator_overloads_autograd TEST_SOURCES
-  test_tensor_operator_overloads_autograd.pf LINK_LIBRARIES FTorch::ftorch)
-add_pfunit_ctest(test_tensor_autograd
-  TEST_SOURCES test_tensor_autograd.pf LINK_LIBRARIES FTorch::ftorch)
+  unittest_operator_overloads_autograd TEST_SOURCES
+  unittest_tensor_operator_overloads_autograd.pf LINK_LIBRARIES FTorch::ftorch)
+add_pfunit_ctest(unittest_tensor_autograd
+  TEST_SOURCES unittest_tensor_autograd.pf LINK_LIBRARIES FTorch::ftorch)
 
 if("${GPU_DEVICE}" STREQUAL "CUDA")
   check_language(CUDA)
@@ -35,6 +35,6 @@ if("${GPU_DEVICE}" STREQUAL "CUDA")
     message(ERROR "No CUDA support")
   endif()
   add_pfunit_ctest(
-    test_tensor_interrogation_cuda TEST_SOURCES
-    test_tensor_interrogation_cuda.pf LINK_LIBRARIES FTorch::ftorch)
+    unittest_tensor_interrogation_cuda TEST_SOURCES
+    unittest_tensor_interrogation_cuda.pf LINK_LIBRARIES FTorch::ftorch)
 endif()

--- a/test/unit/unittest_tensor_autograd.pf
+++ b/test/unit/unittest_tensor_autograd.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module test_tensor_autograd
+module unittest_tensor_autograd
   use funit
   use ftorch, only: assignment(=), ftorch_int, torch_kCPU, torch_kFloat32, torch_tensor, &
                     torch_tensor_backward, torch_tensor_empty, torch_tensor_from_array, &
@@ -120,4 +120,4 @@ contains
 
   end subroutine test_torch_tensor_retain_graph
 
-end module test_tensor_autograd
+end module unittest_tensor_autograd

--- a/test/unit/unittest_tensor_constructors_destructors.pf
+++ b/test/unit/unittest_tensor_constructors_destructors.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module test_tensor_constructors_destructors
+module unittest_tensor_constructors_destructors
   use funit
   use ftorch, only: assignment(=), torch_kFloat32, torch_kCPU, torch_tensor, &
                     torch_tensor_delete, torch_tensor_from_array
@@ -413,4 +413,4 @@ contains
 
   end subroutine test_torch_tensor_destruction
 
-end module test_tensor_constructors_destructors
+end module unittest_tensor_constructors_destructors

--- a/test/unit/unittest_tensor_interrogation.pf
+++ b/test/unit/unittest_tensor_interrogation.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module test_tensor_interrogation
+module unittest_tensor_interrogation
   use funit
   use ftorch, only: torch_kFloat32, torch_kCPU, torch_tensor, torch_tensor_empty
   use iso_c_binding, only: c_int64_t
@@ -247,4 +247,4 @@ contains
 
   end subroutine test_requires_grad
 
-end module test_tensor_interrogation
+end module unittest_tensor_interrogation

--- a/test/unit/unittest_tensor_interrogation_cuda.pf
+++ b/test/unit/unittest_tensor_interrogation_cuda.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module test_tensor_interrogation_cuda
+module unittest_tensor_interrogation_cuda
   use funit
   use ftorch, only: torch_kFloat32, torch_kCUDA, torch_tensor, torch_tensor_empty
   use iso_c_binding, only: c_int64_t
@@ -58,4 +58,4 @@ contains
 
   end subroutine test_torch_tensor_get_device_index_default
 
-end module test_tensor_interrogation_cuda
+end module unittest_tensor_interrogation_cuda

--- a/test/unit/unittest_tensor_manipulation.pf
+++ b/test/unit/unittest_tensor_manipulation.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module test_tensor_manipulation
+module unittest_tensor_manipulation
   use funit
   use ftorch, only: assignment(=), torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_from_array
   use ftorch_test_utils, only: assert_allclose
@@ -52,4 +52,4 @@ contains
 
   end subroutine test_torch_tensor_zero
 
-end module test_tensor_manipulation
+end module unittest_tensor_manipulation

--- a/test/unit/unittest_tensor_operator_overloads.pf
+++ b/test/unit/unittest_tensor_operator_overloads.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module test_tensor_operator_overloads
+module unittest_tensor_operator_overloads
   use funit
   use ftorch, only: assignment(=), torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_from_array
   use ftorch_test_utils, only: assert_allclose
@@ -513,4 +513,4 @@ contains
 
   end subroutine test_torch_tensor_sqrt
 
-end module test_tensor_operator_overloads
+end module unittest_tensor_operator_overloads

--- a/test/unit/unittest_tensor_operator_overloads_autograd.pf
+++ b/test/unit/unittest_tensor_operator_overloads_autograd.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module test_tensor_operator_overloads_autograd
+module unittest_tensor_operator_overloads_autograd
   use funit
   use ftorch, only: assignment(=), ftorch_int, torch_kCPU, torch_kFloat32, &
                     torch_tensor, torch_tensor_backward, torch_tensor_delete, torch_tensor_empty, &
@@ -534,4 +534,4 @@ contains
 
   end subroutine test_torch_tensor_sqrt
 
-end module test_tensor_operator_overloads_autograd
+end module unittest_tensor_operator_overloads_autograd


### PR DESCRIPTION
Closes #249.

Tidies up the test suite to just run with `ctest` directly, rather than navigating into subdirectories.

A big advantage of this approach is that we can use the various useful arguments for `ctest`, such as `ctest -R unittest_tensor_autograd` to run that specific test.