### PR TITLE
Pin Python version in test suite.

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 
       - name: Install PyTorch
         run: |
@@ -205,7 +205,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 
       - name: Install PyTorch
         run: |


### PR DESCRIPTION
In #445 I had to pin the version of Python used in test CI to 3.13 instead of 3.x as there were no PyTorch wheels yet available for 3.14.

It seems this has just appeared in #460 and can be seen [here where I run previously passing tests on main](https://github.com/Cambridge-ICCS/FTorch/actions/runs/18982919100).

This PR pins it, though we should be careful to unpin in future once wheels released.

Slightly worryingly it failed in `jit.script`, though I hope that is coincidental.

It also needs fixing for the cpp-linter action to get a working wheel of pygit