### PR TITLE
Add a note to developer pages to explicitly state use of cmake-lint but not the formatter.

### DIFF
--- a/pages/developer.md
+++ b/pages/developer.md
@@ -152,7 +152,7 @@ The tools we use are as follows on a language-by-language basis:
 * C: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
 * Python: [ruff](https://docs.astral.sh/ruff/)
 * Shell: [ShellCheck](https://github.com/koalaman/shellcheck)
-* CMake: [cmake-format](https://github.com/cheshirekow/cmake_format)
+* CMake: cmake-lint from [cmake-format](https://github.com/cheshirekow/cmake_format) (Note: We do not use cmake-format's formatter)
 * GitHub Actions workflows: [zizmor](https://woodruffw.github.io/zizmor)
 
 Instructions on installing these tools can be found in their respective documentations.


### PR DESCRIPTION
Should resolve #439 

Makes it explicit that we expect code to obey `cmake-lint` from `cmake-format`, but do not apply the formatter as it is overly opinionated making line-length a target rather than a goal, thereby reducing readability (in our opinion).

This should make it explicit in the docs following fair confusion in a community contribution PR.

This was originally discussed back in https://github.com/Cambridge-ICCS/FTorch/pull/204