### PR TITLE
`requires_grad` *should* be carried through expressions

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -381,6 +381,10 @@ void torch_tensor_assign(torch_tensor_t output, const torch_tensor_t input) {
   //       it's removed then the Fortran array keeps its original value and is no
   //       longer be pointed to.
   std::move(*out) = *in;
+  // NOTE: The following line ensures that we always overwrite the requires_grad
+  // property. See the Python examples on
+  // https://github.com/Cambridge-ICCS/FTorch/pull/373.
+  out->requires_grad_(in->requires_grad());
 }
 
 void torch_tensor_add(torch_tensor_t output, const torch_tensor_t tensor1,

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -382,7 +382,7 @@ void torch_tensor_assign(torch_tensor_t output, const torch_tensor_t input) {
   //       longer be pointed to.
   std::move(*out) = *in;
   // NOTE: The following line ensures that we always overwrite the requires_grad
-  // property. See the Python examples on
+  // property matching the PyTorch behaviour. See the Python examples on
   // https://github.com/Cambridge-ICCS/FTorch/pull/373.
   out->requires_grad_(in->requires_grad());
 }

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2532,7 +2532,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, input%get_rank(), input%get_shape(), input%get_dtype(), &
-                              input%get_device_type(), device_index=input%get_device_index())
+                              input%get_device_type(), device_index=input%get_device_index(), &
+                              requires_grad=input%requires_grad())
     else if (input%get_device_type() /= output%get_device_type()) then
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
@@ -2569,7 +2570,8 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_add_c(output%p,tensor1%p, tensor2%p)
   end function torch_tensor_add
@@ -2591,7 +2593,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_negative_c(output%p, tensor%p)
   end function torch_tensor_negative
@@ -2622,7 +2625,8 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_subtract_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_subtract
@@ -2642,7 +2646,8 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_multiply_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_multiply
@@ -2662,7 +2667,8 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_divide_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_divide
@@ -2688,7 +2694,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int8
@@ -2714,7 +2721,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int16
@@ -2740,7 +2748,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int32
@@ -2766,7 +2775,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_int64
@@ -2793,7 +2803,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_real32
@@ -2819,7 +2830,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_real64

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2538,10 +2538,6 @@ contains
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
     end if
-    if (output%requires_grad()) then
-      write(*,*) "Error :: cannot assign values of a tensor with requires_grad=.true."
-      stop 1
-    end if
     call torch_tensor_assign_c(output%p, input%p)
   end subroutine torch_tensor_assign
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -772,10 +772,6 @@ contains
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
     end if
-    if (output%requires_grad()) then
-      write(*,*) "Error :: cannot assign values of a tensor with requires_grad=.true."
-      stop 1
-    end if
     call torch_tensor_assign_c(output%p, input%p)
   end subroutine torch_tensor_assign
 

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -766,7 +766,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, input%get_rank(), input%get_shape(), input%get_dtype(), &
-                              input%get_device_type(), device_index=input%get_device_index())
+                              input%get_device_type(), device_index=input%get_device_index(), &
+                              requires_grad=input%requires_grad())
     else if (input%get_device_type() /= output%get_device_type()) then
       write(*,*) "Error :: cannot assign tensors with different device types"
       stop 1
@@ -803,7 +804,8 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_add_c(output%p,tensor1%p, tensor2%p)
   end function torch_tensor_add
@@ -825,7 +827,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_negative_c(output%p, tensor%p)
   end function torch_tensor_negative
@@ -856,7 +859,8 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_subtract_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_subtract
@@ -876,7 +880,8 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_multiply_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_multiply
@@ -896,7 +901,8 @@ contains
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor1%get_rank(), tensor1%get_shape(), &
                               tensor1%get_dtype(), tensor1%get_device_type(), &
-                              device_index=tensor1%get_device_index())
+                              device_index=tensor1%get_device_index(), &
+                              requires_grad=tensor1%requires_grad())
     end if
     call torch_tensor_divide_c(output%p, tensor1%p, tensor2%p)
   end function torch_tensor_divide
@@ -923,7 +929,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_int_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_${PREC}$
@@ -952,7 +959,8 @@ contains
 
     if (.not. c_associated(output%p)) then
       call torch_tensor_empty(output, tensor%get_rank(), tensor%get_shape(), tensor%get_dtype(), &
-                              tensor%get_device_type(), device_index=tensor%get_device_index())
+                              tensor%get_device_type(), device_index=tensor%get_device_index(), &
+                              requires_grad=tensor%requires_grad())
     end if
     call torch_tensor_power_float_c(output%p, tensor%p, c_loc(power))
   end function torch_tensor_power_${PREC}$

--- a/test/unit/test_tensor_autograd.pf
+++ b/test/unit/test_tensor_autograd.pf
@@ -40,7 +40,7 @@ module test_tensor_autograd
   end type TestParametersType
 
   ! Typedef for a test case with a particular set of parameters
-  @testCase(constructor=test_case_ctor)
+  @testCase(constructor=test_case_constructor)
   type, extends (ParameterizedTestCase) :: TestCaseType
     type(TestParametersType) :: param
   end type TestCaseType
@@ -104,11 +104,11 @@ contains
   end function get_parameters_short
 
   ! Constructor for the test case type
-  function test_case_ctor(param)
-    type(TestCaseType) :: test_case_ctor
+  function test_case_constructor(param)
+    type(TestCaseType) :: test_case_constructor
     type(TestParametersType), intent(in) :: param
-    test_case_ctor%param = param
-  end function test_case_ctor
+    test_case_constructor%param = param
+  end function test_case_constructor
 
   ! Function for representing a parameter set as a string
   function toString(this) result(string)

--- a/test/unit/test_tensor_autograd.pf
+++ b/test/unit/test_tensor_autograd.pf
@@ -28,6 +28,9 @@ module test_tensor_autograd
   integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
   integer, parameter :: dtype = torch_kFloat32
 
+  ! Scalar shape for reduction operators
+  integer(c_int64_t), parameter, dimension(1) :: scalar_shape = [1]
+
   @testParameter
   type, extends(AbstractTestParameter) :: TestParametersType
     logical :: switch
