### PR TITLE
Add `torch_kHIP` and `hip` device type for `pt2ts`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ if("${GPU_DEVICE}" STREQUAL "NONE")
 elseif("${GPU_DEVICE}" STREQUAL "CUDA")
   set(GPU_DEVICE_CODE ${GPU_DEVICE_CUDA})
 elseif("${GPU_DEVICE}" STREQUAL "HIP")
-  # As stated in the PyTorch documentation (https://docs.pytorch.org/docs/stable/notes/hip.html)
+  # As stated in the PyTorch documentation
+  # (https://docs.pytorch.org/docs/stable/notes/hip.html)
   # > "PyTorch for HIP intentionally reuses the existing torch.cuda interfaces.
   # > This helps to accelerate the porting of existing PyTorch code and models
   # > because very few code changes are necessary, if any."
@@ -69,9 +70,9 @@ endif()
 if("${GPU_DEVICE}" STREQUAL "HIP")
   check_language(HIP)
   if(CMAKE_HIP_COMPILER)
-   enable_language(HIP)
+    enable_language(HIP)
   else()
-   message(WARNING "No HIP support")
+    message(WARNING "No HIP support")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # throughout source files.
 set(GPU_DEVICE_NONE 0)
 set(GPU_DEVICE_CUDA 1)
+set(GPU_DEVICE_HIP  1)  # NOTE: HIP is treated as CUDA in this project
 set(GPU_DEVICE_XPU 12)
 set(GPU_DEVICE_MPS 13)
-option(GPU_DEVICE "Set the GPU device (NONE [default], CUDA, XPU, or MPS)" NONE)
+option(GPU_DEVICE
+       "Set the GPU device (NONE [default], CUDA, HIP, XPU, or MPS)" NONE)
 if("${GPU_DEVICE}" STREQUAL "OFF")
   set(GPU_DEVICE NONE)
 endif()
@@ -38,6 +40,8 @@ if("${GPU_DEVICE}" STREQUAL "NONE")
   set(GPU_DEVICE_CODE ${GPU_DEVICE_NONE})
 elseif("${GPU_DEVICE}" STREQUAL "CUDA")
   set(GPU_DEVICE_CODE ${GPU_DEVICE_CUDA})
+elseif("${GPU_DEVICE}" STREQUAL "HIP")
+  set(GPU_DEVICE_CODE ${GPU_DEVICE_HIP})
 elseif("${GPU_DEVICE}" STREQUAL "XPU")
   set(GPU_DEVICE_CODE ${GPU_DEVICE_XPU})
 elseif("${GPU_DEVICE}" STREQUAL "MPS")
@@ -91,8 +95,11 @@ endif()
 target_compile_definitions(
   ${LIB_NAME}
   PRIVATE ${COMPILE_DEFS} GPU_DEVICE=${GPU_DEVICE_CODE}
-          GPU_DEVICE_NONE=${GPU_DEVICE_NONE} GPU_DEVICE_CUDA=${GPU_DEVICE_CUDA}
-          GPU_DEVICE_XPU=${GPU_DEVICE_XPU} GPU_DEVICE_MPS=${GPU_DEVICE_MPS})
+          GPU_DEVICE_NONE=${GPU_DEVICE_NONE}
+          GPU_DEVICE_CUDA=${GPU_DEVICE_CUDA}
+          GPU_DEVICE_HIP=${GPU_DEVICE_HIP}
+          GPU_DEVICE_XPU=${GPU_DEVICE_XPU}
+          GPU_DEVICE_MPS=${GPU_DEVICE_MPS})
 
 # Add an alias FTorch::ftorch for the library
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})

