### PR TITLE
to() method in tuple is not supported in example 4

### DIFF
--- a/examples/4_MultiIO/multiionet_infer_python.py
+++ b/examples/4_MultiIO/multiionet_infer_python.py
@@ -39,9 +39,9 @@ def deploy(saved_model: str, device: str, batch_size: int = 1) -> torch.Tensor:
         # loaded onto CPU, and then are moved to the devices they were saved
         # from, so we don't need to manually transfer the model to the GPU
         model = torch.jit.load(saved_model)
-        input_tensors_gpu = input_tensors.to(torch.device("cuda"))
+        input_tensors_gpu = [input_tensor.to(torch.device("cuda")) for input_tensor in input_tensors]
         outputs_gpu = model.forward(*input_tensors_gpu)
-        outputs = outputs_gpu.to(torch.device("cpu"))
+        outputs = [output_gpu.to(torch.device("cpu")) for output_gpu in outputs_gpu]
 
     else:
         device_error = f"Device '{device}' not recognised."

--- a/examples/4_MultiIO/pt2ts.py
+++ b/examples/4_MultiIO/pt2ts.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
             device = torch.device(device_type)
         trained_model = trained_model.to(device)
         trained_model.eval()
-        trained_model_dummy_inputs = trained_model_dummy_inputs.to(device)
+        trained_model_dummy_inputs = [trained_model_dummy_input.to(device) for trained_model_dummy_input in trained_model_dummy_inputs]
 
     # FTORCH-TODO
     # Run model for dummy inputs


### PR DESCRIPTION
No "to" attribute exist in tuple object in example 4. Unit tests don‘t complain this since only CPU backend is tested. Suggest add more examples with GPU enabled.