@@ -391,5 +394,42 @@ contains
     end if
 
   end subroutine test_requires_grad_unary
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and a unary reduction operator
+  @test(testparameters={get_parameters_reduction()})
+  subroutine test_requires_grad_reduction(this)
+    use ftorch, only: torch_tensor_mean, torch_tensor_sum
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create a tensor of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor2, 1, scalar_shape, dtype, device_type)
+    ! NOTE: It's not valid for tensor2 to have requires_grad=.true. as that would give the error
+    !    "a leaf Variable that requires grad is being used in an in-place operation".
+
+    if (this%param%op == 9) then
+      call torch_tensor_sum(tensor2, tensor1)
+    else if (this%param%op == 10) then
+      call torch_tensor_mean(tensor2, tensor1)
+    else
+      write(*,*) "Error :: invalid unary reduction operator code"
+    end if
+
+    ! Check that requires_grad is updated correctly
+    expected = this%param%switch
+    if (expected .neqv. tensor2%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_reduction
 
 end module test_tensor_autograd

--- a/test/unit/test_tensor_autograd.pf
+++ b/test/unit/test_tensor_autograd.pf
@@ -8,7 +8,7 @@ module test_tensor_autograd
   use funit
   use ftorch, only: assignment(=), ftorch_int, torch_kCPU, torch_kFloat32, torch_tensor, &
                     torch_tensor_backward, torch_tensor_empty, torch_tensor_from_array, &
-                    torch_tensor_get_gradient
+                    torch_tensor_get_gradient, torch_tensor_ones
   use ftorch_test_utils, only: assert_allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
@@ -28,13 +28,125 @@ module test_tensor_autograd
   integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [2, 3]
   integer, parameter :: dtype = torch_kFloat32
 
+  @testParameter
+  type, extends(AbstractTestParameter) :: TestParametersType
+    logical :: switch
+    integer :: op
+  contains
+    procedure :: toString
+  end type TestParametersType
+
+  ! Typedef for a test case with a particular set of parameters
+  @testCase(constructor=test_case_ctor)
+  type, extends (ParameterizedTestCase) :: TestCaseType
+    type(TestParametersType) :: param
+  end type TestCaseType
+
 contains
 
-  @test
-  subroutine test_torch_tensor_zero_grad()
+  ! A fixture for varying the requires_grad property and binary operator
+  function get_parameters_binary() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [ &
+      TestParametersType(.false.,1), &
+      TestParametersType(.true.,1), &
+      TestParametersType(.false.,2), &
+      TestParametersType(.true.,2), &
+      TestParametersType(.false.,3), &
+      TestParametersType(.true.,3), &
+      TestParametersType(.false.,4), &
+      TestParametersType(.true.,4) &
+    ]
+  end function get_parameters_binary
+
+  ! A fixture for varying the requires_grad property and unary operator
+  function get_parameters_unary() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [ &
+      TestParametersType(.false.,5), &
+      TestParametersType(.true.,5), &
+      TestParametersType(.false.,6), &
+      TestParametersType(.true.,6), &
+      TestParametersType(.false.,7), &
+      TestParametersType(.true.,7), &
+      TestParametersType(.false.,8), &
+      TestParametersType(.true.,8) &
+    ]
+  end function get_parameters_unary
+
+  ! A fixture for varying the requires_grad property and unary reduction operator
+  function get_parameters_reduction() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [ &
+      TestParametersType(.false.,9), &
+      TestParametersType(.true.,9), &
+      TestParametersType(.false.,10), &
+      TestParametersType(.true.,10) &
+    ]
+  end function get_parameters_reduction
+
+  ! A logical switch fixture
+  function get_parameters_switch() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [ &
+      TestParametersType(.false.,0), &
+      TestParametersType(.true.,0) &
+    ]
+  end function get_parameters_switch
+
+  ! A fixture comprised of a short list of parameter sets
+  function get_parameters_short() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [TestParametersType(.false.,0)]
+  end function get_parameters_short
+
+  ! Constructor for the test case type
+  function test_case_ctor(param)
+    type(TestCaseType) :: test_case_ctor
+    type(TestParametersType), intent(in) :: param
+    test_case_ctor%param = param
+  end function test_case_ctor
+
+  ! Function for representing a parameter set as a string
+  function toString(this) result(string)
+    class(TestParametersType), intent(in) :: this
+    character(:), allocatable :: string
+    character(len=10) :: str
+    if (this%op == 0) then
+      write(str,"(l1)") this%switch
+    else if (this%op == 1) then
+      write(str,"(l1,',add')") this%switch
+    else if (this%op == 2) then
+      write(str,"(l1,',subtract')") this%switch
+    else if (this%op == 3) then
+      write(str,"(l1,',multiply')") this%switch
+    else if (this%op == 4) then
+      write(str,"(l1,',divide')") this%switch
+    else if (this%op == 5) then
+      write(str,"(l1,',negative')") this%switch
+    else if (this%op == 6) then
+      write(str,"(l1,',isquare')") this%switch
+    else if (this%op == 7) then
+      write(str,"(l1,',fsquare')") this%switch
+    else if (this%op == 8) then
+      write(str,"(l1,',sqrt')") this%switch
+    else if (this%op == 9) then
+      write(str,"(l1,',sum')") this%switch
+    else if (this%op == 10) then
+      write(str,"(l1,',mean')") this%switch
+    else
+      write(*,*) "Error :: invalid operator code"
+      stop 999
+    end if
+    string = trim(str)
+  end function toString
+
+  @test(testParameters={get_parameters_short()})
+  subroutine test_torch_tensor_zero_grad(this)
 
     implicit none
 
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: Q, a, dQda
     real(wp), dimension(2,3), target :: in_data, out_data
     real(wp), dimension(2,3) :: expected
@@ -75,11 +187,12 @@ contains
 
   end subroutine test_torch_tensor_zero_grad
 
-  @test
-  subroutine test_torch_tensor_retain_graph()
+  @test(testParameters={get_parameters_short()})
+  subroutine test_torch_tensor_retain_graph(this)
 
     implicit none
 
+    class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: Q, a, dQda
     real(wp), dimension(2,3), target :: in_data, out_data
     real(wp), dimension(2,3) :: expected
@@ -119,5 +232,164 @@ contains
     end if
 
   end subroutine test_torch_tensor_retain_graph
+ 
+  ! ============================================================================
+  ! --- Unit tests for the requires_grad property
+  ! ============================================================================
+
+  ! Unit test checking the requires_grad property is carried over during assignment
+  @test(testparameters={get_parameters_switch()})
+  subroutine test_requires_grad_assign(this)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create a tensor of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%switch)
+
+    tensor2 = tensor1
+
+    ! Check that requires_grad is updated correctly
+    expected = this%param%switch
+    if (expected .neqv. tensor2%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_assign
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and a binary operator applied to tensors with the same requires_grad value
+  @test(testparameters={get_parameters_binary()})
+  subroutine test_requires_grad_binary_same(this)
+    use ftorch, only: operator(+), operator(-), operator(*), operator(/)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2, tensor3
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create two tensors of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%switch)
+
+    ! Compute the appropriate binary operator
+    if (this%param%op == 1) then
+      tensor3 = tensor1 + tensor2
+    else if (this%param%op == 2) then
+      tensor3 = tensor1 - tensor2
+    else if (this%param%op == 3) then
+      tensor3 = tensor1 * tensor2
+    else if (this%param%op == 4) then
+      tensor3 = tensor1 / tensor2
+    else
+      write(*,*) "Error :: invalid operator code"
+    end if
+
+    ! Check that requires_grad is updated correctly
+    expected = this%param%switch
+    if (expected .neqv. tensor3%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_binary_same
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and a binary operator applied to tensors with different requires_grad values
+  @test(testparameters={get_parameters_binary()})
+  subroutine test_requires_grad_binary_different(this)
+    use ftorch, only: operator(+), operator(-), operator(*), operator(/)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2, tensor3
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create two tensors of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=.not. this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+    ! NOTE: It's not valid for tensor3 to have requires_grad=.true. as that would give the error
+    !    "a leaf Variable that requires grad is being used in an in-place operation".
+
+    ! Compute the appropriate binary operator
+    if (this%param%op == 1) then
+      tensor3 = tensor1 + tensor2
+    else if (this%param%op == 2) then
+      tensor3 = tensor1 - tensor2
+    else if (this%param%op == 3) then
+      tensor3 = tensor1 * tensor2
+    else if (this%param%op == 4) then
+      tensor3 = tensor1 / tensor2
+    else
+      write(*,*) "Error :: invalid binary operator code"
+    end if
+
+    ! Check that requires_grad is updated correctly
+    expected = .true.
+    if (expected .neqv. tensor3%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_binary_different
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and a unary operator
+  @test(testparameters={get_parameters_unary()})
+  subroutine test_requires_grad_unary(this)
+    use ftorch, only: operator(-), operator(**)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create a tensor of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%switch)
+
+    if (this%param%op == 5) then
+      tensor2 = -tensor1
+    else if (this%param%op == 6) then
+      tensor2 = tensor1 ** 2
+    else if (this%param%op == 7) then
+      tensor2 = tensor1 ** 2.0
+    else if (this%param%op == 8) then
+      tensor2 = tensor1 ** 0.5
+    else
+      write(*,*) "Error :: invalid unary operator code"
+    end if
+
+    ! Check that requires_grad is updated correctly
+    expected = this%param%switch
+    if (expected .neqv. tensor2%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_unary
 
 end module test_tensor_autograd

--- a/test/unit/test_tensor_constructors_destructors.pf
+++ b/test/unit/test_tensor_constructors_destructors.pf
@@ -39,7 +39,7 @@ module test_tensor_constructors_destructors
   end type TestParametersType
 
   ! Typedef for a test case with a particular set of parameters
-  @testCase(constructor=test_case_ctor)
+  @testCase(constructor=test_case_constructor)
   type, extends (ParameterizedTestCase) :: TestCaseType
     type(TestParametersType) :: param
   end type TestCaseType
@@ -47,11 +47,11 @@ module test_tensor_constructors_destructors
 contains
 
   ! Constructor for the test case type
-  function test_case_ctor(param)
-    type(TestCaseType) :: test_case_ctor
+  function test_case_constructor(param)
+    type(TestCaseType) :: test_case_constructor
     type(TestParametersType), intent(in) :: param
-    test_case_ctor%param = param
-  end function test_case_ctor
+    test_case_constructor%param = param
+  end function test_case_constructor
 
   ! A fixture comprised of parameter sets for destructor tests
   function get_parameters_destruction() result(params)

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -28,7 +28,7 @@ module test_tensor_interrogation
   end type TestParametersType
 
   ! Typedef for a test case with a particular set of parameters
-  @testCase(constructor=test_case_ctor)
+  @testCase(constructor=test_case_constructor)
   type, extends (ParameterizedTestCase) :: TestCaseType
     type(TestParametersType) :: param
   end type TestCaseType
@@ -36,11 +36,11 @@ module test_tensor_interrogation
 contains
 
   ! Constructor for the test case type
-  function test_case_ctor(param)
-    type(TestCaseType) :: test_case_ctor
+  function test_case_constructor(param)
+    type(TestCaseType) :: test_case_constructor
     type(TestParametersType), intent(in) :: param
-    test_case_ctor%param = param
-  end function test_case_ctor
+    test_case_constructor%param = param
+  end function test_case_constructor
 
   ! A fixture comprised of a full list of parameter sets
   function get_parameters_full() result(params)

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -261,8 +261,8 @@ contains
                            requires_grad=this%param%requires_grad)
 
     ! Create another empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
-    ! FIXME:                        requires_grad=.not. this%param%requires_grad)
+    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%requires_grad)
 
     tensor2 = tensor1
 
