### PR TITLE
Add cmake optional variable `MULTI_GPU` to switch `ON`/`OFF` 

### DIFF
--- a/.github/workflows/test_suite_ubuntu_cuda.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda.yml
@@ -1,0 +1,125 @@
+# Workflow to run the FTorch test suite on a CUDA enabled runner
+name: TestSuiteUbuntuCUDA
+
+# Controls when the workflow will run
+on:
+
+  # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
+  push:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/test_suite_ubuntu_cuda.yml'
+      # Library source files
+      - 'src/*.fypp'
+      - 'src/*.f90'
+      - 'src/*.F90'
+      - 'src/*.c'
+      - 'src/*.cpp'
+      - 'src/*.h'
+      # Unit tests
+      - 'test/unit/*.pf'
+      # Integration tests
+      - 'examples/**/*.py'
+      - 'examples/**/*.f90'
+      # Build system
+      - '**CMakeLists.txt'
+      - '**requirements.txt'
+
+  # TODO: remove, just here for testing!!
+  pull_request:
+    paths:
+      - '.github/workflows/test_suite_ubuntu_cuda.yml'
+  
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Workflow run - one or more jobs that can run sequentially or in parallel
+jobs:
+  test-suite-ubuntu-cuda:
+    # The type of runner that the job will run on
+    runs-on: GPU-runner
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout code
+        with:
+          persist-credentials: false
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PyTorch
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv ftorch
+          . ftorch/bin/activate
+          # CUDA v11.8 chosen as the GPU-runner has v12.4 installed (backward compatible)
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cu118
+
+      - name: Install cmake and NVIDIA dev toolkit
+        run: |
+          sudo apt update
+          sudo apt install -y cmake nvidia-cuda-toolkit
+
+        # Currently used by example7_mpi
+      - name: Install an MPI distribution
+        run: |
+          sudo apt install -y openmpi-bin openmpi-common libopenmpi-dev
+
+      - name: Install pFUnit
+        run: |
+          export FC=/usr/bin/gfortran
+          # TODO: Avoid version pinning (needed because version appears in install path)
+          git clone -b v4.12.0 https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          mkdir pFUnit/build
+          cd pFUnit/build
+          # MPI support is currently not needed for the unit testing
+          cmake .. -DSKIP_MPI=YES
+          make -j 4 install
+
+      - name: Build FTorch
+        run: |
+          . ftorch/bin/activate
+          VN=$(python -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
+          export Torch_DIR=${VIRTUAL_ENV}/lib/python${VN}/site-packages
+          export BUILD_DIR=$(pwd)/build
+          # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
+          export PFUNIT_DIR=$(pwd)/pFUnit/build/installed/PFUNIT-4.12
+          mkdir ${BUILD_DIR}
+          cd ${BUILD_DIR}
+          cmake .. \
+            -DPython_EXECUTABLE="$(which python)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${BUILD_DIR} \
+            -DCMAKE_BUILD_TESTS=TRUE \
+            -DGPU_DEVICE=CUDA \
+            -DMULTI_GPU=OFF \
+            -DCMAKE_PREFIX_PATH="${PFUNIT_DIR};${Torch_DIR}" \
+            -DCMAKE_Fortran_FLAGS="-std=f2008"
+          cmake --build .
+          cmake --install .
+
+      - name: Run unit tests
+        run: |
+          . ftorch/bin/activate
+          cd build
+          ctest --verbose --tests-regex unit
+
+      - name: Run integration tests
+        run: |
+          . ftorch/bin/activate
+          cd build
+          ctest --verbose --tests-regex example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,17 @@ else()
   message(SEND_ERROR "GPU_DEVICE '${GPU_DEVICE}' not recognised")
 endif()
 
+# If a GPU device is passed, specify if more than one is available This is used
+# to determine whether to run Multi GPU testing
+if(NOT "${GPU_DEVICE}" STREQUAL "NONE")
+  option(MULTI_GPU "Whether to enable Multi GPU testing (OFF [default], ON)"
+         OFF)
+else()
+  if(MULTI_GPU)
+    message(SEND_ERROR "Multi GPU turned ON but no GPU device specified")
+  endif()
+endif()
+
 # Other GPU specific setup
 include(CheckLanguage)
 if("${GPU_DEVICE}" STREQUAL "CUDA")
@@ -168,6 +179,10 @@ if(CMAKE_BUILD_TESTS)
   if(NOT DEFINED ENV{VIRTUAL_ENV})
     message(FATAL_ERROR
             "No Python virtual environment detected. Please activate one.")
+  endif()
+
+  if(MULTI_GPU)
+    message(STATUS "Building tests with Multi GPU support")
   endif()
 
   # Enable CTest

--- a/examples/6_MultiGPU/CMakeLists.txt
+++ b/examples/6_MultiGPU/CMakeLists.txt
@@ -66,26 +66,29 @@ if(CMAKE_BUILD_TESTS)
               cuda --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3a. Check the model can be loaded from file and run on two CUDA devices in
-    # Python and that its outputs meet expectations
-    add_test(
-      NAME example6_multigpu_infer_python
-      COMMAND ${Python_EXECUTABLE}
-              ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type cuda
-              --filepath ${PROJECT_BINARY_DIR}
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    if(MULTI_GPU)
+      # 3a. Check the model can be loaded from file and run on two CUDA devices
+      # in Python and that its outputs meet expectations
+      add_test(
+        NAME example6_multigpu_infer_python
+        COMMAND ${Python_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py
+                --device_type cuda
+                --filepath ${PROJECT_BINARY_DIR}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4a. Check the model can be loaded from file and run on two CUDA devices in
-    # Fortran and that its outputs meet expectations
-    add_test(
-      NAME example6_multigpu_infer_fortran
-      COMMAND multigpu_infer_fortran cuda
-              ${PROJECT_BINARY_DIR}/saved_multigpu_model_cuda.pt
-      # Command line arguments for device type and model file
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-    set_tests_properties(
-      example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-      "MultiGPU example ran successfully")
+      # 4a. Check the model can be loaded from file and run on two CUDA devices
+      # in Fortran and that its outputs meet expectations
+      add_test(
+        NAME example6_multigpu_infer_fortran
+        COMMAND multigpu_infer_fortran cuda
+                ${PROJECT_BINARY_DIR}/saved_multigpu_model_cuda.pt
+        # Command line arguments for device type and model file
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+      set_tests_properties(
+        example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+        "MultiGPU example ran successfully")
+    endif()
   endif()
 
   if("${GPU_DEVICE}" STREQUAL "HIP")
@@ -103,26 +106,28 @@ if(CMAKE_BUILD_TESTS)
               hip --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3b. Check the model can be loaded from file and run on two HIP devices in
-    # Python and that its outputs meet expectations
-    add_test(
-      NAME multigpu_infer_python
-      COMMAND ${Python_EXECUTABLE}
-              ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type hip
-              --filepath ${PROJECT_BINARY_DIR}
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    if(MULTI_GPU)
+      # 3b.Check the model can be loaded from file and run on two HIP devices in
+      # Python and that its outputs meet expectations
+      add_test(
+        NAME multigpu_infer_python
+        COMMAND ${Python_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type hip
+                --filepath ${PROJECT_BINARY_DIR}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4b. Check the model can be loaded from file and run on two HIP devices in
-    # Fortran and that its outputs meet expectations
-    add_test(
-      NAME multigpu_infer_fortran
-      COMMAND multigpu_infer_fortran hip
-              ${PROJECT_BINARY_DIR}/saved_multigpu_model_hip.pt
-      # Command line arguments for device type and model file
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-    set_tests_properties(
-      multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-                                        "MultiGPU example ran successfully")
+      # 4b.Check the model can be loaded from file and run on two HIP devices in
+      # Fortran and that its outputs meet expectations
+      add_test(
+        NAME multigpu_infer_fortran
+        COMMAND multigpu_infer_fortran hip
+                ${PROJECT_BINARY_DIR}/saved_multigpu_model_hip.pt
+        # Command line arguments for device type and model file
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+      set_tests_properties(
+        multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+                                          "MultiGPU example ran successfully")
+    endif()
   endif()
 
   if("${GPU_DEVICE}" STREQUAL "XPU")
@@ -140,26 +145,28 @@ if(CMAKE_BUILD_TESTS)
               xpu --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3b. Check the model can be loaded from file and run on two XPU devices in
-    # Python and that its outputs meet expectations
-    add_test(
-      NAME example6_multigpu_infer_python
-      COMMAND ${Python_EXECUTABLE}
-              ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type xpu
-              --filepath ${PROJECT_BINARY_DIR}
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    if(MULTI_GPU)
+      # 3b. Check the model can be loaded from file and run on two XPU devices
+      # in Python and that its outputs meet expectations
+      add_test(
+        NAME example6_multigpu_infer_python
+        COMMAND ${Python_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type xpu
+                --filepath ${PROJECT_BINARY_DIR}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4b. Check the model can be loaded from file and run on two XPU devices in
-    # Fortran and that its outputs meet expectations
-    add_test(
-      NAME example6_multigpu_infer_fortran
-      COMMAND multigpu_infer_fortran xpu
-              ${PROJECT_BINARY_DIR}/saved_multigpu_model_xpu.pt
-      # Command line arguments for device type and model file
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-    set_tests_properties(
-      example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-      "MultiGPU example ran successfully")
+      # 4b. Check the model can be loaded from file and run on two XPU devices
+      # in Fortran and that its outputs meet expectations
+      add_test(
+        NAME example6_multigpu_infer_fortran
+        COMMAND multigpu_infer_fortran xpu
+                ${PROJECT_BINARY_DIR}/saved_multigpu_model_xpu.pt
+        # Command line arguments for device type and model file
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+      set_tests_properties(
+        example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+        "MultiGPU example ran successfully")
+    endif()
   endif()
 
   if("${GPU_DEVICE}" STREQUAL "MPS")
@@ -176,25 +183,27 @@ if(CMAKE_BUILD_TESTS)
               mps --filepath ${PROJECT_BINARY_DIR}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 3c. Check the model can be loaded from file and run on one MPS device in
-    # Python and that its outputs meet expectations
-    add_test(
-      NAME example6_multigpu_infer_python
-      COMMAND ${Python_EXECUTABLE}
-              ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type mps
-              --filepath ${PROJECT_BINARY_DIR}
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    if(MULTI_GPU)
+      # 3c. Check the model can be loaded from file and run on one MPS device in
+      # Python and that its outputs meet expectations
+      add_test(
+        NAME example6_multigpu_infer_python
+        COMMAND ${Python_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/multigpu_infer_python.py --device_type mps
+                --filepath ${PROJECT_BINARY_DIR}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-    # 4c. Check the model can be loaded from file and run on one MPS device in
-    # Fortran and that its outputs meet expectations
-    add_test(
-      NAME example6_multigpu_infer_fortran
-      COMMAND multigpu_infer_fortran mps
-              ${PROJECT_BINARY_DIR}/saved_multigpu_model_mps.pt
-      # Command line arguments for device type and model file
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-    set_tests_properties(
-      example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
-      "MultiGPU example ran successfully")
+      # 4c. Check the model can be loaded from file and run on one MPS device in
+      # Fortran and that its outputs meet expectations
+      add_test(
+        NAME example6_multigpu_infer_fortran
+        COMMAND multigpu_infer_fortran mps
+                ${PROJECT_BINARY_DIR}/saved_multigpu_model_mps.pt
+        # Command line arguments for device type and model file
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+      set_tests_properties(
+        example6_multigpu_infer_fortran PROPERTIES PASS_REGULAR_EXPRESSION
+        "MultiGPU example ran successfully")
+    endif()
   endif()
 endif()


### PR DESCRIPTION
The need for this was prompted by #410 since the runner used to do the GPU testing offers just 1 GPU.

**Note**: This would change the build behavior as building MultiGPU integration tests now explicitely requires setting `MULTI_GPU=ON`
- [ ] Consider whether to change default behavior, i.e. OFF by default
- [ ] Add changes made by this PR to the docs