### PR TITLE
Update example 5 to fix mismatching TorchScript and executable names.

### DIFF
--- a/examples/5_Looping/CMakeLists.txt
+++ b/examples/5_Looping/CMakeLists.txt
@@ -30,17 +30,17 @@ execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r
                         ${PROJECT_SOURCE_DIR}/requirements.txt)
 
 # Fortran example - bad
-add_executable(example5_simplenet_infer_fortran_bad
+add_executable(simplenet_infer_fortran_bad
                bad/simplenet_infer_fortran.f90)
-target_link_libraries(example5_simplenet_infer_fortran_bad
+target_link_libraries(simplenet_infer_fortran_bad
                       PRIVATE FTorch::ftorch)
-target_sources(example5_simplenet_infer_fortran_bad
+target_sources(simplenet_infer_fortran_bad
                PRIVATE bad/fortran_ml_mod.f90)
 
 # Fortran example - good
-add_executable(example5_simplenet_infer_fortran_good
+add_executable(simplenet_infer_fortran_good
                good/simplenet_infer_fortran.f90)
-target_link_libraries(example5_simplenet_infer_fortran_good
+target_link_libraries(simplenet_infer_fortran_good
                       PRIVATE FTorch::ftorch)
-target_sources(example5_simplenet_infer_fortran_good
+target_sources(simplenet_infer_fortran_good
                PRIVATE good/fortran_ml_mod.f90)

--- a/examples/5_Looping/README.md
+++ b/examples/5_Looping/README.md
@@ -90,7 +90,7 @@ To save the SimpleNet model to TorchScript, run the modified version of the
 ```
 python3 pt2ts.py
 ```
-which will generate `saved_simplenet_model.pt` - the TorchScript instance of
+which will generate `saved_simplenet_cpu.pt` - the TorchScript instance of
 the network and perform a quick sanity check that it can be read.
 
 At this point we no longer require Python, so can deactivate the virtual

--- a/examples/5_Looping/bad/fortran_ml_mod.f90
+++ b/examples/5_Looping/bad/fortran_ml_mod.f90
@@ -37,7 +37,7 @@ module ml_mod
     call torch_tensor_from_array(output_tensors(1), out_data, tensor_layout, torch_kCPU)
 
     ! Load ML model
-    model_torchscript_file = '../saved_simplenet_model.pt'
+    model_torchscript_file = '../saved_simplenet_cpu.pt'
     call torch_model_load(torch_net, model_torchscript_file, torch_kCPU)
 
     ! Infer

--- a/examples/5_Looping/good/fortran_ml_mod.f90
+++ b/examples/5_Looping/good/fortran_ml_mod.f90
@@ -29,7 +29,7 @@ module ml_mod
   subroutine ml_init()
 
     ! Load ML model
-    model_torchscript_file = '../saved_simplenet_model.pt'
+    model_torchscript_file = '../saved_simplenet_cpu.pt'
     call torch_model_load(torch_net, model_torchscript_file, torch_kCPU)
 
   end subroutine ml_init


### PR DESCRIPTION
As pointed out in #460 there is a mismatch between the filename of the TorchScript net generated by `pt2ts.py` and that expected by the Fortran. This fixes that.

In addition I noticed the names of the generated executables had been prepended with `example_` to match the integration tests in other files, but these are not run as tests. I have changed them back to match the README documentation and previous setup used in workshops.