@@ -289,8 +289,8 @@ contains
                            requires_grad=this%param%requires_grad)
 
     ! Create another empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
-    ! FIXME:                        requires_grad=.not. this%param%requires_grad)
+    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%requires_grad)
 
     tensor2 = -tensor1
 

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -6,8 +6,7 @@
 !    file for details.
 module test_tensor_interrogation
   use funit
-  use ftorch, only: assignment(=), torch_kFloat32, torch_kCPU, torch_tensor, torch_tensor_empty, &
-                    torch_tensor_ones
+  use ftorch, only: torch_kFloat32, torch_kCPU, torch_tensor, torch_tensor_empty
   use iso_c_binding, only: c_int64_t
 
   implicit none
@@ -247,59 +246,5 @@ contains
     end if
 
   end subroutine test_requires_grad
-
-  ! Unit test checking the requires_grad property is carried over during assignment
-  @test(testparameters={get_parameters_full()})
-  subroutine test_requires_grad_assign(this)
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor1, tensor2
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-
-    ! Create a tensor of ones on the CPU with 
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%requires_grad)
-
-    ! Create another empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
-                            requires_grad=.not. this%param%requires_grad)
-
-    tensor2 = tensor1
-
-    ! Check that requires_grad is updated correctly
-    if (tensor1%requires_grad() .neqv. tensor2%requires_grad()) then
-      print *, "Error :: tensor%requires_grad() returned incorrect value"
-      stop 999
-    end if
-
-  end subroutine test_requires_grad_assign
-
-  ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and a negation
-  @test(testparameters={get_parameters_full()})
-  subroutine test_requires_grad_negative(this)
-    use ftorch, only: operator(-)
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor1, tensor2
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-
-    ! Create a tensor of ones on the CPU with the default device type
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%requires_grad)
-
-    ! Create another empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
-                            requires_grad=.not. this%param%requires_grad)
-
-    tensor2 = -tensor1
-
-    ! Check that requires_grad is updated correctly
-    if (tensor1%requires_grad() .neqv. tensor2%requires_grad()) then
-      print *, "Error :: tensor%requires_grad() returned incorrect value"
-      stop 999
-    end if
-
-  end subroutine test_requires_grad_negative
 
 end module test_tensor_interrogation

--- a/test/unit/test_tensor_interrogation.pf
+++ b/test/unit/test_tensor_interrogation.pf
@@ -6,7 +6,8 @@
 !    file for details.
 module test_tensor_interrogation
   use funit
