### PR TITLE
Permute view

### DIFF
--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -376,6 +376,22 @@ void torch_tensor_to(const torch_tensor_t source_tensor, torch_tensor_t target_t
 // --- Operator overloads acting on tensors
 // =====================================================================================
 
+void torch_tensor_shallow_copy(torch_tensor_t *to, const torch_tensor_t from) {
+  auto to_tensor = reinterpret_cast<torch::Tensor *>(*to);
+  auto from_tensor = reinterpret_cast<torch::Tensor *>(from);
+
+  validate_tensor(from_tensor, "from");
+  if (!to_tensor) {
+    to_tensor = new torch::Tensor();
+  }
+
+  // Copy Tensors
+  *to_tensor = *from_tensor;
+
+  // Update lhs pointer value
+  *to = to_tensor;
+}
+
 void torch_tensor_assign(torch_tensor_t output, const torch_tensor_t input) {
   auto out = reinterpret_cast<torch::Tensor *>(output);
   auto in = reinterpret_cast<torch::Tensor *const>(input);

--- a/src/ctorch.cpp
+++ b/src/ctorch.cpp
@@ -8,6 +8,8 @@
 
 #include "ctorch.h"
 
+#include <sstream>
+
 #ifndef GPU_DEVICE
 #define GPU_DEVICE GPU_DEVICE_NONE
 #endif
@@ -30,6 +32,19 @@ void ctorch_error(const std::string &message,
 void ctorch_warn(const std::string &message) {
   std::cerr << "[WARNING]: " << message << std::endl;
 }
+
+void assert_not_nullptr(const void *ptr, const char *variable_name) {
+  if (!ptr) {
+    std::stringstream ss;
+    ss << "Pointer " << variable_name << "cannot be null\n";
+    ctorch_error(ss.str());
+  }
+}
+
+/**
+ * Raise `ctorch_error` if the expression evaluates to a NULL ptr
+ */
+#define CTORCH_ASSERT_NOT_NULLPTR(ptr) assert_not_nullptr(ptr, #ptr)
 
 // =============================================================================
 // --- Constant expressions
@@ -370,6 +385,30 @@ void torch_tensor_to(const torch_tensor_t source_tensor, torch_tensor_t target_t
   // For non-blocking usage see:
   // https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html
   std::move(*target_tens) = source_tens->to(device_type, dtype, non_blocking);
+}
+
+// =============================================================================
+// --- Tensor view functions
+// =============================================================================
+
+torch_tensor_t torch_tensor_permute(const torch_tensor_t self, const int64_t dims[]) {
+  auto t = reinterpret_cast<const torch::Tensor *>(self);
+  validate_tensor(t, "self");
+
+  CTORCH_ASSERT_NOT_NULLPTR(dims);
+
+  // `dim()` method of the tensor returns a signed int64, but ArrayRef requires
+  // unsigned std::size_t. Since dimensions of a tensor are never negative the cast
+  // is safe... unless we are on a system where 64bit is not used for size_t.
+  static_assert(sizeof(int64_t) == sizeof(std::size_t),
+                "CTorch has an assumption that `size_t` is 64bit to safely cast "
+                "between `int64` and `size_t`. This should be the case for most modern "
+                "64bit systems. If you are running into this problem when "
+                "compiling FTorch please open an Issue so we can fix this!");
+  const auto dims_arrayref = at::IntArrayRef{dims, static_cast<std::size_t>(t->dim())};
+
+  auto *out = new torch::Tensor(at::permute(*t, dims_arrayref));
+  return out;
 }
 
 // =====================================================================================

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -199,6 +199,18 @@ EXPORT_C void torch_tensor_to(const torch_tensor_t source_tensor,
 // =============================================================================
 
 /**
+ * Shallow copy a tensor
+ *
+ * Mimics the semantics of `libtorch` assignments to lvalues.
+ * At the end `to` and `from` will use (alias) the same underlying data
+ *
+ * @param to will be associated to a shallow copy of `from`
+ * @param from source
+ *
+ */
+EXPORT_C void torch_tensor_shallow_copy(torch_tensor_t* to, const torch_tensor_t from);
+
+/**
  * Overloads the assignment operator for Torch Tensor
  * @param output Tensor
  * @param input Tensor

--- a/src/ctorch.h
+++ b/src/ctorch.h
@@ -195,6 +195,24 @@ EXPORT_C void torch_tensor_to(const torch_tensor_t source_tensor,
                               torch_tensor_t target_tensor, bool non_blocking);
 
 // =============================================================================
+// --- Tensor view functions
+// =============================================================================
+
+/**
+ * Return a permuted View of the tensor
+ * @param self Source Torch tensor
+ * @param dims Array indicating the new indexing, 0-indexed e.g [2,1,0]. The size
+ *   of the array is not checked. Must be at least equal to the dimensions of `self`
+ *
+ * @return A new Tensor view (sharing underlying memory with `self`)
+ *
+ * @note This function creates a new tensor. Don't forget to free it as well as
+ *   the original to avoid leaking memory!
+ */
+EXPORT_C torch_tensor_t torch_tensor_permute(const torch_tensor_t self,
+                                             const int64_t dims[]);
+
+// =============================================================================
 // --- Operator overloads acting on tensors
 // =============================================================================
 
@@ -208,7 +226,7 @@ EXPORT_C void torch_tensor_to(const torch_tensor_t source_tensor,
  * @param from source
  *
  */
-EXPORT_C void torch_tensor_shallow_copy(torch_tensor_t* to, const torch_tensor_t from);
+EXPORT_C void torch_tensor_shallow_copy(torch_tensor_t *to, const torch_tensor_t from);
 
 /**
  * Overloads the assignment operator for Torch Tensor

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2483,6 +2483,67 @@ contains
   end subroutine torch_tensor_to
 
   ! ============================================================================
+  ! --- Tensor view functions
+  ! ============================================================================
+
+
+  !>
+  !> Return a permuted tensor view
+  !>
+  !> @note
+  !> The `dims` are specified using a 1-based indexing to be consistent
+  !> with Fortran conventions. However, as in PyTorch negative values are also
+  !> allowed to specifiy dimensions counting from the end!
+  !>
+  !> As the result one needs to pay attention to the dimension `0`!
+  !>
+  !>   - In Python: `0` indicates the first dimension
+  !>   - In FTorch: `0` indicates the last dimension
+  !> @endnote
+  !>
+  function torch_tensor_permute(tensor, dims) result(out)
+    use, intrinsic :: iso_c_binding, only : c_int64_t, c_associated
+    type(torch_tensor), intent(in) :: tensor    !! Tensor to permute
+    integer(ftorch_int), intent(in) :: dims(:)  !! New ordering of dimensions
+    type(torch_tensor) :: out                   !! Permuted tensor view
+    integer(c_int64_t) :: dims_c(size(dims))
+
+    interface
+      function torch_tensor_permute_c(tensor_c, dims_c) result(out_c) &
+        bind(c, name = 'torch_tensor_permute')
+        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor_c
+        integer(c_int64_t), intent(in) :: dims_c(*)
+        type(c_ptr) :: out_c
+      end function torch_tensor_permute_c
+    end interface
+
+    ! Check preconditions
+    if (.not. c_associated(tensor%p)) then
+      write(*,*) "Error :: tensor must be constructed before permuting dimensions"
+      stop 1
+    end if
+
+    if (size(dims) /= tensor % get_rank()) then
+      write(*, *) "Error :: number of dimensions: ", size(dims), &
+        " in dims must match rank of tensor: ", tensor % get_rank()
+      stop 1
+    end if
+
+    ! Convert the dims specifiers from 1 to 0 indexing
+    ! Don't forget that the negative values are allowed
+    where (dims <= 0)
+      dims_c = tensor % get_rank() + dims - 1
+    elsewhere
+      dims_c = dims - 1
+    end where
+
+    out%p = torch_tensor_permute_c(tensor%p, dims_c)
+
+  end function torch_tensor_permute
+
+  ! ============================================================================
   ! --- Overloaded operators acting on tensors
   ! ============================================================================
 

--- a/src/ftorch.F90
+++ b/src/ftorch.F90
@@ -2486,6 +2486,27 @@ contains
   ! --- Overloaded operators acting on tensors
   ! ============================================================================
 
+  !> Makes a shallow copy of a tensor
+  !>
+  !> Mimics more Python-like assigment behaviour where `b = a` makes `b` point
+  !> to the same underlying data as `a`.
+  subroutine torch_tensor_shallow_copy(to, from)
+    type(torch_tensor), intent(out) :: to !! target
+    type(torch_tensor), intent(in) :: from !! source
+
+    interface
+      subroutine torch_tensor_shallow_copy_c(output_c, input_c) &
+        bind(c, name = 'torch_tensor_shallow_copy')
+        use, intrinsic :: iso_c_binding, only : c_ptr
+        implicit none
+        type(c_ptr), intent(inout) :: output_c
+        type(c_ptr), value, intent(in) :: input_c
+      end subroutine torch_tensor_shallow_copy_c
+    end interface
+    call torch_tensor_shallow_copy_c(to%p, from%p)
+
+  end subroutine torch_tensor_shallow_copy
+
   !> Overloads assignment operator for tensors.
   subroutine torch_tensor_assign(output, input)
     use, intrinsic :: iso_c_binding, only : c_associated

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -749,6 +749,27 @@ contains
   ! --- Overloaded operators acting on tensors
   ! ============================================================================
 
+  !> Makes a shallow copy of a tensor
+  !>
+  !> Mimics more Python-like assigment behaviour where `b = a` makes `b` point
+  !> to the same underlying data as `a`.
+  subroutine torch_tensor_shallow_copy(to, from)
+    type(torch_tensor), intent(out) :: to !! target
+    type(torch_tensor), intent(in) :: from !! source
+
+    interface
+      subroutine torch_tensor_shallow_copy_c(output_c, input_c) &
+        bind(c, name = 'torch_tensor_shallow_copy')
+        use, intrinsic :: iso_c_binding, only : c_ptr
+        implicit none
+        type(c_ptr), intent(inout) :: output_c
+        type(c_ptr), value, intent(in) :: input_c
+      end subroutine torch_tensor_shallow_copy_c
+    end interface
+    call torch_tensor_shallow_copy_c(to%p, from%p)
+
+  end subroutine torch_tensor_shallow_copy
+
   !> Overloads assignment operator for tensors.
   subroutine torch_tensor_assign(output, input)
     use, intrinsic :: iso_c_binding, only : c_associated

--- a/src/ftorch.fypp
+++ b/src/ftorch.fypp
@@ -746,6 +746,67 @@ contains
   end subroutine torch_tensor_to
 
   ! ============================================================================
+  ! --- Tensor view functions
+  ! ============================================================================
+
+
+  !>
+  !> Return a permuted tensor view
+  !>
+  !> @note
+  !> The `dims` are specified using a 1-based indexing to be consistent
+  !> with Fortran conventions. However, as in PyTorch negative values are also
+  !> allowed to specifiy dimensions counting from the end!
+  !>
+  !> As the result one needs to pay attention to the dimension `0`!
+  !>
+  !>   - In Python: `0` indicates the first dimension
+  !>   - In FTorch: `0` indicates the last dimension
+  !> @endnote
+  !>
+  function torch_tensor_permute(tensor, dims) result(out)
+    use, intrinsic :: iso_c_binding, only : c_int64_t, c_associated
+    type(torch_tensor), intent(in) :: tensor    !! Tensor to permute
+    integer(ftorch_int), intent(in) :: dims(:)  !! New ordering of dimensions
+    type(torch_tensor) :: out                   !! Permuted tensor view
+    integer(c_int64_t) :: dims_c(size(dims))
+
+    interface
+      function torch_tensor_permute_c(tensor_c, dims_c) result(out_c) &
+        bind(c, name = 'torch_tensor_permute')
+        use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+        implicit none
+        type(c_ptr), value, intent(in) :: tensor_c
+        integer(c_int64_t), intent(in) :: dims_c(*)
+        type(c_ptr) :: out_c
+      end function torch_tensor_permute_c
+    end interface
+
+    ! Check preconditions
+    if (.not. c_associated(tensor%p)) then
+      write(*,*) "Error :: tensor must be constructed before permuting dimensions"
+      stop 1
+    end if
+
+    if (size(dims) /= tensor % get_rank()) then
+      write(*, *) "Error :: number of dimensions: ", size(dims), &
+        " in dims must match rank of tensor: ", tensor % get_rank()
+      stop 1
+    end if
+
+    ! Convert the dims specifiers from 1 to 0 indexing
+    ! Don't forget that the negative values are allowed
+    where (dims <= 0)
+      dims_c = tensor % get_rank() + dims - 1
+    elsewhere
+      dims_c = dims - 1
+    end where
+
+    out%p = torch_tensor_permute_c(tensor%p, dims_c)
+
+  end function torch_tensor_permute
+
+  ! ============================================================================
   ! --- Overloaded operators acting on tensors
   ! ============================================================================
 

--- a/test/unit/unittest_tensor_manipulation.pf
+++ b/test/unit/unittest_tensor_manipulation.pf
@@ -80,4 +80,42 @@ contains
 
   end subroutine test_tensor_shallow_copy
 
+  @test
+  subroutine test_tensor_permute()
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use ftorch, only: torch_tensor_permute, torch_tensor_shallow_copy
+
+    type(torch_tensor) :: original, permuted, out
+    real(wp), dimension(2,3), target :: in_data
+    real(wp), dimension(3,2), target :: out_data
+    integer, dimension(2) :: dims
+    logical :: test_pass
+
+    ! Original tensor backed by Fortran array
+    in_data = reshape([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, 6.0_wp], [2, 3])
+    call torch_tensor_from_array(original, in_data, device_type)
+
+    ! We apply transpose by permutation using positive indices
+    dims = [2, 1]
+    call torch_tensor_shallow_copy(permuted, torch_tensor_permute(original, dims))
+
+    ! Output tensor backed by another Fortran array
+    call torch_tensor_from_array(out, out_data, device_type)
+
+    ! We copy the data from the permuted view
+    ! It should fail is the shape is mismatched
+    out = permuted
+
+    @assertTrue( assert_allclose(out_data, transpose(in_data), test_name="test_tensor_permute") )
+
+    ! We reverse the transposition by applying it with negative indices
+    dims = [0, -1]
+    call torch_tensor_shallow_copy(permuted, torch_tensor_permute(out, dims))
+
+    original = permuted
+    @assertTrue( assert_allclose(in_data, transpose(out_data), test_name="test_tensor_permute") )
+
+
+  end subroutine test_tensor_permute
+
 end module unittest_tensor_manipulation

--- a/test/unit/unittest_tensor_manipulation.pf
+++ b/test/unit/unittest_tensor_manipulation.pf
@@ -52,4 +52,32 @@ contains
 
   end subroutine test_torch_tensor_zero
 
+  @test
+  subroutine test_tensor_shallow_copy()
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use ftorch, only: torch_tensor_shallow_copy
+
+    type(torch_tensor) :: original, copy,  out
+    real(wp), dimension(2,3), target :: in_data
+    real(wp), dimension(2,3), target :: out_data
+
+
+    ! Original tensor backed by Fortran array
+    in_data = reshape([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, 6.0_wp], [2, 3])
+    call torch_tensor_from_array(original, in_data, device_type)
+
+    ! Another view of the original tensor
+    call torch_tensor_shallow_copy(copy, original)
+
+    ! Output tensor backed by another Fortran array
+    call torch_tensor_from_array(out, out_data, device_type)
+
+    in_data = 2.0_wp * in_data
+
+    out = copy
+
+    @assertTrue( assert_allclose(out_data, in_data, test_name="test_tensor_shallow_copy") )
+
+  end subroutine test_tensor_shallow_copy
+
 end module unittest_tensor_manipulation


### PR DESCRIPTION
Add a binding for the `permute` function so one can create permuted views of a tensor. 

I believe it is a desired feature to resolve #157 since to use batching, on the Fortran side one would like to organise the data such that the batch dimension is the rightmost one (to avoid scattering data for a single datapoint(?) in a batch across memory). However, the `pytorch` assumes the leftmost dimension is the batch dimension. Hence some sort of permutation is required to make the two conventions agree. 

One could probably do the required permutation on the tensor constructor using the changes in #415, but I had a feeling that having an explicit option to make new, permuted views after construction will not hurt. 

The side effect is that I had to add another 'assignment'  function to mimic what would happen on assignment in Python (I think!) or when `libtorch` does assignment to an lvalue i.e. make shallow copy of the tensor.

Will address the todo below after we agree that we are sure we want these features ;-) 

Todo: 
- [ ] Update changelog 
- [ ] Add additional tests to assert `requires_grad` is propagated correctly
- [ ] Add user-facing (web) documentation and example in `Example 1`