### PR TITLE
Optimisation demo: checks and plotting

### DIFF
--- a/examples/n_Optimizers/CMakeLists.txt
+++ b/examples/n_Optimizers/CMakeLists.txt
@@ -28,7 +28,8 @@ if(CMAKE_BUILD_TESTS)
   # 1. Check the Python Optimizers script runs successfully
   add_test(
     NAME pyoptim
-    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/optimizers.py)
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/optimizers.py
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(pyoptim PROPERTIES PASS_REGULAR_EXPRESSION
                        "Python optimizers example ran successfully")
 
@@ -39,4 +40,10 @@ if(CMAKE_BUILD_TESTS)
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
   set_tests_properties(foptim PROPERTIES PASS_REGULAR_EXPRESSION
                        "Fortran optimizers example ran successfully")
+
+  # 3. Check the plotting script runs successfully
+  add_test(
+    NAME plot
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/plot_losses.py && ${CMAKE_COMMAND} -E test_file ${PROJECT_BINARY_DIR}/losses.png
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 endif()

--- a/examples/n_Optimizers/optimizers.f90
+++ b/examples/n_Optimizers/optimizers.f90
@@ -16,6 +16,9 @@ program foptimizer
                     torch_tensor_mean
   use ftorch_optim, only: torch_optim, torch_optim_SGD
 
+  ! Import our tools module for testing utils
+  use ftorch_test_utils, only : assert_allclose
+
   implicit none
 
   ! Set working precision for reals
@@ -24,7 +27,7 @@ program foptimizer
   ! Set up Fortran data structures
   integer, parameter :: ndims = 1
   integer, parameter :: n=4
-  real(wp), dimension(n), target :: input_data, output_data, target_data
+  real(wp), dimension(n), target :: input_data, output_data, target_data, scaling_data
   real(wp), dimension(1), target :: loss_data
   integer :: scalar_layout(1) = [1]
   integer :: tensor_layout(ndims) = [1]
@@ -46,8 +49,8 @@ program foptimizer
   call torch_tensor_from_array(target_vec, target_data, tensor_layout, torch_kCPU)
 
   ! Initialise Scaling tensor as ones as in Python example
-  call torch_tensor_ones(scaling_tensor, ndims, tensor_shape, &
-                         torch_kFloat32, torch_kCPU, requires_grad=.true.)
+  call torch_tensor_from_array(scaling_tensor, scaling_data, tensor_layout, torch_kCPU, &
+                               requires_grad=.true.)
 
   ! Initialise an optimizer and apply it to scaling_tensor
   ! TODO optimizer expects an array of tensors, should be a cleaner consistent way to formalise this.
@@ -104,6 +107,12 @@ program foptimizer
     call torch_delete(output_vec)
   end do
   close(unit=10)
+
+  ! Check scaling tensor converges to the expected value
+  if (.not. assert_allclose(scaling_data, target_data, test_name="optimizers", rtol=1e-3)) then
+    write(*,*) "Error :: value of scaling_data does not match expected value"
+    stop 999
+  end if
 
   write(*,*) "Training complete."
 

--- a/examples/n_Optimizers/optimizers.f90
+++ b/examples/n_Optimizers/optimizers.f90
@@ -25,13 +25,13 @@ program foptimizer
   integer, parameter :: ndims = 1
   integer, parameter :: n=4
   real(wp), dimension(n), target :: input_data, output_data, target_data
+  real(wp), dimension(1), target :: loss_data
+  integer :: scalar_layout(1) = [1]
   integer :: tensor_layout(ndims) = [1]
 
   ! Set up Torch data structures
   integer(c_int64_t), dimension(1), parameter :: tensor_shape = [4]
-  integer(c_int64_t), dimension(1), parameter :: scalar_shape = [1]
-  type(torch_tensor) :: input_vec, output_vec, target_vec, &
-                        scaling_tensor, scaling_grad, loss
+  type(torch_tensor) :: input_vec, output_vec, target_vec, scaling_tensor, scaling_grad, loss
   type(torch_optim) :: optimizer
 
   ! Set up training parameters
@@ -53,9 +53,14 @@ program foptimizer
   ! TODO optimizer expects an array of tensors, should be a cleaner consistent way to formalise this.
   call torch_optim_SGD(optimizer, [scaling_tensor], learning_rate=1D0)
 
-  ! Create an empty loss tensor
+  ! Create loss 'tensor' associated with a trivial Fortran array
+  call torch_tensor_from_array(loss, loss_data, scalar_layout, torch_kCPU)
+
+  ! Create an empty tensor for the gradient of the scaling
   call torch_tensor_empty(scaling_grad, ndims, tensor_shape, torch_kFloat32, torch_kCPU)
-  call torch_tensor_empty(loss, 1, scalar_shape, torch_kFloat32, torch_kCPU)
+
+  ! Create a file for recording the loss function progress
+  open(unit=10, file="losses_ftorch.dat")
 
   ! Conduct training loop
   do i = 1, n_train+1
@@ -66,8 +71,10 @@ program foptimizer
     call torch_tensor_from_array(output_vec, output_data, tensor_layout, torch_kCPU)
     output_vec = input_vec * scaling_tensor
 
-    ! Create a loss tensor as computed mean square error (MSE) between target and input
+    ! Evaluate the loss function as computed mean square error (MSE) between target and input, then
+    ! log its value
     call torch_tensor_mean(loss, (output_vec - target_vec) ** 2)
+    write(unit=10, fmt="(e9.4)") loss_data(1)
 
     ! Perform backward step on loss to propogate gradients using autograd
     ! NOTE: This implicitly passes a unit 'external gradient' to the backward pass
@@ -96,6 +103,7 @@ program foptimizer
 
     call torch_delete(output_vec)
   end do
+  close(unit=10)
 
   write(*,*) "Training complete."
 

--- a/examples/n_Optimizers/optimizers.py
+++ b/examples/n_Optimizers/optimizers.py
@@ -21,6 +21,7 @@ optimizer = torch.optim.SGD([scaling_tensor], lr=1.0)
 # Run n_iter times printing every n_print steps
 n_iter = 15
 n_print = 1
+loss_progress = []
 for epoch in range(n_iter + 1):
     # Zero any previously stored gradients ready for a new iteration
     optimizer.zero_grad()
@@ -28,8 +29,10 @@ for epoch in range(n_iter + 1):
     # Forward pass: multiply the input of ones by the tensor (elementwise)
     output = input_vec * scaling_tensor
 
-    # Create a loss tensor as computed mean square error (MSE) between target and input
+    # Evaluate the loss function as computed mean square error (MSE) between target and
+    # input, then log its value
     loss = ((output - target_vec) ** 2).mean()
+    loss_progress.append(float(loss))
 
     # Perform backward step on loss to propogate gradients using autograd
     # NOTE: This implicitly passes a unit 'external gradient' to the backward pass
@@ -45,6 +48,11 @@ for epoch in range(n_iter + 1):
         print(f"\tloss:\n\t\t{loss}")
         print(f"\ttensor gradient:\n\t\t{scaling_tensor.grad}")
         print(f"\tscaling_tensor:\n\t\t{scaling_tensor}")
+
+# Write loss progress to file
+with open("losses_pytorch.dat", "w+") as floss:
+    for loss_val in loss_progress:
+        floss.write(f"{loss_val:9.4e}\n")
 
 print("Training complete.")
 print("Python optimizers example ran successfully")

--- a/examples/n_Optimizers/optimizers.py
+++ b/examples/n_Optimizers/optimizers.py
@@ -49,6 +49,9 @@ for epoch in range(n_iter + 1):
         print(f"\ttensor gradient:\n\t\t{scaling_tensor.grad}")
         print(f"\tscaling_tensor:\n\t\t{scaling_tensor}")
 
+# Check scaling tensor converges to the expected value
+assert scaling_tensor.allclose(torch.tensor([1.0, 2.0, 3.0, 4.0]), rtol=1e-3)
+
 # Write loss progress to file
 with open("losses_pytorch.dat", "w+") as floss:
     for loss_val in loss_progress:

--- a/examples/n_Optimizers/plot_losses.py
+++ b/examples/n_Optimizers/plot_losses.py
@@ -1,0 +1,19 @@
+"""Plot losses from optimizer example."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+with open("losses_pytorch.dat", "r") as f:
+    pytorch = [float(line) for line in f.readlines()]
+
+with open("losses_ftorch.dat", "r") as f:
+    ftorch = [float(line) for line in f.readlines()]
+
+fig, axes = plt.subplots()
+axes.loglog(np.arange(1, len(pytorch) + 1), pytorch, "--x", label="PyTorch")
+axes.loglog(np.arange(1, len(ftorch) + 1), ftorch, ":o", label="FTorch")
+axes.set_xlabel("Epoch")
+axes.set_ylabel("Loss")
+axes.legend()
+axes.grid()
+plt.savefig("losses.png", bbox_inches="tight")


### PR DESCRIPTION
Merges into #320.

This PR adds a few nice things for the optimisation example:
* Check both the Python and Fortran implementations converge to the expected array [1,2,3,4].
* Track the convergence of the loss function for both implementations and write these to files.
* Add a `ctest` check that the plotting script can be run and produces a PNG file.