-  use ftorch, only: torch_kFloat32, torch_kCPU, torch_tensor, torch_tensor_empty
+  use ftorch, only: assignment(=), torch_kFloat32, torch_kCPU, torch_tensor, torch_tensor_empty, &
+                    torch_tensor_ones
   use iso_c_binding, only: c_int64_t
 
   implicit none
@@ -238,7 +239,7 @@ contains
     call torch_tensor_empty(tensor, ndims, tensor_shape, dtype, device_type, &
                             requires_grad=this%param%requires_grad)
 
-    ! Check that torch_tensor_get_device_type can get the device type
+    ! Check that querying requires_grad gives the expected value
     expected = this%param%requires_grad
     if (expected .neqv. tensor%requires_grad()) then
       print *, "Error :: tensor%requires_grad() returned incorrect value"
@@ -246,5 +247,59 @@ contains
     end if
 
   end subroutine test_requires_grad
+
+  ! Unit test checking the requires_grad property is carried over during assignment
+  @test(testparameters={get_parameters_full()})
+  subroutine test_requires_grad_assign(this)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+
+    ! Create a tensor of ones on the CPU with 
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%requires_grad)
+
+    ! Create another empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
+    ! FIXME:                        requires_grad=.not. this%param%requires_grad)
+
+    tensor2 = tensor1
+
+    ! Check that requires_grad is updated correctly
+    if (tensor1%requires_grad() .neqv. tensor2%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_assign
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and a negation
+  @test(testparameters={get_parameters_full()})
+  subroutine test_requires_grad_negative(this)
+    use ftorch, only: operator(-)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+
+    ! Create a tensor of ones on the CPU with the default device type
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%requires_grad)
+
+    ! Create another empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type)
+    ! FIXME:                        requires_grad=.not. this%param%requires_grad)
+
+    tensor2 = -tensor1
+
+    ! Check that requires_grad is updated correctly
+    if (tensor1%requires_grad() .neqv. tensor2%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_negative
 
 end module test_tensor_interrogation

--- a/test/unit/test_tensor_operator_overloads.pf
+++ b/test/unit/test_tensor_operator_overloads.pf
@@ -6,8 +6,7 @@
 !    file for details.
 module test_tensor_operator_overloads
   use funit
-  use ftorch, only: assignment(=), torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_empty, &
-                    torch_tensor_from_array, torch_tensor_ones
+  use ftorch, only: assignment(=), torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_from_array
   use ftorch_test_utils, only: assert_allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use, intrinsic :: iso_c_binding, only : c_int64_t
@@ -30,7 +29,6 @@ module test_tensor_operator_overloads
   @testParameter
   type, extends(AbstractTestParameter) :: TestParametersType
     logical :: switch
-    integer :: op
   contains
     procedure :: toString
   end type TestParametersType
@@ -43,49 +41,19 @@ module test_tensor_operator_overloads
 
 contains
 
-  ! A fixture for varying the requires_grad property and binary operator
-  function get_parameters_binary() result(params)
+  ! A fixture comprised of a full list of parameter sets
+  function get_parameters_full() result(params)
     type(TestParametersType), allocatable :: params(:)
     params = [ &
-      TestParametersType(.false.,1), &
-      TestParametersType(.true.,1), &
-      TestParametersType(.false.,2), &
-      TestParametersType(.true.,2), &
-      TestParametersType(.false.,3), &
-      TestParametersType(.true.,3), &
-      TestParametersType(.false.,4), &
-      TestParametersType(.true.,4) &
+      TestParametersType(.false.), &
+      TestParametersType(.true.) &
     ]
-  end function get_parameters_binary
-
-  ! A fixture for varying the requires_grad property and unary operator
-  function get_parameters_unary() result(params)
-    type(TestParametersType), allocatable :: params(:)
-    params = [ &
-      TestParametersType(.false.,5), &
-      TestParametersType(.true.,5), &
-      TestParametersType(.false.,6), &
-      TestParametersType(.true.,6), &
-      TestParametersType(.false.,7), &
-      TestParametersType(.true.,7), &
-      TestParametersType(.false.,8), &
-      TestParametersType(.true.,8) &
-    ]
-  end function get_parameters_unary
-
-  ! A logical switch fixture
-  function get_parameters_switch() result(params)
-    type(TestParametersType), allocatable :: params(:)
-    params = [ &
-      TestParametersType(.false.,0), &
-      TestParametersType(.true.,0) &
-    ]
-  end function get_parameters_switch
+  end function get_parameters_full
 
   ! A fixture comprised of a short list of parameter sets
   function get_parameters_short() result(params)
     type(TestParametersType), allocatable :: params(:)
-    params = [TestParametersType(.false.,0)]
+    params = [TestParametersType(.false.)]
   end function get_parameters_short
 
   ! Constructor for the test case type
@@ -99,30 +67,9 @@ contains
   function toString(this) result(string)
     class(TestParametersType), intent(in) :: this
     character(:), allocatable :: string
-    character(len=10) :: str
-    if (this%op == 0) then
-      write(str,"(l1)") this%switch
-    else if (this%op == 1) then
-      write(str,"(l1,',add')") this%switch
-    else if (this%op == 2) then
-      write(str,"(l1,',subtract')") this%switch
-    else if (this%op == 3) then
-      write(str,"(l1,',multiply')") this%switch
-    else if (this%op == 4) then
-      write(str,"(l1,',divide')") this%switch
-    else if (this%op == 5) then
-      write(str,"(l1,',negative')") this%switch
-    else if (this%op == 6) then
-      write(str,"(l1,',isquare')") this%switch
-    else if (this%op == 7) then
-      write(str,"(l1,',fsquare')") this%switch
-    else if (this%op == 8) then
-      write(str,"(l1,',sqrt')") this%switch
-    else
-      write(*,*) "Error :: invalid operator code"
-      stop 999
-    end if
-    string = trim(str)
+    character(len=1) :: str
+    write(str,'(l1)') this%switch
+    string = str
   end function toString
 
   @test(testParameters={get_parameters_short()})
@@ -342,7 +289,7 @@ contains
 
   end subroutine test_torch_tensor_multiply
 
-  @test(testParameters={get_parameters_switch()})
+  @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_scalar_multiply(this)
     use ftorch, only: operator(*)
 
@@ -482,7 +429,7 @@ contains
 
   end subroutine test_torch_tensor_scalar_divide
 
-  @test(testParameters={get_parameters_switch()})
+  @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_square(this)
     use ftorch, only: operator(**)
 
@@ -565,164 +512,5 @@ contains
     end if
 
   end subroutine test_torch_tensor_sqrt
-
-  ! ============================================================================
-  ! --- Unit tests for the requires_grad property
-  ! ============================================================================
-
-  ! Unit test checking the requires_grad property is carried over during assignment
-  @test(testparameters={get_parameters_switch()})
-  subroutine test_requires_grad_assign(this)
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor1, tensor2
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-    logical :: expected
-
-    ! Create a tensor of ones with the provided requires_grad value
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%switch)
-
-    ! Create an empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
-                            requires_grad=.not. this%param%switch)
-
-    tensor2 = tensor1
-
-    ! Check that requires_grad is updated correctly
-    expected = this%param%switch
-    if (expected .neqv. tensor2%requires_grad()) then
-      print *, "Error :: tensor%requires_grad() returned incorrect value"
-      stop 999
-    end if
-
-  end subroutine test_requires_grad_assign
-
-  ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and a binary operator applied to tensors with the same requires_grad value
-  @test(testparameters={get_parameters_binary()})
-  subroutine test_requires_grad_binary_same(this)
-    use ftorch, only: operator(+), operator(-), operator(*), operator(/)
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor1, tensor2, tensor3
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-    logical :: expected
-
-    ! Create two tensors of ones with the provided requires_grad value
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%switch)
-    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%switch)
-
-    ! Create an empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type, &
-                            requires_grad=.not. this%param%switch)
-
-    ! Compute the appropriate binary operator
-    if (this%param%op == 1) then
-      tensor3 = tensor1 + tensor2
-    else if (this%param%op == 2) then
-      tensor3 = tensor1 - tensor2
-    else if (this%param%op == 3) then
-      tensor3 = tensor1 * tensor2
-    else if (this%param%op == 4) then
-      tensor3 = tensor1 / tensor2
-    else
-      write(*,*) "Error :: invalid operator code"
-    end if
-
-    ! Check that requires_grad is updated correctly
-    expected = this%param%switch
-    if (expected .neqv. tensor3%requires_grad()) then
-      print *, "Error :: tensor%requires_grad() returned incorrect value"
-      stop 999
-    end if
-
-  end subroutine test_requires_grad_binary_same
-
-  ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and a binary operator applied to tensors with different requires_grad values
-  @test(testparameters={get_parameters_binary()})
-  subroutine test_requires_grad_binary_different(this)
-    use ftorch, only: operator(+), operator(-), operator(*), operator(/)
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor1, tensor2, tensor3
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-    logical :: expected
-
-    ! Create two tensors of ones with the provided requires_grad value
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%switch)
-    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=.not. this%param%switch)
-
-    ! Create an empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
-    ! NOTE: It's not valid for tensor3 to have requires_grad=.true. as that would give the error
-    !    "a leaf Variable that requires grad is being used in an in-place operation".
-
-    ! Compute the appropriate binary operator
-    if (this%param%op == 1) then
-      tensor3 = tensor1 + tensor2
-    else if (this%param%op == 2) then
-      tensor3 = tensor1 - tensor2
-    else if (this%param%op == 3) then
-      tensor3 = tensor1 * tensor2
-    else if (this%param%op == 4) then
-      tensor3 = tensor1 / tensor2
-    else
-      write(*,*) "Error :: invalid binary operator code"
-    end if
-
-    ! Check that requires_grad is updated correctly
-    expected = .true.
-    if (expected .neqv. tensor3%requires_grad()) then
-      print *, "Error :: tensor%requires_grad() returned incorrect value"
-      stop 999
-    end if
-
-  end subroutine test_requires_grad_binary_different
-
-  ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and a unary operator
-  @test(testparameters={get_parameters_unary()})
-  subroutine test_requires_grad_unary(this)
-    use ftorch, only: operator(-), operator(**)
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor1, tensor2
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-    logical :: expected
-
-    ! Create a tensor of ones with the provided requires_grad value
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%switch)
-
-    ! Create an empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
-                            requires_grad=.not. this%param%switch)
-
-    if (this%param%op == 5) then
-      tensor2 = -tensor1
-    else if (this%param%op == 6) then
-      tensor2 = tensor1 ** 2
-    else if (this%param%op == 7) then
-      tensor2 = tensor1 ** 2.0
-    else if (this%param%op == 8) then
-      tensor2 = tensor1 ** 0.5
-    else
-      write(*,*) "Error :: invalid unary operator code"
-    end if
-
-    ! Check that requires_grad is updated correctly
-    expected = this%param%switch
-    if (expected .neqv. tensor2%requires_grad()) then
-      print *, "Error :: tensor%requires_grad() returned incorrect value"
-      stop 999
-    end if
-
-  end subroutine test_requires_grad_unary
 
 end module test_tensor_operator_overloads

