### PR TITLE
Do not carry over `requires_grad` with overloaded ops

### DIFF
--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2478,8 +2478,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, input%get_rank(), input%get_shape(), input%get_dtype(), &
-                              input%get_device_type(), device_index=input%get_device_index(), &
-                              requires_grad=input%requires_grad())
+                              input%get_device_type(), device_index=input%get_device_index())
     else if (input%get_device_type() /= output%get_device_type()) then
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
@@ -2516,8 +2515,7 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index(), &
-                              requires_grad=tensor1%requires_grad())
+                              device_index=tensor1%get_device_index())
     end if
     call torch_tensor_add_c(output%p,tensor1%p, tensor2%p)
   end function torch_tensor_add
@@ -2539,8 +2537,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_negative_c(output%p, tensor%p)
   end function torch_tensor_negative
@@ -2571,8 +2568,7 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index(), &
-                              requires_grad=tensor1%requires_grad())
+                              device_index=tensor1%get_device_index())
     end if
     call torch_tensor_subtract_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_subtract
@@ -2592,8 +2588,7 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index(), &
-                              requires_grad=tensor1%requires_grad())
+                              device_index=tensor1%get_device_index())
     end if
     call torch_tensor_multiply_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_multiply
@@ -2613,8 +2608,7 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index(), &
-                              requires_grad=tensor1%requires_grad())
+                              device_index=tensor1%get_device_index())
     end if
     call torch_tensor_divide_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_divide
@@ -2640,8 +2634,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int8
@@ -2667,8 +2660,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int16
@@ -2694,8 +2686,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int32
@@ -2721,8 +2712,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int64
@@ -2749,8 +2739,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_real32
@@ -2776,8 +2765,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_real64

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -712,8 +712,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, input%get_rank(), input%get_shape(), input%get_dtype(), &
-                              input%get_device_type(), device_index=input%get_device_index(), &
-                              requires_grad=input%requires_grad())
+                              input%get_device_type(), device_index=input%get_device_index())
     else if (input%get_device_type() /= output%get_device_type()) then
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
@@ -750,8 +749,7 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index(), &
-                              requires_grad=tensor1%requires_grad())
+                              device_index=tensor1%get_device_index())
     end if
     call torch_tensor_add_c(output%p,tensor1%p, tensor2%p)
   end function torch_tensor_add
@@ -773,8 +771,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_negative_c(output%p, tensor%p)
   end function torch_tensor_negative
@@ -805,8 +802,7 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index(), &
-                              requires_grad=tensor1%requires_grad())
+                              device_index=tensor1%get_device_index())
     end if
     call torch_tensor_subtract_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_subtract
@@ -826,8 +822,7 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index(), &
-                              requires_grad=tensor1%requires_grad())
+                              device_index=tensor1%get_device_index())
     end if
     call torch_tensor_multiply_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_multiply
@@ -847,8 +842,7 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index(), &
-                              requires_grad=tensor1%requires_grad())
+                              device_index=tensor1%get_device_index())
     end if
     call torch_tensor_divide_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_divide
@@ -875,8 +869,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_${PREC}$
@@ -905,8 +898,7 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
-                              requires_grad=tensor%requires_grad())
+                              tensor%get_device_type(), device_index=tensor%get_device_index())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_${PREC}$


### PR DESCRIPTION
I don't think we should be carrying over the `requires_grad` property with overloaded operations. This should only be used for tensors that we want to differentiate w.r.t.