### PR TITLE
fix a minor bug

### DIFF
--- a/examples/3_ResNet/resnet_infer_python.py
+++ b/examples/3_ResNet/resnet_infer_python.py
@@ -96,6 +96,7 @@ if __name__ == "__main__":
 
     batch_size_to_run = 1
 
-    result = deploy(saved_model_file, device_to_run, batch_size_to_run)
+    with torch.no_grad():
+        result = deploy(saved_model_file, device_to_run, batch_size_to_run)
     print_top_results(result)
     check_results(result)


### PR DESCRIPTION
fix: prevent gradient calculation in inference mode

Add torch.no_grad() context manager to the model inference step
to avoid unnecessary computation and memory usage.