### PR TITLE
Raise an error if user attempts to assign to tensor with `requires_grad=.true.`

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -325,6 +325,11 @@ void torch_tensor_assign(torch_tensor_t output, const torch_tensor_t input) {
   auto out = reinterpret_cast<torch::Tensor *>(output);
   auto in = reinterpret_cast<torch::Tensor *const>(input);
   torch::AutoGradMode enable_grad(in->requires_grad());
+  if (out->requires_grad()) {
+    std::cerr << "[ERROR]: Cannot modify the values of a tensor with requires_grad=true"
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
   // NOTE: The following line ensures that the output tensor continues to point to a
   //       Fortran array if it was set up to do so using torch_tensor_from_array. If
   //       it's removed then the Fortran array keeps its original value and is no

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -325,11 +325,6 @@ void torch_tensor_assign(torch_tensor_t output, const torch_tensor_t input) {
   auto out = reinterpret_cast<torch::Tensor *>(output);
   auto in = reinterpret_cast<torch::Tensor *const>(input);
   torch::AutoGradMode enable_grad(in->requires_grad());
-  if (out->requires_grad()) {
-    std::cerr << "[ERROR]: Cannot modify the values of a tensor with requires_grad=true"
-              << std::endl;
-    exit(EXIT_FAILURE);
-  }
   // NOTE: The following line ensures that the output tensor continues to point to a
   //       Fortran array if it was set up to do so using torch_tensor_from_array. If
   //       it's removed then the Fortran array keeps its original value and is no

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2484,6 +2484,10 @@ contains
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
     end if
+    if (output%requires_grad()) then
+      write(*,*) "Error :: cannot modify the values of a tensor with requires_grad=.true."
+      stop 1
+    end if
     call torch_tensor_assign_c(output%p, input%p)
   end subroutine torch_tensor_assign
 

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2485,7 +2485,7 @@ contains
       stop 1
     end if
     if (output%requires_grad()) then
-      write(*,*) "Error :: cannot modify the values of a tensor with requires_grad=.true."
+      write(*,*) "Error :: cannot assign values of a tensor with requires_grad=.true."
       stop 1
     end if
     call torch_tensor_assign_c(output%p, input%p)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -719,7 +719,7 @@ contains
       stop 1
     end if
     if (output%requires_grad()) then
-      write(*,*) "Error :: cannot modify the values of a tensor with requires_grad=.true."
+      write(*,*) "Error :: cannot assign values of a tensor with requires_grad=.true."
       stop 1
     end if
     call torch_tensor_assign_c(output%p, input%p)

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -718,6 +718,10 @@ contains
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
     end if
+    if (output%requires_grad()) then
+      write(*,*) "Error :: cannot modify the values of a tensor with requires_grad=.true."
+      stop 1
+    end if
     call torch_tensor_assign_c(output%p, input%p)
   end subroutine torch_tensor_assign
 


### PR DESCRIPTION
Closes #327.

As discussed in-person, it shouldn't be allowed to modify a tensor that has `requires_grad=true` because this is a tensor that's marked as something we differentiate with respect to. This PR raises an error if someone attempts to do so.

~~Unfortunately, I had to raise the error on the C++ side because it didn't work on the Fortran side in `torch_tensor_assign`. The reason is that the `output` tensor is actually the return value of a function, so we can't query its attributes. It seems to always be set to `.false.`. However, it is possible to do this when its pointer gets passed to C++.~~

Edit: Ignore me! Having set things back up on my fresh OS, I'd set up my editor autocmds incorrectly and was auto-generating `ftorch.f90` rather than `ftorch.F90`. The error is now raised on the Fortran side.