### PR TITLE
Make FORD fail on warnings

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -27,6 +27,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Install Graphviz (Required by FORD)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
         with:

--- a/FTorch.md
+++ b/FTorch.md
@@ -15,6 +15,7 @@ extra_filetypes: c   //
                  h //
                  py  #
 preprocess: true
+dbg: false
 macro: UNIX
        GPU_DEVICE_NONE=0
        GPU_DEVICE_CUDA=1
@@ -117,7 +118,7 @@ distributed under an [MIT License which can be viewed here](page/LICENSE.html).
 Projects using FTorch
 ---------------------
 
-The following projects make use of FTorch.  
+The following projects make use of FTorch.<br>
 If you use our library in your work please let us know.
 
 * [DataWave CAM-GW](https://github.com/DataWaveProject/CAM/) -

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -237,3 +237,8 @@ by [Doxygen](https://www.doxygen.nl/index.html).
 
 Note that we need to define the macros for GPU devices that are passed to `ftorch.F90`
 via the C preprocessor in `FTorch.md` to match those in the CMakeLists.txt.
+
+If you are building documentation locally and wish FORD to continue when it encounters
+errors, you can change the `dbg` setting in the `FTorch.md` file to `true`. Note that
+in this case the documentation may build but be incomplete. Please pay close attention
+to the warnings.


### PR DESCRIPTION
Turns out by default FORD runs in a debug mode :upside_down_face:. 
So it prints a message to a console on some exceptions. 

Switching it off should make it fail. It is still draft since I want to test if the warning due to missing `graphviz` will also trip the build. 