### PR TITLE
Prevent fatal error from being thrown during cmake examples

### DIFF
--- a/examples/2_SimpleNet/CMakeLists.txt
+++ b/examples/2_SimpleNet/CMakeLists.txt
@@ -19,7 +19,7 @@ message(STATUS "Building with Fortran PyTorch coupling")
 
 # Install Python dependencies
 find_package(Python COMPONENTS Interpreter REQUIRED)
-if(NOT DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+if(NOT DEFINED ENV{VIRTUAL_ENV} AND NOT DEFINED ENV{CONDA_PREFIX})
   message(FATAL_ERROR "Please activate your virtualenv or conda environment")
 endif()
 execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r

--- a/examples/3_ResNet/CMakeLists.txt
+++ b/examples/3_ResNet/CMakeLists.txt
@@ -19,7 +19,7 @@ message(STATUS "Building with Fortran PyTorch coupling")
 
 # Install Python dependencies
 find_package(Python COMPONENTS Interpreter REQUIRED)
-if(NOT DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+if(NOT DEFINED ENV{VIRTUAL_ENV} AND NOT DEFINED ENV{CONDA_PREFIX})
   message(FATAL_ERROR "Please activate your virtualenv or conda environment")
 endif()
 execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r

--- a/examples/4_MultiIO/CMakeLists.txt
+++ b/examples/4_MultiIO/CMakeLists.txt
@@ -19,7 +19,7 @@ message(STATUS "Building with Fortran PyTorch coupling")
 
 # Install Python dependencies
 find_package(Python COMPONENTS Interpreter REQUIRED)
-if(NOT DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+if(NOT DEFINED ENV{VIRTUAL_ENV} AND NOT DEFINED ENV{CONDA_PREFIX})
   message(FATAL_ERROR "Please activate your virtualenv or conda environment")
 endif()
 execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r

--- a/examples/5_Looping/CMakeLists.txt
+++ b/examples/5_Looping/CMakeLists.txt
@@ -19,7 +19,7 @@ message(STATUS "Building with Fortran PyTorch coupling")
 
 # Install Python dependencies
 find_package(Python COMPONENTS Interpreter REQUIRED)
-if(NOT DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+if(NOT DEFINED ENV{VIRTUAL_ENV} AND NOT DEFINED ENV{CONDA_PREFIX})
   message(FATAL_ERROR "Please activate your virtualenv or conda environment")
 endif()
 execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r

--- a/examples/6_MultiGPU/CMakeLists.txt
+++ b/examples/6_MultiGPU/CMakeLists.txt
@@ -19,7 +19,7 @@ message(STATUS "Building with Fortran PyTorch coupling")
 
 # Install Python dependencies
 find_package(Python COMPONENTS Interpreter REQUIRED)
-if(NOT DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+if(NOT DEFINED ENV{VIRTUAL_ENV} AND NOT DEFINED ENV{CONDA_PREFIX})
   message(FATAL_ERROR "Please activate your virtualenv or conda environment")
 endif()
 execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r

--- a/examples/7_MPI/CMakeLists.txt
+++ b/examples/7_MPI/CMakeLists.txt
@@ -20,7 +20,7 @@ message(STATUS "Building with Fortran PyTorch coupling")
 
 # Install Python dependencies
 find_package(Python COMPONENTS Interpreter REQUIRED)
-if(NOT DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+if(NOT DEFINED ENV{VIRTUAL_ENV} AND NOT DEFINED ENV{CONDA_PREFIX})
   message(FATAL_ERROR "Please activate your virtualenv or conda environment")
 endif()
 execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r

--- a/examples/8_Autograd/CMakeLists.txt
+++ b/examples/8_Autograd/CMakeLists.txt
@@ -19,7 +19,7 @@ message(STATUS "Building with Fortran PyTorch coupling")
 
 # Install Python dependencies
 find_package(Python COMPONENTS Interpreter REQUIRED)
-if(NOT DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+if(NOT DEFINED ENV{VIRTUAL_ENV} AND NOT DEFINED ENV{CONDA_PREFIX})
   message(FATAL_ERROR "Please activate your virtualenv or conda environment")
 endif()
 execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r


### PR DESCRIPTION
Fatal error was caused by faulty logic in environment variables related to Python installation. This logic is corrected.

Resolves https://github.com/Cambridge-ICCS/FTorch/issues/430