--- a/examples/2_SimpleNet/pt2ts.py
+++ b/examples/2_SimpleNet/pt2ts.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "hip", "xpu", "mps"],
         default="cpu",
     )
     parser.add_argument(
@@ -120,6 +120,8 @@ if __name__ == "__main__":
 
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
+        if device_type == "hip":
+            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
         device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()

--- a/examples/2_SimpleNet/pt2ts.py
+++ b/examples/2_SimpleNet/pt2ts.py
@@ -121,8 +121,9 @@ if __name__ == "__main__":
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
         if device_type == "hip":
-            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
-        device = torch.device(device_type)
+            device = torch.device("cuda")  # NOTE: HIP is treated as CUDA in FTorch
+        else:
+            device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()
         trained_model_dummy_input = trained_model_dummy_input.to(device)

--- a/examples/3_ResNet/pt2ts.py
+++ b/examples/3_ResNet/pt2ts.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "hip", "xpu", "mps"],
         default="cpu",
     )
     parser.add_argument(
@@ -126,6 +126,8 @@ if __name__ == "__main__":
 
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
+        if device_type == "hip":
+            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
         device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()

--- a/examples/3_ResNet/pt2ts.py
+++ b/examples/3_ResNet/pt2ts.py
@@ -127,8 +127,9 @@ if __name__ == "__main__":
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
         if device_type == "hip":
-            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
-        device = torch.device(device_type)
+            device = torch.device("cuda")  # NOTE: HIP is treated as CUDA in FTorch
+        else:
+            device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()
         trained_model_dummy_input = trained_model_dummy_input.to(device)

--- a/examples/4_MultiIO/pt2ts.py
+++ b/examples/4_MultiIO/pt2ts.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "hip", "xpu", "mps"],
         default="cpu",
     )
     parser.add_argument(
@@ -120,6 +120,8 @@ if __name__ == "__main__":
 
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
+        if device_type == "hip":
+            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
         device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()

--- a/examples/4_MultiIO/pt2ts.py
+++ b/examples/4_MultiIO/pt2ts.py
@@ -121,8 +121,9 @@ if __name__ == "__main__":
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
         if device_type == "hip":
-            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
-        device = torch.device(device_type)
+            device = torch.device("cuda")  # NOTE: HIP is treated as CUDA in FTorch
+        else:
+            device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()
         trained_model_dummy_inputs = trained_model_dummy_inputs.to(device)

--- a/examples/5_Looping/pt2ts.py
+++ b/examples/5_Looping/pt2ts.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "hip", "xpu", "mps"],
         default="cpu",
     )
     parser.add_argument(
@@ -116,6 +116,8 @@ if __name__ == "__main__":
 
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
+        if device_type == "hip":
+            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
         device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()

--- a/examples/5_Looping/pt2ts.py
+++ b/examples/5_Looping/pt2ts.py
@@ -117,8 +117,9 @@ if __name__ == "__main__":
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
         if device_type == "hip":
-            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
-        device = torch.device(device_type)
+            device = torch.device("cuda")  # NOTE: HIP is treated as CUDA in FTorch
+        else:
+            device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()
         trained_model_dummy_input = trained_model_dummy_input.to(device)

--- a/examples/6_MultiGPU/multigpu_infer_fortran.f90
+++ b/examples/6_MultiGPU/multigpu_infer_fortran.f90
@@ -5,7 +5,7 @@ program inference
 
    ! Import our library for interfacing with PyTorch
    use ftorch, only : torch_model, torch_tensor, &
-                      torch_kCPU, torch_kCUDA, torch_kXPU, torch_kMPS, &
+                      torch_kCPU, torch_kCUDA, torch_kHIP, torch_kXPU, torch_kMPS, &
                       torch_tensor_from_array, torch_model_load, torch_model_forward, &
                       torch_delete
 
@@ -46,6 +46,8 @@ program inference
    end do
    if (trim(args(1)) == "cuda") then
       device_type = torch_kCUDA
+    else if (trim(args(1)) == "hip") then
+      device_type = torch_kHIP
    else if (trim(args(1)) == "xpu") then
       device_type = torch_kXPU
    else if (trim(args(1)) == "mps") then

--- a/examples/6_MultiGPU/multigpu_infer_python.py
+++ b/examples/6_MultiGPU/multigpu_infer_python.py
@@ -32,7 +32,7 @@ def deploy(saved_model: str, device: str, batch_size: int = 1) -> torch.Tensor:
         # Inference
         return model.forward(input_tensor)
 
-    if device.startswith("cuda"):
+    if device.startswith("cuda") or device.startswith("hip"):
         pass
     elif device.startswith("xpu"):
         # XPU devices need to be initialised before use
@@ -76,7 +76,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "hip", "xpu", "mps"],
         default="cuda",
     )
     parsed_args = parser.parse_args()

