### PR TITLE
[WIP] Permute shape in torch_tensor_from_blob

### DIFF
--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -349,7 +349,7 @@ contains
   !  This routine will take an (i, j, k) array and return an (k, j, i) tensor.
   subroutine torch_tensor_from_blob(tensor, data, ndims, tensor_shape, layout, dtype, &
                                     device_type, device_index, &
-                                    requires_grad)
+                                    requires_grad, permute_shape)
     use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_ptr
     type(torch_tensor), intent(out) :: tensor     !! Returned tensor
     type(c_ptr), intent(in)         :: data       !! Pointer to data
@@ -360,26 +360,14 @@ contains
     integer(c_int), intent(in)      :: device_type  !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in)   :: permute_shape  !! Whether to permute the shape ('transpose') to match the `layout`
 
     integer(c_int)                  :: i                    !! loop index
+    integer(c_int64_t)              :: torch_shape(size(tensor_shape))       !! Shape of the tensor in torch based on `layout`
     integer(c_int64_t)              :: strides(ndims)       !! Strides for accessing data
     integer(c_int)                  :: device_index_value   !! device index used
     logical(c_bool)                 :: requires_grad_value  !! Whether gradients need to be computed for the created tensor
-
-    if (.not. present(requires_grad)) then
-      requires_grad_value = logical(.false., c_bool)
-    else
-      requires_grad_value = requires_grad
-    end if
-
-    strides(:) = 0
-    do i = 1, ndims
-      if (i == 1) then
-        strides(layout(i)) = 1
-      else
-        strides(layout(i)) = strides(layout(i - 1)) * tensor_shape(layout(i - 1))
-      end if
-    end do
+    logical                         :: permute_shape_value  !! Whether to permute the shape ('transpose') to match the `layout`
 
     ! Process optional arguments
     if (present(device_index)) then
@@ -390,7 +378,39 @@ contains
       device_index_value = 0
     endif
 
-    tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype,    &
+    if (.not. present(requires_grad)) then
+      requires_grad_value = logical(.false., c_bool)
+    else
+      requires_grad_value = requires_grad
+    end if
+
+    if (.not. present(permute_shape)) then
+      permute_shape_value = .false.
+    else
+      permute_shape_value = permute_shape
+    end if
+
+    if (permute_shape_value) then
+      ! Permute shape of torch tensor to match layout requested ('transpose')
+      do i = 1, ndims
+          torch_shape(i) = tensor_shape(layout(i))
+      end do
+    else
+      ! Keep shape same as fortran despite permuting indices
+      torch_shape = tensor_shape
+    end if
+
+    ! Set strides to populate elements based on torch shape and layout
+    strides(:) = 0
+    do i = 1, ndims
+      if (i == 1) then
+        strides(layout(i)) = 1
+      else
+        strides(layout(i)) = strides(layout(i - 1)) * torch_shape(layout(i - 1))
+      end if
+    end do
+
+    tensor%p = torch_from_blob_c(data, ndims, torch_shape, strides, dtype,    &
                                  device_type, device_index_value,              &
                                  requires_grad_value)
   end subroutine torch_tensor_from_blob
@@ -399,7 +419,8 @@ contains
   #:for RANK in RANKS
   !> Return a Torch tensor pointing to data_in array of rank ${RANK}$ containing data of type `${PREC}$`
   subroutine torch_tensor_from_array_${PREC}$_${RANK}$d(tensor, data_in, layout, &
-                                                        device_type, device_index, requires_grad)
+                                                        device_type, device_index, &
+                                                        requires_grad, permute_shape)
     use, intrinsic :: iso_c_binding, only : c_bool, c_int, c_int64_t, c_loc
     use, intrinsic :: iso_fortran_env, only : ${PREC}$
 
@@ -412,6 +433,7 @@ contains
     integer(c_int), intent(in)    :: device_type    !! Device type the tensor will live on (`torch_kCPU` or `torch_kCUDA`)
     integer, optional, intent(in) :: device_index   !! Device index to use for `torch_kCUDA` case
     logical, optional, intent(in) :: requires_grad  !! Whether gradients need to be computed for the created tensor
+    logical, optional, intent(in) :: permute_shape  !! Whether to permute the shape ('transpose') to match the `layout`
 
     ! local data
     integer(c_int64_t)        :: tensor_shape(${RANK}$)            !! Shape of the tensor
@@ -422,7 +444,7 @@ contains
 
     call torch_tensor_from_blob(tensor, c_loc(data_in), ndims, tensor_shape, &
                                 layout, dtype, device_type, device_index, &
-                                requires_grad)
+                                requires_grad, permute_shape)
 
   end subroutine torch_tensor_from_array_${PREC}$_${RANK}$d
 
@@ -453,14 +475,17 @@ contains
     ! local data
     integer(ftorch_int)       :: layout(${RANK}$)  !! Order of indices
     integer(c_int), parameter :: ndims = ${RANK}$  !! Number of dimension of input data
+    logical, parameter        :: permute_shape = .false.  !! default layout requires option permute_shape false
     integer :: i
 
     ! Set the default tensor layout
+    ! `permute shape` also set as parameter `.false.` for explicit intent
     do i = 1, ndims
       layout(i) = i
     end do
 
-    call torch_tensor_from_array(tensor, data_in, layout, device_type, device_index, requires_grad)
+    call torch_tensor_from_array(tensor, data_in, layout, device_type, device_index, &
+                                 requires_grad, permute_shape)
 
   end subroutine torch_tensor_from_array_${PREC}$_${RANK}$d_default_layout
 


### PR DESCRIPTION
Exploring the functionality of layout following query raised in #412 

The aim is to generate row-major tensors with a 'transposed' shape when layout `[n, n-1, ..., 2, 1]` is passed.

To make this backwards-compatible (non-breaking) I have added a `permute_shape` argument.

However, there could be some debate about making this the default, since `permute_shape=.false.` with a non-monotonically increasing `layout` arguably produces a 'useless' tensor (see impending description below).
It is arguably the expectation of the user (principle of least surprise) that the use of layout should 'transpose' the shape as well as the indexing.

This is complicated by the fact we use an ambiguous example in the  [docs](https://cambridge-iccs.github.io/FTorch/page/transposing.html) (section 3) with a 2x2 array where the result of both operations is identical.

IIRC this was always the original intent (though users always had to be explicit when passing the desired shape in) but perhaps got lost in changes to move away from separate `Fortran` and `C` routines and abstracting details from users that occurred before we had explicit tests to catch this sort of thing.

TODO:

- [x] Make proposed change in code
- [x] Check existing tests pass unaffected
- [ ] Write tests to check for correct row-major tensors in Torch generated from Fortran transpose with `layout = [2, 1]` and `permute_shape=.true.`
- [x] Add explanation here of working to explore this issue
- [ ] Check that this correctly performs what is (arguably) described in the [docs](https://cambridge-iccs.github.io/FTorch/page/transposing.html) (section 3) and is perhaps expected.
- [ ] Discuss what the default value of `permute_shape` should be (see above)
- [ ] Improve documentation with clear examples
- [ ] Add changelog
- [ ] Make minor version release

There is perhaps some discussion to be had around "should we require users to transpose the data themselves before calling this routine, as is the current implementation, or should we instead make the Fortran transpose part of the internals?"\
I.e. providing `torch_tensor_from_array()` instead with a `row-major=.true.` argument that will perform the Fortran transpose (`[m, n] -> [n, m]`) and then calculate appropriate shape (`[m, n]`) and strides (`[n, 1]`) to appear in the same in Torch as it does in Fortran.