### PR TITLE
Fix bug in implementation of wrapper function `torch_from_blob` (#365)

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -272,6 +272,9 @@ torch_tensor_t torch_from_blob(void *data, int ndim, const int64_t *shape,
     // This doesn't throw if shape and dimensions are incompatible
     c10::IntArrayRef vshape(shape, ndim);
     c10::IntArrayRef vstrides(strides, ndim);
+    // NOTE: Do not pass device TensorOptions since this would cause torch::from_blob
+    //       to expect data to reside on the host device_type, which is not case if
+    //       device_type is a GPU device (see #365)
     auto options = torch::TensorOptions()
                        .dtype(get_libtorch_dtype(dtype))
                        .requires_grad(requires_grad);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -274,9 +274,9 @@ torch_tensor_t torch_from_blob(void *data, int ndim, const int64_t *shape,
     c10::IntArrayRef vstrides(strides, ndim);
     auto options = torch::TensorOptions()
                        .dtype(get_libtorch_dtype(dtype))
-                       .device(get_libtorch_device(device_type, device_index))
                        .requires_grad(requires_grad);
-    *tensor = torch::from_blob(data, vshape, vstrides, options);
+    *tensor = torch::from_blob(data, vshape, vstrides, options)
+                  .to(get_libtorch_device(device_type, device_index));
 
   } catch (const torch::Error &e) {
     ctorch_error(e.msg(), [&]() { delete tensor; });


### PR DESCRIPTION
This would patch #365. 

As discussed in #365 this PR would fix the bug that sneaked in at 864b0eb causing any call to `torch_tensor_from_array` on a gpu device to throw
```
[ERROR]: The specified pointer resides on host memory and is not
registered with any CUDA device.
```

It rolls back to previous approach (6deab9a) where the device is not explicitly passed to the `options` but the tensor is rather moved `to` the target device.