### PR TITLE
Adopt Green CI good practices

### DIFF
--- a/.github/workflows/JOSS_paper_pdf.yml
+++ b/.github/workflows/JOSS_paper_pdf.yml
@@ -28,6 +28,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    # Terminate the job if it runs for more than 5 minutes
+    timeout-minutes: 5
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
@@ -46,6 +49,9 @@ jobs:
   upload-draft:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
+    # Terminate the job if it runs for more than 5 minutes
+    timeout-minutes: 5
 
     # The draft need to have been built first
     needs: [build-draft]

--- a/.github/workflows/JOSS_paper_pdf.yml
+++ b/.github/workflows/JOSS_paper_pdf.yml
@@ -14,6 +14,11 @@ on:
       - '.github/workflows/JOSS_paper_pdf.yml'
       - 'paper/*'
 
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # No write permission by default
 permissions: {}
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -33,6 +33,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    # Terminate the job if it runs for more than 5 minutes
+    timeout-minutes: 5
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install Graphviz (Required by FORD)

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -18,6 +18,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # No write permission by default
 permissions: {}
 

--- a/.github/workflows/fypp_checks.yml
+++ b/.github/workflows/fypp_checks.yml
@@ -29,6 +29,10 @@ jobs:
   fypp-checks:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
+    # Terminate the job if it runs for more than 5 minutes
+    timeout-minutes: 5
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/fypp_checks.yml
+++ b/.github/workflows/fypp_checks.yml
@@ -15,6 +15,11 @@ on:
       - '**.F90'
       - '**.pf'
 
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Write permissions are not required
 permissions: {}
 

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -42,6 +42,9 @@ jobs:
     strategy:
       fail-fast: false
 
+    # Terminate the job if it runs for more than 5 minutes
+    timeout-minutes: 5
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -25,6 +25,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Write permissions are not required
 permissions: {}
 

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -35,8 +35,8 @@ permissions: {}
 
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "static-analysis"
-  static-analysis:
+  # This workflow contains a single job called "linting"
+  linting:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -45,6 +45,9 @@ jobs:
       matrix:
         std: ["f2008", "f2018"]
 
+    # Terminate the job if it runs for more than 10 minutes
+    timeout-minutes: 10
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/test_suite_ubuntu_cuda.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda.yml
@@ -41,9 +41,11 @@ jobs:
   test-suite-ubuntu-cuda:
     # The type of runner that the job will run on
     runs-on: GPU-runner
-    timeout-minutes: 10
     strategy:
       fail-fast: true
+
+    # Terminate the job if it runs for more than 10 minutes
+    timeout-minutes: 10
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -47,6 +47,9 @@ jobs:
         toolchain:
           - {compiler: intel, version: '2023.2'}
 
+    # Terminate the job if it runs for more than 10 minutes
+    timeout-minutes: 10
+
     steps:
       # configure windows VM with intel compilers
       - uses: fortran-lang/setup-fortran@d2ba6ea44297a24407def2f6e117954d844a5368 # v1


### PR DESCRIPTION
Merges into #441 

FTorch is already doing pretty well in terms of Green CI usage, although there are two recommendations from https://github.com/Cambridge-ICCS/green-ci that are missing for most workflows:
1. Cancel running jobs when the workflow is re-triggered.
2. Set a time limit lower than the default 6 hours to avoid wasted resources when jobs stall.