--- a/test/unit/test_tensor_operator_overloads.pf
+++ b/test/unit/test_tensor_operator_overloads.pf
@@ -6,7 +6,8 @@
 !    file for details.
 module test_tensor_operator_overloads
   use funit
-  use ftorch, only: assignment(=), torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_from_array
+  use ftorch, only: assignment(=), torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_empty, &
+                    torch_tensor_from_array, torch_tensor_ones
   use ftorch_test_utils, only: assert_allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use, intrinsic :: iso_c_binding, only : c_int64_t
@@ -512,5 +513,59 @@ contains
     end if
 
   end subroutine test_torch_tensor_sqrt
+
+  ! Unit test checking the requires_grad property is carried over during assignment
+  @test(testparameters={get_parameters_full()})
+  subroutine test_requires_grad_assign(this)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+
+    ! Create a tensor of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+
+    ! Create another empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%switch)
+
+    tensor2 = tensor1
+
+    ! Check that requires_grad is updated correctly
+    if (tensor1%requires_grad() .neqv. tensor2%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_assign
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and a negation
+  @test(testparameters={get_parameters_full()})
+  subroutine test_requires_grad_negative(this)
+    use ftorch, only: operator(-)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+
+    ! Create a tensor of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+
+    ! Create another empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%switch)
+
+    tensor2 = -tensor1
+
+    ! Check that requires_grad is updated correctly
+    if (tensor1%requires_grad() .neqv. tensor2%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_negative
 
 end module test_tensor_operator_overloads

--- a/test/unit/test_tensor_operator_overloads.pf
+++ b/test/unit/test_tensor_operator_overloads.pf
@@ -43,8 +43,8 @@ module test_tensor_operator_overloads
 
 contains
 
-  ! A fixture comprised of a full list of parameter sets
-  function get_parameters_full() result(params)
+  ! A fixture for varying the requires_grad property and binary operator
+  function get_parameters_binary() result(params)
     type(TestParametersType), allocatable :: params(:)
     params = [ &
       TestParametersType(.false.,1), &
@@ -56,7 +56,22 @@ contains
       TestParametersType(.false.,4), &
       TestParametersType(.true.,4) &
     ]
-  end function get_parameters_full
+  end function get_parameters_binary
+
+  ! A fixture for varying the requires_grad property and unary operator
+  function get_parameters_unary() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [ &
+      TestParametersType(.false.,5), &
+      TestParametersType(.true.,5), &
+      TestParametersType(.false.,6), &
+      TestParametersType(.true.,6), &
+      TestParametersType(.false.,7), &
+      TestParametersType(.true.,7), &
+      TestParametersType(.false.,8), &
+      TestParametersType(.true.,8) &
+    ]
+  end function get_parameters_unary
 
   ! A logical switch fixture
   function get_parameters_switch() result(params)
@@ -95,6 +110,14 @@ contains
       write(str,"(l1,',multiply')") this%switch
     else if (this%op == 4) then
       write(str,"(l1,',divide')") this%switch
+    else if (this%op == 5) then
+      write(str,"(l1,',negative')") this%switch
+    else if (this%op == 6) then
+      write(str,"(l1,',isquare')") this%switch
+    else if (this%op == 7) then
+      write(str,"(l1,',fsquare')") this%switch
+    else if (this%op == 8) then
+      write(str,"(l1,',sqrt')") this%switch
     else
       write(*,*) "Error :: invalid operator code"
       stop 999
@@ -577,7 +600,7 @@ contains
 
   ! Unit test checking the requires_grad property is carried over during a combination of an
   ! assignment and a binary operator applied to tensors with the same requires_grad value
-  @test(testparameters={get_parameters_full()})
+  @test(testparameters={get_parameters_binary()})
   subroutine test_requires_grad_binary_same(this)
     use ftorch, only: operator(+), operator(-), operator(*), operator(/)
     class(TestCaseType), intent(inout) :: this
@@ -620,7 +643,7 @@ contains
 
   ! Unit test checking the requires_grad property is carried over during a combination of an
   ! assignment and a binary operator applied to tensors with different requires_grad values
-  @test(testparameters={get_parameters_full()})
+  @test(testparameters={get_parameters_binary()})
   subroutine test_requires_grad_binary_different(this)
     use ftorch, only: operator(+), operator(-), operator(*), operator(/)
     class(TestCaseType), intent(inout) :: this
@@ -650,7 +673,7 @@ contains
     else if (this%param%op == 4) then
       tensor3 = tensor1 / tensor2
     else
-      write(*,*) "Error :: invalid operator code"
+      write(*,*) "Error :: invalid binary operator code"
     end if
 
     ! Check that requires_grad is updated correctly
@@ -663,10 +686,10 @@ contains
   end subroutine test_requires_grad_binary_different
 
   ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and a negation
-  @test(testparameters={get_parameters_switch()})
-  subroutine test_requires_grad_negative(this)
-    use ftorch, only: operator(-)
+  ! assignment and a unary operator
+  @test(testparameters={get_parameters_unary()})
+  subroutine test_requires_grad_unary(this)
+    use ftorch, only: operator(-), operator(**)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2
     integer, parameter :: ndims = 1
@@ -681,7 +704,17 @@ contains
     call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
                             requires_grad=.not. this%param%switch)
 
