### PR TITLE
Update presentations

### DIFF
--- a/FTorch.md
+++ b/FTorch.md
@@ -85,6 +85,9 @@ Select Presentations
 
 The following presentations contain information about FTorch:
 
+* FTorch: Facilitating Hybrid Modelling<br>
+  N8-CIR Seminar, Leeds - July 2025<br>
+  [Slides](https://jackatkinson.net/slides/Leeds-N8-FTorch) - [Recording](https://www.youtube.com/watch?v=je7St0t_W9A)
 * Facilitating machine learning in Fortran using FTorch<br>
   Seminars at the University of Reading
   [Data Assimilation Research Centre](https://research.reading.ac.uk/met-darc/news-and-events/darc-seminar-series/)
@@ -98,12 +101,6 @@ The following presentations contain information about FTorch:
 * Coupling Machine Learning to Numerical (Climate) Models<br>
   Platform for Advanced Scientific Computing, Zurich - June 2024<br>
   [Slides](https://jackatkinson.net/slides/PASC24)
-* Blending Machine Learning and Numerical Simulation, with Applications to Climate Modelling<br>
-  Durham HPC days, Durham - May 2024<br>
-  [Slides](https://jackatkinson.net/slides/HPC_Durham_2024)
-* Reducing the overheads for coupling PyTorch machine learning models to Fortran<br>
-  ML & DL Seminars, LSCE, IPSL, Paris - November 2023<br>
-  [Slides](https://jackatkinson.net/slides/IPSL_FTorch) - [Recording](https://www.youtube.com/watch?v=-NJGuV6Rz6U)
 
 See the [presentations](page/presentations.html) page for a full list of
 presentations on FTorch.

--- a/README.md
+++ b/README.md
@@ -58,18 +58,12 @@ call torch_model_forward(model, model_input_arr, model_output_arr)
 
 The following presentations provide an introduction and overview of _FTorch_:
 
+* FTorch: Facilitating Hybrid Modelling\
+  N8-CIR Seminar, Leeds - July 2025\
+  [Slides](https://jackatkinson.net/slides/Leeds-N8-FTorch) - [Recording](https://www.youtube.com/watch?v=je7St0t_W9A)
 * Coupling Machine Learning to Numerical (Climate) Models\
   Platform for Advanced Scientific Computing, Zurich - June 2024\
   [Slides](https://jackatkinson.net/slides/PASC24)
-* Blending Machine Learning and Numerical Simulation, with Applications to Climate Modelling\
-  Durham HPC days, Durham - May 2024\
-  [Slides](https://jackatkinson.net/slides/HPC_Durham_2024)
-* Reducing the overheads for coupling PyTorch machine learning models to Fortran\
-  ML & DL Seminars, LSCE, IPSL, Paris - November 2023\
-  [Slides](https://jackatkinson.net/slides/IPSL_FTorch) - [Recording](https://www.youtube.com/watch?v=-NJGuV6Rz6U)
-* Reducing the Overhead of Coupled Machine Learning Models between Python and Fortran\
-  RSECon23, Swansea - September 2023\
-  [Slides](https://jackatkinson.net/slides/RSECon23) - [Recording](https://www.youtube.com/watch?v=Ei6H_BoQ7g4&list=PL27mQJy8eDHmibt_aL3M68x-4gnXpxvZP&index=33)
 
 If you are interested in using this library please get in touch.
 

--- a/pages/presentations.md
+++ b/pages/presentations.md
@@ -7,6 +7,9 @@ title: Presentations
 The following presentations contain information about FTorch and its
 applications:
 
+* FTorch: Facilitating Hybrid Modelling<br>
+  N8-CIR Seminar, Leeds - July 2025<br>
+  [Slides](https://jackatkinson.net/slides/Leeds-N8-FTorch) - [Recording](https://www.youtube.com/watch?v=je7St0t_W9A)
 * FTorch - Facilitating Hybrid Modelling<br>
   Seminar at the [Department of Atmospheric, Oceanic, and Planetary Physics](https://www.physics.ox.ac.uk/research/subdepartment/atmospheric-oceanic-and-planetary-physics)
   at the University of Oxford<br>
@@ -62,3 +65,8 @@ on the following occasions:
   June 2025.
 * [ICCS Summer School](https://iccs.cam.ac.uk/events/institute-computing-climate-science-annual-summer-school-2024),
   July 2024.
+
+## Past Events
+
+* [Cambridge Hybrid Modelling Workshop](https://cambridge-iccs.github.io/ml-coupling-workshop/) - 3rd-4th September 2025<br>
+  FTorch developers Jack atkinson and Joe Wallwork hosted a workshop on hybrid modelling developments and challenges in Cambridge with support from [C2D3](https://www.c2d3.cam.ac.uk/) and [Accelerate](https://science.ai.cam.ac.uk/).


### PR DESCRIPTION
I added the latest talk I did at the N8-CIR as it also has a recording.

I also took the opportunity to remove some older seminars as these contain older details about the code, older API examples, and were just adding clutter to the README. People are only likely to click on 1 or 2 slide decks really.