### PR TITLE
Move AOPP tutorial to presentation archive

### DIFF
--- a/FTorch.md
+++ b/FTorch.md
@@ -72,10 +72,6 @@ companion repository
 provides a set of exercises and solutions to help users get started with FTorch.
 Details of upcoming in-person training events are as follows:
 
-* FTorch developers Jack Atkinson and Joe Wallwork will be giving an FTorch
-  tutorial in the
-  [Department of Atmospheric, Oceanic, and Planetary Physics](https://www.physics.ox.ac.uk/research/subdepartment/atmospheric-oceanic-and-planetary-physics)
-  at the University of Oxford on 2nd July 2025.
 * The FTorch developers will be giving an FTorch tutorial at the
   [ICCS Summer School](https://iccs.cam.ac.uk/events/institute-computing-climate-science-annual-summer-school-2025)
   on 11th July 2025.

--- a/pages/presentations.md
+++ b/pages/presentations.md
@@ -49,7 +49,9 @@ workshops based on the companion repository
 [https://github.com/Cambridge-ICCS/FTorch-workshop](https://github.com/Cambridge-ICCS/FTorch-workshop)
 on the following occasions:
 
-* [ICCS Summer School](https://iccs.cam.ac.uk/events/institute-computing-climate-science-annual-summer-school-2024),
-  July 2024.
+* [Department of Atmospheric, Oceanic, and Planetary Physics](https://www.physics.ox.ac.uk/research/subdepartment/atmospheric-oceanic-and-planetary-physics)
+  at the University of Oxford.
 * [Durham HPC Days](https://www.durham.ac.uk/research/institutes-and-centres/data-science/events-/durham---hpc-days/),
   June 2025.
+* [ICCS Summer School](https://iccs.cam.ac.uk/events/institute-computing-climate-science-annual-summer-school-2024),
+  July 2024.


### PR DESCRIPTION
Moves the event from upcoming events to the presentation archive. Reorders past trainings in reverse order, consistently with the past talks.