### PR TITLE
Example 5: fix parallel .mod race by separate Fortran module dirs per target

### DIFF
--- a/examples/5_Looping/CMakeLists.txt
+++ b/examples/5_Looping/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(simplenet_infer_fortran_good
 # Same purpose as above: isolate this target's .mod output for parallel builds
 set_target_properties(simplenet_infer_fortran_good PROPERTIES
                       Fortran_MODULE_DIRECTORY
-                      ${CMAKE_CURRENT_BINARY_DIR}/mod_good)
+                      ${CMAKE_CURRENT_BINARY_DIR}/mod_good
+)
 target_include_directories(simplenet_infer_fortran_good PRIVATE
                            ${CMAKE_CURRENT_BINARY_DIR}/mod_good)


### PR DESCRIPTION
# Summary
Parallel builds of Example 5 create a race: good and bad both define ml_mod.mod into the same folder and in parallel, one target overwrites the other's .mod, which results in error.
## Reproduction
```vbnet
$ cmake --build . --parallel 16
[ 16%] Building Fortran object CMakeFiles/example5_simplenet_infer_fortran_good.dir/good/fortran_ml_mod.f90.o
[ 33%] Building Fortran object CMakeFiles/example5_simplenet_infer_fortran_bad.dir/bad/fortran_ml_mod.f90.o
f951: Fatal Error: Cannot rename module file ‘ml_mod.mod0’ to ‘ml_mod.mod’: No such file or directory
compilation terminated.
gmake[2]: *** [CMakeFiles/example5_simplenet_infer_fortran_bad.dir/build.make:88: CMakeFiles/example5_simplenet_infer_fortran_bad.dir/bad/fortran_ml_mod.f90.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/example5_simplenet_infer_fortran_bad.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
Error copying Fortran module "ml_mod.mod".  Tried "ML_MOD.mod" and "ml_mod.mod".
gmake[2]: *** [CMakeFiles/example5_simplenet_infer_fortran_good.dir/depend.make:8: CMakeFiles/example5_simplenet_infer_fortran_good.dir/ml_mod.mod.stamp] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:111: CMakeFiles/example5_simplenet_infer_fortran_good.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```

## Fixes #306 
Give each target its own Fortran module output directory and add it to the include path to avoid collisions.

## After
Both example5_simplenet_infer_fortran_good and example5_simplenet_infer_fortran_bad build reliably and parallel.
```vbnet
$ cmake --build . --parallel 16
[ 33%] Building Fortran object CMakeFiles/example5_simplenet_infer_fortran_bad.dir/bad/fortran_ml_mod.f90.o
[ 33%] Building Fortran object CMakeFiles/example5_simplenet_infer_fortran_good.dir/good/fortran_ml_mod.f90.o
[ 50%] Building Fortran object CMakeFiles/example5_simplenet_infer_fortran_bad.dir/bad/simplenet_infer_fortran.f90.o
[ 66%] Building Fortran object CMakeFiles/example5_simplenet_infer_fortran_good.dir/good/simplenet_infer_fortran.f90.o
[ 83%] Linking Fortran executable example5_simplenet_infer_fortran_bad
[100%] Linking Fortran executable example5_simplenet_infer_fortran_good
[100%] Built target example5_simplenet_infer_fortran_good
[100%] Built target example5_simplenet_infer_fortran_bad
```

## Environment
```bash
OS: Ubuntu 24.04.3 LTS on WSL2
Kernel: 6.6.87.2-microsoft-standard-WSL2
GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
cmake version 3.28.3
GNU Make 4.3
Python 3.12.3
PyTorch 2.9.0+cpu cuda: False
```

## Note
`pt2ts.py` saved the model as `saved_simplenet_cpu.pt` on my run, while the Fortran example expected `saved_simplenet_model.pt`. I solved this by renaming.