### PR TITLE
Use Zizmor action

### DIFF
--- a/.github/workflows/JOSS_paper_pdf.yml
+++ b/.github/workflows/JOSS_paper_pdf.yml
@@ -14,10 +14,17 @@ on:
       - '.github/workflows/JOSS_paper_pdf.yml'
       - 'paper/*'
 
+# No write permission by default
+permissions: {}
+
 jobs:
-  paper:
+  # The first job in this workflow builds a draft of the JOSS paper
+  build-draft:
+    name: Build paper draft
+
+    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    name: Paper Draft
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
@@ -32,7 +39,20 @@ jobs:
           journal: joss
           paper-path: paper/paper.md
 
-      # Uploads the rendered pdf to GitHub.
+  # The second job in this workflow uploads the rendered PDF to GitHub
+  upload-draft:
+    name: Upload paper draft
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # The draft need to have been built first
+    needs: [build-draft]
+
+    # We trust the deploy action with write permissions
+    permissions:
+      id-token: write
+    steps:
       - name: Upload draft PDF
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/JOSS_paper_pdf.yml
+++ b/.github/workflows/JOSS_paper_pdf.yml
@@ -1,5 +1,5 @@
 # Workflow to render the FTorch submission to JOSS
-name: RenderJOSSPaper
+name: Render JOSS paper
 
 # Controls when the workflow will run
 on:
@@ -20,8 +20,6 @@ permissions: {}
 jobs:
   # The first job in this workflow builds a draft of the JOSS paper
   build-draft:
-    name: Build paper draft
-
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -41,8 +39,6 @@ jobs:
 
   # The second job in this workflow uploads the rendered PDF to GitHub
   upload-draft:
-    name: Upload paper draft
-
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/JOSS_paper_pdf.yml
+++ b/.github/workflows/JOSS_paper_pdf.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Builds/renders the paper using the openjournals action
       - name: Build draft PDF
-        uses: openjournals/openjournals-draft-action@master
+        uses: openjournals/openjournals-draft-action@85a18372e48f551d8af9ddb7a747de685fbbb01c
         with:
           journal: joss
           paper-path: paper/paper.md

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -62,11 +62,16 @@ jobs:
           folder: doc      # The folder the action should deploy.
           dry-run: true    # Don't actually push to pages, just test if we can
 
+  publish:
+    name: Publish website
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    permissions:
+      id-token: write # trusted publishing + attestations
+    steps:
       - name: Deploy Documentation for main
-        if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@v4
-        permissions:
-          id-token: write # trusted publishing + attestations
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc      # The folder the action should deploy.

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,5 +1,5 @@
 # Workflow to build and deploy FORD docs for FTorch
-name: BuildDocs
+name: Build docs
 
 # Controls when the workflow will run
 on:
@@ -63,8 +63,7 @@ jobs:
           dry-run: true    # Don't actually push to pages, just test if we can
 
   # The second job in this workflow publishes the website in the case of a merge into main
-  publish:
-    name: Publish website
+  publish-website:
     if: github.ref == 'refs/heads/main'
 
     # The type of runner that the job will run on

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Test docs build
         if: github.ref != 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4
         with:
           branch: docs-test # The branch the action should deploy to.
           folder: doc      # The folder the action should deploy.

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -18,6 +18,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# No write permission by default
+permissions: {}
+
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build-docs"
@@ -31,6 +34,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y graphviz
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
         with:
@@ -61,6 +65,8 @@ jobs:
       - name: Deploy Documentation for main
         if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
+        permissions:
+          id-token: write # trusted publishing + attestations
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc      # The folder the action should deploy.

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -23,7 +23,7 @@ permissions: {}
 
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build-docs"
+  # The first job in this workflow builds the documentation for the website
   build-docs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -62,13 +62,20 @@ jobs:
           folder: doc      # The folder the action should deploy.
           dry-run: true    # Don't actually push to pages, just test if we can
 
+  # The second job in this workflow publishes the website in the case of a merge into main
   publish:
     name: Publish website
     if: github.ref == 'refs/heads/main'
+
+    # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
+    # The docs need to have been built first
     needs: [build-docs]
+
+    # We trust the deploy action with write permissions
     permissions:
-      id-token: write # trusted publishing + attestations
+      id-token: write
     steps:
       - name: Deploy Documentation for main
         uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4

--- a/.github/workflows/fypp_checks.yml
+++ b/.github/workflows/fypp_checks.yml
@@ -1,5 +1,5 @@
 # Workflow to run Fortran pre-processor checks on source
-name: FyppChecks
+name: Fypp checks
 
 on:
   # Triggers the workflow on pushes to the "main" branch, i.e., PR merges

--- a/.github/workflows/fypp_checks.yml
+++ b/.github/workflows/fypp_checks.yml
@@ -15,6 +15,9 @@ on:
       - '**.F90'
       - '**.pf'
 
+# Write permissions are not required
+permissions: {}
+
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "fypp-checks"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,5 +1,5 @@
 # Workflow to run static-analysis and linting checks on source
-name: StaticAnalysis
+name: Static analysis
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -25,7 +25,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Permissions for Zizmor action
+# Write permissions are not required
 permissions: {}
 
 # Workflow run - one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -134,8 +134,9 @@ jobs:
           ruff format --diff ./
           ruff check --diff ./
 
+  # Apply GitHub Actions linter, zizmor
   zizmor:
-    name: Apply GitHub Actions linter, zizmor
+    name: zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -102,7 +102,7 @@ jobs:
       # Configurable using the .clang-format and .clang-tidy config files if present
       - name: clang source
         if: always()
-        uses: cpp-linter/cpp-linter-action@v2
+        uses: cpp-linter/cpp-linter-action@b7fbdde0f6776f478f4d8867c2b746077fa7ea89 # v2
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -25,6 +25,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Permissions for Zizmor action
+permissions: {}
+
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "static-analysis"
@@ -85,14 +88,6 @@ jobs:
             shellcheck --external-sources ${FILE}
           done
 
-      # Apply GitHub Actions linter, zizmor
-      - name: zizmor
-        if: always()
-        run: |
-          cd ${{ github.workspace }}
-          . ../ftorch_venv/bin/activate
-          zizmor .github/workflows/*.yml
-
       # Apply Fortran linter, fortitude
       # Configurable using the fortitude.toml file if present
       - name: fortitude source
@@ -138,3 +133,17 @@ jobs:
           . ../ftorch_venv/bin/activate
           ruff format --diff ./
           ruff check --diff ./
+
+  zizmor:
+    name: Apply GitHub Actions linter, zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0

--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -1,5 +1,5 @@
 # Workflow to run the FTorch test suite
-name: TestSuiteUbuntu
+name: Test suite (Ubuntu CPU)
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -31,6 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Write permissions are not required
+permissions: {}
+
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "test-suite-ubuntu"

--- a/.github/workflows/test_suite_ubuntu_cuda.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda.yml
@@ -33,6 +33,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Write permissions are not required
+permissions: {}
+
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   test-suite-ubuntu-cuda:

--- a/.github/workflows/test_suite_ubuntu_cuda.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda.yml
@@ -1,5 +1,5 @@
 # Workflow to run the FTorch test suite on a CUDA enabled runner
-name: TestSuiteUbuntuCUDA
+name: Test suite (Ubuntu CUDA)
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       # configure windows VM with intel compilers
-      - uses: fortran-lang/setup-fortran@v1
+      - uses: fortran-lang/setup-fortran@d2ba6ea44297a24407def2f6e117954d844a5368 # v1
         id: setup-fortran
         with:
           compiler: ${{ matrix.toolchain.compiler }}

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -1,5 +1,5 @@
 # Workflow to run the FTorch test suite
-name: TestSuiteWindows
+name: Test suite (Windows)
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -32,6 +32,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Write permissions are not required
+permissions: {}
+
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "test-suite-windows"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,3 @@ ford
 fortitude-lint==0.7.0
 fypp==3.2
 ruff==0.7.3
-zizmor==0.9.2


### PR DESCRIPTION
It turns out there's a Zizmor GitHub Action that we could be using instead of the current manual approach: https://docs.zizmor.sh/integrations/.

With this action, we get Security info (see comment below), which I also address in this PR. Namely:
* Avoid giving anything write permissions that doesn't need it.
* Pin community actions to a specific hash.

Also includes some relabelling for consistency.