--- a/examples/6_MultiGPU/pt2ts.py
+++ b/examples/6_MultiGPU/pt2ts.py
@@ -121,8 +121,9 @@ if __name__ == "__main__":
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
         if device_type == "hip":
-            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
-        device = torch.device(device_type)
+            device = torch.device("cuda")  # NOTE: HIP is treated as CUDA in FTorch
+        else:
+            device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()
         trained_model_dummy_input = trained_model_dummy_input.to(device)

--- a/examples/6_MultiGPU/pt2ts.py
+++ b/examples/6_MultiGPU/pt2ts.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "hip", "xpu", "mps"],
         default="cuda",
     )
     parsed_args = parser.parse_args()
@@ -120,6 +120,8 @@ if __name__ == "__main__":
 
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
+        if device_type == "hip":
+            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
         device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()

--- a/examples/7_MPI/pt2ts.py
+++ b/examples/7_MPI/pt2ts.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "hip", "xpu", "mps"],
         default="cpu",
     )
     parser.add_argument(
@@ -121,6 +121,8 @@ if __name__ == "__main__":
 
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
+        if device_type == "hip":
+            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
         device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()

--- a/examples/7_MPI/pt2ts.py
+++ b/examples/7_MPI/pt2ts.py
@@ -122,8 +122,9 @@ if __name__ == "__main__":
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
         if device_type == "hip":
-            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
-        device = torch.device(device_type)
+            device = torch.device("cuda")  # NOTE: HIP is treated as CUDA in FTorch
+        else:
+            device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()
         trained_model_dummy_input = trained_model_dummy_input.to(device)

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -98,7 +98,7 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
       ctorch_warn("device index unused for CPU-only runs");
     }
     return torch::Device(torch::kCPU);