-    tensor2 = -tensor1
+    if (this%param%op == 5) then
+      tensor2 = -tensor1
+    else if (this%param%op == 6) then
+      tensor2 = tensor1 ** 2
+    else if (this%param%op == 7) then
+      tensor2 = tensor1 ** 2.0
+    else if (this%param%op == 8) then
+      tensor2 = tensor1 ** 0.5
+    else
+      write(*,*) "Error :: invalid unary operator code"
+    end if
 
     ! Check that requires_grad is updated correctly
     expected = this%param%switch
@@ -690,6 +723,6 @@ contains
       stop 999
     end if
 
-  end subroutine test_requires_grad_negative
+  end subroutine test_requires_grad_unary
 
 end module test_tensor_operator_overloads

--- a/test/unit/test_tensor_operator_overloads.pf
+++ b/test/unit/test_tensor_operator_overloads.pf
@@ -30,6 +30,7 @@ module test_tensor_operator_overloads
   @testParameter
   type, extends(AbstractTestParameter) :: TestParametersType
     logical :: switch
+    integer :: op
   contains
     procedure :: toString
   end type TestParametersType
@@ -46,15 +47,30 @@ contains
   function get_parameters_full() result(params)
     type(TestParametersType), allocatable :: params(:)
     params = [ &
-      TestParametersType(.false.), &
-      TestParametersType(.true.) &
+      TestParametersType(.false.,1), &
+      TestParametersType(.true.,1), &
+      TestParametersType(.false.,2), &
+      TestParametersType(.true.,2), &
+      TestParametersType(.false.,3), &
+      TestParametersType(.true.,3), &
+      TestParametersType(.false.,4), &
+      TestParametersType(.true.,4) &
     ]
   end function get_parameters_full
+
+  ! A logical switch fixture
+  function get_parameters_switch() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [ &
+      TestParametersType(.false.,0), &
+      TestParametersType(.true.,0) &
+    ]
+  end function get_parameters_switch
 
   ! A fixture comprised of a short list of parameter sets
   function get_parameters_short() result(params)
     type(TestParametersType), allocatable :: params(:)
-    params = [TestParametersType(.false.)]
+    params = [TestParametersType(.false.,0)]
   end function get_parameters_short
 
   ! Constructor for the test case type
@@ -68,9 +84,22 @@ contains
   function toString(this) result(string)
     class(TestParametersType), intent(in) :: this
     character(:), allocatable :: string
-    character(len=1) :: str
-    write(str,'(l1)') this%switch
-    string = str
+    character(len=10) :: str
+    if (this%op == 0) then
+      write(str,"(l1)") this%switch
+    else if (this%op == 1) then
+      write(str,"(l1,',add')") this%switch
+    else if (this%op == 2) then
+      write(str,"(l1,',subtract')") this%switch
+    else if (this%op == 3) then
+      write(str,"(l1,',multiply')") this%switch
+    else if (this%op == 4) then
+      write(str,"(l1,',divide')") this%switch
+    else
+      write(*,*) "Error :: invalid operator code"
+      stop 999
+    end if
+    string = trim(str)
   end function toString
 
   @test(testParameters={get_parameters_short()})
@@ -290,7 +319,7 @@ contains
 
   end subroutine test_torch_tensor_multiply
 
-  @test(testParameters={get_parameters_full()})
+  @test(testParameters={get_parameters_switch()})
   subroutine test_torch_tensor_scalar_multiply(this)
     use ftorch, only: operator(*)
 
@@ -430,7 +459,7 @@ contains
 
   end subroutine test_torch_tensor_scalar_divide
 
-  @test(testParameters={get_parameters_full()})
+  @test(testParameters={get_parameters_switch()})
   subroutine test_torch_tensor_square(this)
     use ftorch, only: operator(**)
 
@@ -519,7 +548,7 @@ contains
   ! ============================================================================
 
   ! Unit test checking the requires_grad property is carried over during assignment
-  @test(testparameters={get_parameters_full()})
+  @test(testparameters={get_parameters_switch()})
   subroutine test_requires_grad_assign(this)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2
@@ -547,10 +576,10 @@ contains
   end subroutine test_requires_grad_assign
 
   ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and an addition applied to tensors with the same requires_grad value
