### PR TITLE
Mention FTorch workshop repo and separate out events

### DIFF
--- a/FTorch.md
+++ b/FTorch.md
@@ -59,13 +59,28 @@ Some recent updates about FTorch:
   grant will support development for online training functionality for FTorch,
   as well as research visits, FTorch training tutorials, and organisation of a
   [workshop on hybrid modelling](https://cambridge-iccs.github.io/ml-coupling-workshop).
+* FTorch developer Joe Wallwork will be giving a talk on *Accelerating UKCA by
+  predicting timesteps with FTorch* in the
+  [HPC in Weather & Climate Research](https://durham.readthedocs.io/en/latest/hpcdays/workshops.html#Weather)
+  session at
+  [Durham HPC Days](https://www.durham.ac.uk/research/institutes-and-centres/data-science/events-/durham---hpc-days/)
+  on 4th June 2025.
+* FTorch developer Jack Atkinson will be presenting FTorch in a SciML seminar at
+  [CEMAC](https://www.cemac.leeds.ac.uk/) in Leeds on 18th July 2025.
+
+FTorch training
+---------------
+
+We offer training on FTorch in the form of tutorials and workshops. The
+companion repository
+[https://github.com/Cambridge-ICCS/FTorch-workshop](https://github.com/Cambridge-ICCS/FTorch-workshop)
+provides a set of exercises and solutions to help users get started with FTorch.
+Details of upcoming in-person training events are as follows:
+
 * FTorch developers Joe Wallwork and Tom Meltzer will be giving an FTorch
   tutorial at
   [Durham HPC Days](https://www.durham.ac.uk/research/institutes-and-centres/data-science/events-/durham---hpc-days/)
-  on 2nd June 2025. Joe will also be giving a talk on *Accelerating UKCA by
-  predicting timesteps with FTorch* in the
-  [HPC in Weather & Climate Research](https://durham.readthedocs.io/en/latest/hpcdays/workshops.html#Weather)
-  session.
+  on 2nd June 2025.
 * FTorch developers Jack Atkinson and Joe Wallwork will be giving an FTorch
   tutorial in the
   [Department of Atmospheric, Oceanic, and Planetary Physics](https://www.physics.ox.ac.uk/research/subdepartment/atmospheric-oceanic-and-planetary-physics)
@@ -73,9 +88,6 @@ Some recent updates about FTorch:
 * The FTorch developers will be giving an FTorch tutorial at the
   [ICCS Summer School](https://iccs.cam.ac.uk/events/institute-computing-climate-science-annual-summer-school-2025)
   on 11th July 2025.
-  * FTorch developer Jack Atkinson will be presenting FTorch in a SciML seminar at
-  [CEMAC](https://www.cemac.leeds.ac.uk/) in Leeds on 18th July 2025.
-
 
 Publications and Select Presentations
 -------------------------------------

--- a/FTorch.md
+++ b/FTorch.md
@@ -59,12 +59,6 @@ Some recent updates about FTorch:
   grant will support development for online training functionality for FTorch,
   as well as research visits, FTorch training tutorials, and organisation of a
   [workshop on hybrid modelling](https://cambridge-iccs.github.io/ml-coupling-workshop).
-* FTorch developer Joe Wallwork will be giving a talk on *Accelerating UKCA by
-  predicting timesteps with FTorch* in the
-  [HPC in Weather & Climate Research](https://durham.readthedocs.io/en/latest/hpcdays/workshops.html#Weather)
-  session at
-  [Durham HPC Days](https://www.durham.ac.uk/research/institutes-and-centres/data-science/events-/durham---hpc-days/)
-  on 4th June 2025.
 * FTorch developer Jack Atkinson will be presenting FTorch in a SciML seminar at
   [CEMAC](https://www.cemac.leeds.ac.uk/) in Leeds on 18th July 2025.
 
@@ -77,10 +71,6 @@ companion repository
 provides a set of exercises and solutions to help users get started with FTorch.
 Details of upcoming in-person training events are as follows:
 
-* FTorch developers Joe Wallwork and Tom Meltzer will be giving an FTorch
-  tutorial at
-  [Durham HPC Days](https://www.durham.ac.uk/research/institutes-and-centres/data-science/events-/durham---hpc-days/)
-  on 2nd June 2025.
 * FTorch developers Jack Atkinson and Joe Wallwork will be giving an FTorch
   tutorial in the
   [Department of Atmospheric, Oceanic, and Planetary Physics](https://www.physics.ox.ac.uk/research/subdepartment/atmospheric-oceanic-and-planetary-physics)

--- a/pages/presentations.md
+++ b/pages/presentations.md
@@ -2,8 +2,17 @@ title: Presentations
 
 [TOC]
 
-The following presentations contain information about FTorch:
+## Talks and posters
 
+The following presentations contain information about FTorch and its
+applications:
+
+* Accelerating UKCA by predicting timesteps with FTorch<br>
+  [HPC in Weather & Climate Research](https://durham.readthedocs.io/en/latest/hpcdays/workshops.html#Weather)
+  session at
+  [Durham HPC Days](https://www.durham.ac.uk/research/institutes-and-centres/data-science/events-/durham---hpc-days/)
+  University of Durham - June 2025<br>
+  [Slides](https://hackmd.io/@jwallwork/2025-durham-hpc-days?type=slide)
 * Facilitating machine learning in Fortran using FTorch<br>
   Seminars at the University of Reading
   [Data Assimilation Research Centre](https://research.reading.ac.uk/met-darc/news-and-events/darc-seminar-series/)
@@ -32,3 +41,15 @@ The following presentations contain information about FTorch:
 * Reducing the Overhead of Coupled Machine Learning Models between Python and Fortran<br>
   RSECon23, Swansea - September 2023<br>
   [Slides](https://jackatkinson.net/slides/RSECon23) - [Recording](https://www.youtube.com/watch?v=Ei6H_BoQ7g4&list=PL27mQJy8eDHmibt_aL3M68x-4gnXpxvZP&index=33)
+
+## Past FTorch tutorials:
+
+We have given in-person training on FTorch in the form of tutorials and
+workshops based on the companion repository
+[https://github.com/Cambridge-ICCS/FTorch-workshop](https://github.com/Cambridge-ICCS/FTorch-workshop)
+on the following occasions:
+
+* [ICCS Summer School](https://iccs.cam.ac.uk/events/institute-computing-climate-science-annual-summer-school-2024),
+  July 2024.
+* [Durham HPC Days](https://www.durham.ac.uk/research/institutes-and-centres/data-science/events-/durham---hpc-days/),
+  June 2025.


### PR DESCRIPTION
Closes #379.

This PR mentions the FTorch workshop repo on the main webpage. It also separates out the event listing into news vs training.