### PR TITLE
pkg-config support

### DIFF
--- a/.github/workflows/test_suite_ubuntu.yml
+++ b/.github/workflows/test_suite_ubuntu.yml
@@ -162,6 +162,46 @@ jobs:
           cmake --build .
           cmake --install .
 
+      - name: Check pkg-config file 
+        run: |
+          # pkg-config looks in the `build` directory for libraries
+          export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:build
+
+          libs=$(pkg-config --libs ftorch)
+          cflags=$(pkg-config --cflags ftorch)
+
+          # Assert linker flags not empty
+          if [[ -z "${libs}" ]]
+          then
+            echo "::error ::pkg-config --libs ftorch returned empty output"
+            exit 1
+          fi
+
+          # Assert expected linker flags
+          lib_dir=$(grep -oE "\-L.*/lib" <<< ${libs})
+          lib=$(grep -oE "\-lftorch" <<< ${libs})
+          if [[ -z "${lib_dir}" || -z "${lib}" ]]
+          then
+            echo "::error ::pkg-config --libs ftorch do not contain expected linker flags"
+            exit 1
+          fi
+
+          # Assert compiler flags not empty
+          if [[ -z "${cflags}" ]]
+          then
+            echo "::error ::pkg-config --cflags ftorch returned empty output"
+            exit 1
+          fi
+
+          # Assert expected compiler flags
+          include_dir=$(grep -oE "/include " <<< ${cflags})
+          module_dir=$(grep -oE "/include/ftorch" <<< ${cflags})
+          if [[ -z ${include_dir} || -z ${module_dir} ]]
+          then
+              echo "::error ::pkg-config --cflags ftorch do not contain expected compiler flags"
+              exit 1
+          fi
+
       - name: Run unit tests
         run: |
           . ftorch/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
 
 ### Added
 
