### PR TITLE
corrected RELEASE build type to Debug build type in hpc docs

### DIFF
--- a/pages/hpc.md
+++ b/pages/hpc.md
@@ -114,7 +114,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path/to/Torch/installation>/lib
 > Note: _On MacOS devices you will need to set `DYLD_LIBRARY_PATH` rather than `LD_LIBRARY_PATH`._
 
 Whilst experimenting, it may be useful to build FTorch using the
-`CMAKE_BUILD_TYPE=Debug` (see [CMAKE_BUILD_TYPE](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html)
+`CMAKE_BUILD_TYPE=Debug` (see [CMAKE_BUILD_TYPE](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 and [CMAKE_\<LANG\>_FLAGS](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html))
 CMake flag to allow useful error messages and investigation with debugging
 tools.


### PR DESCRIPTION
Release build type does not add debug flags. Therefore, corrected HPC docs to reflect the correct build type one might use to get verbose debugging information.