### PR TITLE
Fig bug that made Fortran source is missing from the API docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,23 +10,22 @@ set -eo pipefail
 
 # ===================================================================
 
-if git rev-parse --verify HEAD >/dev/null 2>&1
-then
-	against=HEAD
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+  against=HEAD
 else
-	# Initial commit: diff against an empty tree object
-	against=$(git hash-object -t tree /dev/null)
+  # Initial commit: diff against an empty tree object
+  against=$(git hash-object -t tree /dev/null)
 fi
 
 # ===================================================================
 
 # Check that ftorch.90 is not modified and staged alone.
-git diff --cached --name-only | if grep --quiet "ftorch.f90"; then
+git diff --cached --name-only | if grep --quiet "ftorch.F90"; then
   git diff --cached --name-only | if ! grep --quiet "ftorch.fypp"; then
     cat <<\EOF
-Error: File ftorch.f90 has been modified and staged without ftorch.fypp being changed.
+Error: File ftorch.F90 has been modified and staged without ftorch.fypp being changed.
 ftorch.90 should be generated from ftorch.fypp using fypp.
-Please restore ftorch.f90 and make your modifications to ftorch.fypp instead.
+Please restore ftorch.F90 and make your modifications to ftorch.fypp instead.
 EOF
     exit 1
   fi
@@ -36,16 +35,16 @@ fi
 git diff --cached --name-only | if grep --quiet "ftorch.fypp"; then
 
   # Check that ftorch.90 is also modified and staged.
-  git diff --cached --name-only | if ! grep --quiet "ftorch.f90"; then
+  git diff --cached --name-only | if ! grep --quiet "ftorch.F90"; then
     cat <<\EOF
-Error: File ftorch.fypp has been modified and staged, but ftorch.f90 has not.
+Error: File ftorch.fypp has been modified and staged, but ftorch.F90 has not.
 ftorch.90 should be generated from ftorch.fypp and both committed together.
-Please run fypp on ftorch.fypp to generate ftorch.f90 and commit together.
+Please run fypp on ftorch.fypp to generate ftorch.F90 and commit together.
 EOF
     exit 1
   else
     # Check fypp available, and raise error and exit if not.
-    if ! command -v fypp &> /dev/null; then
+    if ! command -v fypp &>/dev/null; then
       cat <<\EOF
 echo "Error: Could not find fypp to run on ftorch.fypp.
 Please install fypp using "pip install fypp" and then try committing again.
@@ -54,16 +53,16 @@ EOF
     fi
 
     # If fypp is available and both .f90 and .fypp staged, check they match.
-    fypp src/ftorch.fypp src/ftorch.f90_tmp
-    if ! diff -q "src/ftorch.f90" "src/ftorch.f90_tmp" &> /dev/null; then
-      rm src/ftorch.f90_tmp
+    fypp src/ftorch.fypp src/ftorch.F90_tmp
+    if ! diff -q "src/ftorch.F90" "src/ftorch.F90_tmp" &>/dev/null; then
+      rm src/ftorch.F90_tmp
       cat <<\EOF
-Error: The code in ftorch.f90 does not match that expected from ftorch.fypp.
+Error: The code in ftorch.F90 does not match that expected from ftorch.fypp.
 Please re-run fypp on ftorch.fypp to ensure consistency before committing.
 EOF
       exit 1
     else
-      rm src/ftorch.f90_tmp
+      rm src/ftorch.F90_tmp
     fi
   fi
 fi

--- a/FTorch.md
+++ b/FTorch.md
@@ -20,6 +20,7 @@ macro: UNIX
        GPU_DEVICE_CUDA=1
        GPU_DEVICE_XPU=11
        GPU_DEVICE_MPS=12
+       GPU_DEVICE_HIP=1
 sort: alpha
 source: true
 graph: true

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -59,7 +59,7 @@ inside a Python virtual environment from the base FTorch directory.
 
 ### Fortran source and Fypp
 
-The Fortran source code for FTorch is contained in `src/ftorch.f90`.
+The Fortran source code for FTorch is contained in `src/ftorch.F90`.
 However, this file should not be edited directly, but instead generated from
 `src/ftorch.fypp`.
 This is a file that is set up to be run through the
@@ -73,7 +73,7 @@ Fypp is a pip-installable package that comes bundled with the [developer require
 
 To generate the Fortran code run:
 ```
-fypp src/ftorch.fypp src/ftorch.f90
+fypp src/ftorch.fypp src/ftorch.F90
 ```
 
 _Note: Generally it would be advisable to provide only the `.fypp` source code to

--- a/src/README.md
+++ b/src/README.md
@@ -26,5 +26,5 @@ For information on testing, see the [test subdirectory](test/README.md).
 
 * ctorch.cpp - Wrapper onto PyTorch for C++
 * ctorch.h   - Header file for C++ wrapper
-* ftorch.f90 - Wrapper onto PyTorch for Fortran
+* ftorch.F90 - Wrapper onto PyTorch for Fortran
 * CMakeLists.txt - Provides the CMake build system configuration


### PR DESCRIPTION
Fixes #394.

The issue was that we hadn't told Ford about the HIP macro but I've included other updates to refer to the correct `.F90` extension for the main module.

The fix works locally for me.