### PR TITLE
Support building tests with conda env present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(CMAKE_BUILD_TESTS)
 
   # Check if Python is in a virtual environment by checking the VIRTUAL_ENV
   # environment variable exists
-  if(NOT DEFINED ENV{VIRTUAL_ENV})
+  if(NOT DEFINED ENV{VIRTUAL_ENV} AND NOT DEFINED ENV{CONDA_PREFIX})
     message(FATAL_ERROR
             "No Python virtual environment detected. Please activate one.")
   endif()


### PR DESCRIPTION
Related to https://github.com/Cambridge-ICCS/FTorch/issues/433

I realized that if users want to build the tests locally, they would run into an error since the toplevel cmake lists requires the environment variable `VIRTUAL_ENV` to be set (which conda does not do). Users can now build the tests locally in a conda environment without issue.