### PR TITLE
Optimisation demo: consistency and scalar loss

### DIFF
--- a/examples/n_Optimizers/CMakeLists.txt
+++ b/examples/n_Optimizers/CMakeLists.txt
@@ -26,8 +26,11 @@ if(CMAKE_BUILD_TESTS)
   include(CTest)
 
   # 1. Check the Python Optimizers script runs successfully
-  add_test(NAME pyoptim COMMAND ${Python_EXECUTABLE}
-                                   ${PROJECT_SOURCE_DIR}/optimizers.py)
+  add_test(
+    NAME pyoptim
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/optimizers.py)
+  set_tests_properties(pyoptim PROPERTIES PASS_REGULAR_EXPRESSION
+                       "Python optimizers example ran successfully")
 
   # 2. Check the Fortran Optimizers script runs successfully
   add_test(
@@ -35,5 +38,5 @@ if(CMAKE_BUILD_TESTS)
     COMMAND optimizers
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(foptim PROPERTIES PASS_REGULAR_EXPRESSION
-                                         "Optimizers example ran successfully")
+                       "Fortran optimizers example ran successfully")
 endif()

--- a/examples/n_Optimizers/optimizers.f90
+++ b/examples/n_Optimizers/optimizers.f90
@@ -52,7 +52,7 @@ program example
 
   ! Initialise an optimizer and apply it to scaling_tensor
   ! TODO optimizer expects an array of tensors, should be a cleaner consistent way to formalise this.
-  call torch_optim_SGD(optimizer, [scaling_tensor])
+  call torch_optim_SGD(optimizer, [scaling_tensor], learning_rate=1D0)
 
   ! Create an empty loss tensor
   call torch_tensor_empty(scaling_grad, ndims, tensor_shape, torch_kFloat32, torch_kCPU)

--- a/examples/n_Optimizers/optimizers.f90
+++ b/examples/n_Optimizers/optimizers.f90
@@ -71,18 +71,18 @@ program example
     grad_reqd = loss%requires_grad()
     write(*,*) "loss%requires_grad = ", grad_reqd
 
-    ! Populate loss with mean square error (MSE) between target and input
-    ! Then perform backward step on loss to propogate gradients using autograd
+    ! Create a loss tensor as computed mean square error (MSE) between target and input
     write(*,*) "Set Loss"
     call torch_tensor_mean(loss, (output_vec - target_vec) ** 2)
     grad_reqd = loss%requires_grad()
     write(*,*) "loss%requires_grad = ", grad_reqd
 
+    ! Perform backward step on loss to propogate gradients using autograd
+    ! NOTE: This implicitly passes a unit 'external gradient' to the backward pass
     write(*,*) "Backwards Step"
     call torch_tensor_backward(loss, retain_graph=.true.)
     grad_reqd = loss%requires_grad()
     write(*,*) "loss%requires_grad = ", grad_reqd
-
     write(*,*) "Get Gradient"
     call torch_tensor_get_gradient(scaling_grad, scaling_tensor)
     grad_reqd = loss%requires_grad()

--- a/examples/n_Optimizers/optimizers.py
+++ b/examples/n_Optimizers/optimizers.py
@@ -29,16 +29,10 @@ for epoch in range(n_iter + 1):
     output = input_vec * scaling_tensor
 
     # Create a loss tensor as computed mean square error (MSE) between target and input
-    # Then perform backward step on loss to propogate gradients using autograd
-    #
-    # We could use the following 2 lines to do this by explicitly specifying a
-    # gradient of ones to start the process:
-    # loss = ((output - target) ** 2) / 4.0
-    # loss.backward(gradient=torch.ones(4))
-    #
-    # However, we can avoid explicitly passing an initial gradient and instead do this
-    # implicitly by aggregating the loss vector into a scalar value:
     loss = ((output - target_vec) ** 2).mean()
+
+    # Perform backward step on loss to propogate gradients using autograd
+    # NOTE: This implicitly passes a unit 'external gradient' to the backward pass
     loss.backward()
 
     # Step the optimizer to update the values in `tensor`

--- a/examples/n_Optimizers/optimizers.py
+++ b/examples/n_Optimizers/optimizers.py
@@ -47,3 +47,4 @@ for epoch in range(n_iter + 1):
         print(f"\tscaling_tensor:\n\t\t{scaling_tensor}")
 
 print("Training complete.")
+print("Fortran optimizers example ran successfully")

--- a/examples/n_Optimizers/optimizers.py
+++ b/examples/n_Optimizers/optimizers.py
@@ -47,4 +47,4 @@ for epoch in range(n_iter + 1):
         print(f"\tscaling_tensor:\n\t\t{scaling_tensor}")
 
 print("Training complete.")
-print("Fortran optimizers example ran successfully")
+print("Python optimizers example ran successfully")


### PR DESCRIPTION
Merges into #320.

This PR includes various improvements for the optimisers demo:
* Implement a scalar loss function with `torch_tensor_mean`.
* Consistent formatting and outputs.
* Drop debug prints from Fortran version of the example.
* Add a regex test for the Python version of the example.