+  ! assignment and a binary operator applied to tensors with the same requires_grad value
   @test(testparameters={get_parameters_full()})
-  subroutine test_requires_grad_add_same(this)
-    use ftorch, only: operator(+)
+  subroutine test_requires_grad_binary_same(this)
+    use ftorch, only: operator(+), operator(-), operator(*), operator(/)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, tensor3
     integer, parameter :: ndims = 1
@@ -567,7 +596,18 @@ contains
     call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type, &
                             requires_grad=.not. this%param%switch)
 
-    tensor3 = tensor1 + tensor2
+    ! Compute the appropriate binary operator
+    if (this%param%op == 1) then
+      tensor3 = tensor1 + tensor2
+    else if (this%param%op == 2) then
+      tensor3 = tensor1 - tensor2
+    else if (this%param%op == 3) then
+      tensor3 = tensor1 * tensor2
+    else if (this%param%op == 4) then
+      tensor3 = tensor1 / tensor2
+    else
+      write(*,*) "Error :: invalid operator code"
+    end if
 
     ! Check that requires_grad is updated correctly
     expected = this%param%switch
@@ -576,13 +616,13 @@ contains
       stop 999
     end if
 
-  end subroutine test_requires_grad_add_same
+  end subroutine test_requires_grad_binary_same
 
   ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and an addition applied to tensors with different requires_grad values
+  ! assignment and a binary operator applied to tensors with different requires_grad values
   @test(testparameters={get_parameters_full()})
-  subroutine test_requires_grad_add_different(this)
-    use ftorch, only: operator(+)
+  subroutine test_requires_grad_binary_different(this)
+    use ftorch, only: operator(+), operator(-), operator(*), operator(/)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, tensor3
     integer, parameter :: ndims = 1
@@ -600,7 +640,18 @@ contains
     ! NOTE: It's not valid for tensor3 to have requires_grad=.true. as that would give the error
     !    "a leaf Variable that requires grad is being used in an in-place operation".
 
-    tensor3 = tensor1 + tensor2
+    ! Compute the appropriate binary operator
+    if (this%param%op == 1) then
+      tensor3 = tensor1 + tensor2
+    else if (this%param%op == 2) then
+      tensor3 = tensor1 - tensor2
+    else if (this%param%op == 3) then
+      tensor3 = tensor1 * tensor2
+    else if (this%param%op == 4) then
+      tensor3 = tensor1 / tensor2
+    else
+      write(*,*) "Error :: invalid operator code"
+    end if
 
     ! Check that requires_grad is updated correctly
     expected = .true.
@@ -609,11 +660,11 @@ contains
       stop 999
     end if
 
-  end subroutine test_requires_grad_add_different
+  end subroutine test_requires_grad_binary_different
 
   ! Unit test checking the requires_grad property is carried over during a combination of an
   ! assignment and a negation
-  @test(testparameters={get_parameters_full()})
+  @test(testparameters={get_parameters_switch()})
   subroutine test_requires_grad_negative(this)
     use ftorch, only: operator(-)
     class(TestCaseType), intent(inout) :: this
@@ -640,70 +691,5 @@ contains
     end if
 
   end subroutine test_requires_grad_negative
-
-  ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and a subtraction with the same requires_grad properties
-  @test(testparameters={get_parameters_full()})
-  subroutine test_requires_grad_subtract_same(this)
-    use ftorch, only: operator(-)
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor1, tensor2, tensor3
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-    logical :: expected
-
-    ! Create two tensors of ones with the provided requires_grad value
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%switch)
-    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%switch)
-
-    ! Create an empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type, &
-                            requires_grad=.not. this%param%switch)
-
-    tensor3 = tensor1 - tensor2
-
-    ! Check that requires_grad is updated correctly
-    expected = this%param%switch
-    if (expected .neqv. tensor3%requires_grad()) then
-      print *, "Error :: tensor%requires_grad() returned incorrect value"
-      stop 999
-    end if
-
-  end subroutine test_requires_grad_subtract_same
-
-  ! Unit test checking the requires_grad property is carried over during a combination of an
-  ! assignment and a subtraction applied to tensors with different requires_grad values
-  @test(testparameters={get_parameters_full()})
-  subroutine test_requires_grad_subtract_different(this)
-    use ftorch, only: operator(-)
-    class(TestCaseType), intent(inout) :: this
-    type(torch_tensor) :: tensor1, tensor2, tensor3
-    integer, parameter :: ndims = 1
-    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
-    logical :: expected
-
-    ! Create two tensors of ones with the provided requires_grad value
-    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=this%param%switch)
-    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
-                           requires_grad=.not. this%param%switch)
-
-    ! Create an empty tensor with the same arguments except the opposite requires_grad value
-    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
-    ! NOTE: It's not valid for tensor3 to have requires_grad=.true. as that would give the error
-    !    "a leaf Variable that requires grad is being used in an in-place operation".
-
-    tensor3 = tensor1 - tensor2
-
-    ! Check that requires_grad is updated correctly
-    expected = .true.
-    if (expected .neqv. tensor3%requires_grad()) then
-      print *, "Error :: tensor%requires_grad() returned incorrect value"
-      stop 999
-    end if
-
-  end subroutine test_requires_grad_subtract_different
 
 end module test_tensor_operator_overloads

--- a/test/unit/test_tensor_operator_overloads.pf
+++ b/test/unit/test_tensor_operator_overloads.pf
@@ -34,7 +34,7 @@ module test_tensor_operator_overloads
   end type TestParametersType
 
   ! Typedef for a test case with a particular set of parameters
-  @testCase(constructor=test_case_ctor)
+  @testCase(constructor=test_case_constructor)
   type, extends (ParameterizedTestCase) :: TestCaseType
     type(TestParametersType) :: param
   end type TestCaseType
@@ -57,11 +57,11 @@ contains
   end function get_parameters_short
 
   ! Constructor for the test case type
-  function test_case_ctor(param)
-    type(TestCaseType) :: test_case_ctor
+  function test_case_constructor(param)
+    type(TestCaseType) :: test_case_constructor
     type(TestParametersType), intent(in) :: param
-    test_case_ctor%param = param
-  end function test_case_ctor
+    test_case_constructor%param = param
+  end function test_case_constructor
 
   ! Function for representing a parameter set as a string
   function toString(this) result(string)

--- a/test/unit/test_tensor_operator_overloads.pf
+++ b/test/unit/test_tensor_operator_overloads.pf
@@ -514,6 +514,10 @@ contains
 
   end subroutine test_torch_tensor_sqrt
 
+  ! ============================================================================
+  ! --- Unit tests for the requires_grad property
+  ! ============================================================================
+
   ! Unit test checking the requires_grad property is carried over during assignment
   @test(testparameters={get_parameters_full()})
   subroutine test_requires_grad_assign(this)
