### PR TITLE
Bump CUDA version used in GPU testing CI job

### DIFF
--- a/.github/workflows/test_suite_ubuntu_cuda.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda.yml
@@ -24,6 +24,10 @@ on:
       # Build system
       - '**CMakeLists.txt'
       - '**requirements.txt'
+  
+  pull_request:
+    paths:
+      - '.github/workflows/test_suite_ubuntu_cuda.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
To close #444 

Bumps CUDA version requested as wheel in GPU CI job.