+- Provide support for using FTorch with pkg-config. [#464](https://github.com/Cambridge-ICCS/FTorch/pull/464)
 - Support building FTorch as a static library. [#448](https://github.com/Cambridge-ICCS/FTorch/pull/448)
 - Intel-ifx and Intel-ifort CI and GCC v9-13 CI. Intel CI builds OpenMPI from source to accomodate MPI integration tests [#438](https://github.com/Cambridge-ICCS/FTorch/pull/438)
 - Expose tensor strides via `get_stride` method [#416](https://github.com/Cambridge-ICCS/FTorch/pull/416)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(PACKAGE_VERSION 1.0.0)
 project(
   ${PROJECT_NAME}
   VERSION ${PACKAGE_VERSION}
+  DESCRIPTION "A library for directly calling PyTorch ML models from Fortran"
   LANGUAGES C CXX Fortran)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
@@ -106,6 +107,11 @@ file(RELATIVE_PATH relDir ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
 get_filename_component(TORCH_LIBRARY_DIR ${TORCH_LIBRARY} DIRECTORY)
 set(CMAKE_INSTALL_RPATH "$ORIGIN/${relDir};${TORCH_LIBRARY_DIR}")
 
+# Initialize Fortran module build output directory for all subsequent targets
+if(NOT DEFINED CMAKE_Fortran_MODULE_DIRECTORY)
+  set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/modules")
+endif()
+
 # Library with C and Fortran bindings
 add_library(${LIB_NAME} src/ctorch.cpp src/ftorch.F90 src/ftorch_test_utils.f90)
 
@@ -122,9 +128,7 @@ target_compile_definitions(
 # Add an alias FTorch::ftorch for the library
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
 # cmake-format: off
-set_target_properties(
-  ${LIB_NAME} PROPERTIES PUBLIC_HEADER "src/ctorch.h"
-  Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/modules")
+set_target_properties(${LIB_NAME} PROPERTIES PUBLIC_HEADER "src/ctorch.h")
 # cmake-format: on
 # Link TorchScript
 # NOTE: Linking stdc++ for downstream targets fixes ctorch link error
@@ -132,7 +136,7 @@ target_link_libraries(${LIB_NAME}
   PRIVATE ${TORCH_LIBRARIES} INTERFACE stdc++)
 # Include the Fortran mod files in the library
 target_include_directories(
-  ${LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/modules>
+  ${LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
   # $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
@@ -160,10 +164,18 @@ install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 # Install Fortran module files
-install(FILES "${CMAKE_BINARY_DIR}/modules/ftorch.mod"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}")
-install(FILES "${CMAKE_BINARY_DIR}/modules/ftorch_test_utils.mod"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}")
+if(NOT DEFINED CMAKE_INSTALL_MODULEDIR)
+  set(
+    CMAKE_INSTALL_MODULEDIR
+    "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}"
+    CACHE STRING "Directory in prefix to install generated module files"
+  )
+endif()
+
+install(FILES "${CMAKE_Fortran_MODULE_DIRECTORY}/ftorch.mod"
+        DESTINATION "${CMAKE_INSTALL_MODULEDIR}")
+install(FILES "${CMAKE_Fortran_MODULE_DIRECTORY}/ftorch_test_utils.mod"
+        DESTINATION "${CMAKE_INSTALL_MODULEDIR}")
 
 # Build integration tests
 if(CMAKE_BUILD_TESTS)
@@ -216,3 +228,15 @@ configure_package_config_file(
 install(
   FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}Config.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
+# Export a pkg-config file
+configure_file(
+  "${PROJECT_SOURCE_DIR}/cmake/template.pc"
+  "${PROJECT_BINARY_DIR}/${LIB_NAME}.pc"
+  @ONLY
+)
+install(
+  FILES
+  "${PROJECT_BINARY_DIR}/${LIB_NAME}.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)

--- a/cmake/template.pc
+++ b/cmake/template.pc
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+moduledir=${prefix}/@CMAKE_INSTALL_MODULEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -l@LIB_NAME@
+Cflags: -I${includedir} -I${moduledir}

--- a/pages/hpc.md
+++ b/pages/hpc.md
@@ -63,9 +63,11 @@ with CMake to enforce this.
 
 ### Building Projects and Linking to FTorch
 
-Whilst we describe how to link to FTorch using CMake to build a project on our main
-page, many HPC models do not use CMake and rely on `make` or more elaborate build
-systems.
+Whilst we describe how to link to FTorch using CMake to build a project on our
+main page, many HPC models do not use CMake and rely on `make` or more
+elaborate build systems. This section assumes that you have successfully
+configured, built, *and* installed FTorch using CMake.
+
 To build a project with `make` or similar you need to _include_ the FTorch's
 header (`.h`) and module (`.mod`) files and _link_ the executable
 to the Ftorch library (e.g., `.so`, `.dll`, `.dylib` depending on your system) when
@@ -78,7 +80,7 @@ use ftorch to _include_ the module and header files:
 ```
 This is often done by appending to an `FCFLAGS` compiler flags variable or similar:
 ```sh
-FCFLAGS += -I<path/to/FTorch/install/location>/include/ftorch
+FCFLAGS+=" -I<path/to/FTorch/install/location>/include/ftorch"
 ```
 
 When compiling the final executable add the following _linker_ flag:
@@ -87,7 +89,28 @@ When compiling the final executable add the following _linker_ flag:
 ```
 This is often done by appending to an `LDFLAGS` linker flags variable or similar:
 ```sh
-LDFLAGS += -L<path/to/FTorch/install/location>/lib -lftorch
+LDFLAGS+=" -L<path/to/FTorch/install/location>/lib -lftorch"
+```
+
+If you have [pkg-config](https://en.wikipedia.org/wiki/Pkg-config) installed,
+you can easily query the compiler and linker flags of FTorch rather than
+manually specifying them as was shown above. FTorch provides a standard
+pkg-config file in both the directory in which FTorch was built (e.g.,
+`</path/to/FTorch>/build`) as well as the library directory in which it was
+installed (e.g., `</path/to/FTorch/install/location>/lib/pkgconfig`). For
+example, the following commands are equivalent to adding the manually specified
+flags:
+```sh
+FCFLAGS+=" $(pkg-config --cflags </path/to/FTorch/install/location>/lib/pkgconfig/ftorch.pc)"
+LDFLAGS+=" $(pkg-config --libs </path/to/FTorch/install/location>/lib/pkgconfig/ftorch.pc)"
+```
+
+You can simplify these commands by adding FTorch to the `PKG_CONFIG_PATH`
+environment variable:
+```sh
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:</path/to/FTorch/install/location>/lib/pkgconfig/
+FCFLAGS+=" $(pkg-config --cflags ftorch)"
+LDFLAGS+=" $(pkg-config --libs ftorch)"
 ```
 
 You may also need to add the location of the dynamic library `.so` files to your


### PR DESCRIPTION
While I was reading the `pages/hpc.md`, I noticed that the description for using FTorch with a make project or with other build systems could be improved by providing users with a package config file (i.e., `FTorch.pc`) so that they can compile against FTorch more easily by querying compilation flags and library flags using `pkg-config` 

This PR adds the following:

* A package config template file that could be used in conjunction with `pkg-config` (a ubiquitous linux utility) for querying relevant flags for compiling against FTorch.
* Setting new variables `CMAKE_Fortran_MODULE_DIRECTORY` and `CMAKE_INSTALL_MODULEDIR` .
* CMake project description based on the FTorch GitHub repo description.
* Update changelog
* update hpc docs to reflect using pkg-config
* update CI to double check pkg-config file 

I thought to add the package config file because I saw [fortran-lang/stdlib](https://github.com/fortran-lang/stdlib/blob/03736faab793ee52fd88e79f6d21d8bda1d294ed/config/template.pc) and [fortran-lang/fftpack](https://github.com/fortran-lang/fftpack/blob/8476c39e1b25d7b5a3a2fac980d76fc82a8c1f37/config/template.pc) do this, and we should naturally try and support users of HPC codes who may not be able to use CMake entirely for their codes.

~I think I should also update `pages/hpc.md` file to include the use of `pkg-config` to query package information, **but I wanted to open the PR first to see what you guys think, so please let me know :)**~

Another thought: maybe it's more appropriate to put `template.pc` into a different directory called say `config` and also move the `cmake/FTorchConfig.cmake.in` into that directory (this is also the approach `stdlib` takes)... so something like 

```
config/
    template.pc
    cmake/
        FTorchConfig.cmake.in  
```

but this is an organizational question that's more up to you guys I would say.

In case you're unfamiliar, `pkg-config` has output like the below:

```shell
 pkg-config --libs /path/to/FTorch/installed/libs/pkgconfig/ftorch.pc
# output: -L/path/to/FTorch/installed/libs/installed/lib -lftorch

pkg-config --cflags /path/to/FTorch/installed/libs/pkgconfig/ftorch.pc
# output: -I/path/to/FTorch/installed/include -I/path/to/FTorch/installed/include/ftorch
```

Or if you added the directory containing `ftorch.pc` to the `PKG_CONFIG_PATH`, you can simply call

```shell
pkg-config --libs ftorch
pkg-config --cflags ftorch
```