-#if GPU_DEVICE == GPU_DEVICE_CUDA
+#if (GPU_DEVICE == GPU_DEVICE_CUDA)
   case torch_kCUDA:
     if (device_index == -1) {
       ctorch_warn("device index unset, defaulting to 0");
@@ -106,6 +106,21 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
     }
     if (device_index >= 0 && device_index < torch::cuda::device_count()) {
       return torch::Device(torch::kCUDA, device_index);
+    } else {
+      std::cerr << "[ERROR]: invalid device index " << device_index
+                << " for device count " << torch::cuda::device_count() << std::endl;
+      exit(EXIT_FAILURE);
+    }
+#endif
+#if (GPU_DEVICE == GPU_DEVICE_HIP)
+  // NOTE: HIP is treated as CUDA in this project
+  case torch_kHIP:
+    if (device_index == -1) {
+      ctorch_warn("device index unset, defaulting to 0");
+      device_index = 0;
+    }
+    if (device_index >= 0 && device_index < torch::cuda::device_count()) {
+      return torch::Device(torch::kHIP, device_index);
     } else {
       std::cerr << "[ERROR]: invalid device index " << device_index
                 << " for device count " << torch::cuda::device_count() << std::endl;
@@ -144,6 +159,8 @@ const torch_device_t get_ftorch_device(torch::DeviceType device_type) {
     return torch_kCPU;
   case torch::kCUDA:
     return torch_kCUDA;
+  case torch::kHIP:
+    return torch_kHIP;
   case torch::kXPU:
     return torch_kXPU;
   case torch::kMPS:

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -98,7 +98,8 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
       ctorch_warn("device index unused for CPU-only runs");
     }
     return torch::Device(torch::kCPU);
-#if (GPU_DEVICE == GPU_DEVICE_CUDA)
+#if (GPU_DEVICE == GPU_DEVICE_CUDA) || (GPU_DEVICE == GPU_DEVICE_HIP)
+  // NOTE: HIP is treated as CUDA in this project
   case torch_kCUDA:
     if (device_index == -1) {
       ctorch_warn("device index unset, defaulting to 0");
@@ -106,21 +107,6 @@ const auto get_libtorch_device(torch_device_t device_type, int device_index) {
     }
     if (device_index >= 0 && device_index < torch::cuda::device_count()) {
       return torch::Device(torch::kCUDA, device_index);
-    } else {
-      std::cerr << "[ERROR]: invalid device index " << device_index
-                << " for device count " << torch::cuda::device_count() << std::endl;
-      exit(EXIT_FAILURE);
-    }
-#endif
-#if (GPU_DEVICE == GPU_DEVICE_HIP)
-  // NOTE: HIP is treated as CUDA in this project
-  case torch_kHIP:
-    if (device_index == -1) {
-      ctorch_warn("device index unset, defaulting to 0");
-      device_index = 0;
-    }
-    if (device_index >= 0 && device_index < torch::cuda::device_count()) {
-      return torch::Device(torch::kHIP, device_index);
     } else {
       std::cerr << "[ERROR]: invalid device index " << device_index
                 << " for device count " << torch::cuda::device_count() << std::endl;

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -42,6 +42,7 @@ typedef enum {
 typedef enum {
   torch_kCPU = GPU_DEVICE_NONE,
   torch_kCUDA = GPU_DEVICE_CUDA,
+  torch_kHIP = GPU_DEVICE_HIP,
   torch_kXPU = GPU_DEVICE_XPU,
   torch_kMPS = GPU_DEVICE_MPS,
 } torch_device_t;

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -62,6 +62,7 @@ module ftorch
   enum, bind(c)
     enumerator :: torch_kCPU = GPU_DEVICE_NONE
     enumerator :: torch_kCUDA = GPU_DEVICE_CUDA
+    enumerator :: torch_kHIP = GPU_DEVICE_HIP
     enumerator :: torch_kXPU = GPU_DEVICE_XPU
     enumerator :: torch_kMPS = GPU_DEVICE_MPS
   end enum

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -81,6 +81,7 @@ module ftorch
   enum, bind(c)
     enumerator :: torch_kCPU = GPU_DEVICE_NONE
     enumerator :: torch_kCUDA = GPU_DEVICE_CUDA
+    enumerator :: torch_kHIP = GPU_DEVICE_HIP
     enumerator :: torch_kXPU = GPU_DEVICE_XPU
     enumerator :: torch_kMPS = GPU_DEVICE_MPS
   end enum

--- a/utils/pt2ts.py
+++ b/utils/pt2ts.py
@@ -121,8 +121,9 @@ if __name__ == "__main__":
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
         if device_type == "hip":
-            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
-        device = torch.device(device_type)
+            device = torch.device("cuda")  # NOTE: HIP is treated as CUDA in FTorch
+        else:
+            device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()
         trained_model_dummy_input_1 = trained_model_dummy_input_1.to(device)

--- a/utils/pt2ts.py
+++ b/utils/pt2ts.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
         "--device_type",
         help="Device type to run the inference on",
         type=str,
-        choices=["cpu", "cuda", "xpu", "mps"],
+        choices=["cpu", "cuda", "hip", "xpu", "mps"],
         default="cpu",
     )
     parser.add_argument(
@@ -120,6 +120,8 @@ if __name__ == "__main__":
 
     # Transfer the model and inputs to GPU device, if appropriate
     if device_type != "cpu":
+        if device_type == "hip":
+            device_type = "cuda"  # NOTE: HIP is treated as CUDA in FTorch
         device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()


### PR DESCRIPTION
Merges into #385.

Some extras to add a `torch_kHIP` enum (aliased to `torch_kCUDA`) and to accept a `hip` device type option for the `pt2ts.py` scripts.