@@ -521,24 +525,91 @@ contains
     type(torch_tensor) :: tensor1, tensor2
     integer, parameter :: ndims = 1
     integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
 
     ! Create a tensor of ones with the provided requires_grad value
     call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
                            requires_grad=this%param%switch)
 
-    ! Create another empty tensor with the same arguments except the opposite requires_grad value
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
     call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
                             requires_grad=.not. this%param%switch)
 
     tensor2 = tensor1
 
     ! Check that requires_grad is updated correctly
-    if (tensor1%requires_grad() .neqv. tensor2%requires_grad()) then
+    expected = this%param%switch
+    if (expected .neqv. tensor2%requires_grad()) then
       print *, "Error :: tensor%requires_grad() returned incorrect value"
       stop 999
     end if
 
   end subroutine test_requires_grad_assign
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and an addition applied to tensors with the same requires_grad value
+  @test(testparameters={get_parameters_full()})
+  subroutine test_requires_grad_add_same(this)
+    use ftorch, only: operator(+)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2, tensor3
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create two tensors of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%switch)
+
+    tensor3 = tensor1 + tensor2
+
+    ! Check that requires_grad is updated correctly
+    expected = this%param%switch
+    if (expected .neqv. tensor3%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_add_same
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and an addition applied to tensors with different requires_grad values
+  @test(testparameters={get_parameters_full()})
+  subroutine test_requires_grad_add_different(this)
+    use ftorch, only: operator(+)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2, tensor3
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create two tensors of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=.not. this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+    ! NOTE: It's not valid for tensor3 to have requires_grad=.true. as that would give the error
+    !    "a leaf Variable that requires grad is being used in an in-place operation".
+
+    tensor3 = tensor1 + tensor2
+
+    ! Check that requires_grad is updated correctly
+    expected = .true.
+    if (expected .neqv. tensor3%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_add_different
 
   ! Unit test checking the requires_grad property is carried over during a combination of an
   ! assignment and a negation
@@ -549,23 +620,90 @@ contains
     type(torch_tensor) :: tensor1, tensor2
     integer, parameter :: ndims = 1
     integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
 
     ! Create a tensor of ones with the provided requires_grad value
     call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
                            requires_grad=this%param%switch)
 
-    ! Create another empty tensor with the same arguments except the opposite requires_grad value
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
     call torch_tensor_empty(tensor2, ndims, tensor_shape, dtype, device_type, &
                             requires_grad=.not. this%param%switch)
 
     tensor2 = -tensor1
 
     ! Check that requires_grad is updated correctly
-    if (tensor1%requires_grad() .neqv. tensor2%requires_grad()) then
+    expected = this%param%switch
+    if (expected .neqv. tensor2%requires_grad()) then
       print *, "Error :: tensor%requires_grad() returned incorrect value"
       stop 999
     end if
 
   end subroutine test_requires_grad_negative
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and a subtraction with the same requires_grad properties
+  @test(testparameters={get_parameters_full()})
+  subroutine test_requires_grad_subtract_same(this)
+    use ftorch, only: operator(-)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2, tensor3
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create two tensors of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type, &
+                            requires_grad=.not. this%param%switch)
+
+    tensor3 = tensor1 - tensor2
+
+    ! Check that requires_grad is updated correctly
+    expected = this%param%switch
+    if (expected .neqv. tensor3%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_subtract_same
+
+  ! Unit test checking the requires_grad property is carried over during a combination of an
+  ! assignment and a subtraction applied to tensors with different requires_grad values
+  @test(testparameters={get_parameters_full()})
+  subroutine test_requires_grad_subtract_different(this)
+    use ftorch, only: operator(-)
+    class(TestCaseType), intent(inout) :: this
+    type(torch_tensor) :: tensor1, tensor2, tensor3
+    integer, parameter :: ndims = 1
+    integer(c_int64_t), parameter, dimension(ndims) :: tensor_shape = [1]
+    logical :: expected
+
+    ! Create two tensors of ones with the provided requires_grad value
+    call torch_tensor_ones(tensor1, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=this%param%switch)
+    call torch_tensor_ones(tensor2, ndims, tensor_shape, dtype, device_type, &
+                           requires_grad=.not. this%param%switch)
+
+    ! Create an empty tensor with the same arguments except the opposite requires_grad value
+    call torch_tensor_empty(tensor3, ndims, tensor_shape, dtype, device_type)
+    ! NOTE: It's not valid for tensor3 to have requires_grad=.true. as that would give the error
+    !    "a leaf Variable that requires grad is being used in an in-place operation".
+
+    tensor3 = tensor1 - tensor2
+
+    ! Check that requires_grad is updated correctly
+    expected = .true.
+    if (expected .neqv. tensor3%requires_grad()) then
+      print *, "Error :: tensor%requires_grad() returned incorrect value"
+      stop 999
+    end if
+
+  end subroutine test_requires_grad_subtract_different
 
 end module test_tensor_operator_overloads

--- a/test/unit/test_tensor_operator_overloads_autograd.pf
+++ b/test/unit/test_tensor_operator_overloads_autograd.pf
@@ -39,7 +39,7 @@ module test_tensor_operator_overloads_autograd
   end type TestParametersType
 
   ! Typedef for a test case with a particular set of parameters
-  @testCase(constructor=test_case_ctor)
+  @testCase(constructor=test_case_constructor)
   type, extends (ParameterizedTestCase) :: TestCaseType
     type(TestParametersType) :: param
   end type TestCaseType
@@ -62,11 +62,11 @@ contains
   end function get_parameters_short
 
   ! Constructor for the test case type
-  function test_case_ctor(param)
-    type(TestCaseType) :: test_case_ctor
+  function test_case_constructor(param)
+    type(TestCaseType) :: test_case_constructor
     type(TestParametersType) :: param
-    test_case_ctor%param = param
-  end function test_case_ctor
+    test_case_constructor%param = param
+  end function test_case_constructor
 
   ! Function for representing a parameter set as a string
   function toString(this) result(string)


### PR DESCRIPTION
Closes #370.

It turns out I was wrong in #364. Some simple Python experimentation shows that we *should* be carrying `requires_grad` over through expressions.
```
>>> a = torch.Tensor([1])
>>> a.requires_grad = True
>>> a
tensor([1.], requires_grad=True)
>>> b = torch.Tensor([2])
>>> c = a + b
>>> c
tensor([3.], grad_fn=<AddBackward0>)
>>> c.requires_grad
True
```
This PR reverts the changes from #364 and drops the related check that was causing issues.

Further, we should actually be overwriting with `requires_grad=False` when appropriate, too:
```
>>> import torch
>>> a = torch.Tensor([1])
>>> a.requires_grad=True
>>> a
tensor([1.], requires_grad=True)
>>> b = torch.Tensor([1])
>>> b
tensor([1.])
>>> a = b + b
>>> a
tensor([2.])
```