### PR TITLE
fixed page/hpc.html to render CMAKE_<LANG>_FLAGS instead of CMAKE_\<LANG>_FLAGS

### DIFF
--- a/pages/hpc.md
+++ b/pages/hpc.md
@@ -115,7 +115,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path/to/Torch/installation>/lib
 
 Whilst experimenting, it may be useful to build FTorch using the
 `CMAKE_BUILD_TYPE=Debug` (see [CMAKE_BUILD_TYPE](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
-and [CMAKE_\<LANG\>_FLAGS](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html))
+and [CMAKE_<LANG\>_FLAGS](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html))
 CMake flag to allow useful error messages and investigation with debugging
 tools.
 


### PR DESCRIPTION
In a PR https://github.com/Cambridge-ICCS/FTorch/pull/463, I erroneously added a backslash in front of `<`, therefore causing the below to render:

<img width="268" height="93" alt="image" src="https://github.com/user-attachments/assets/8606a24c-2bb8-4c6c-a892-64c0f143294d" />

The current PR corrects this rendering issue, now it renders correctly as below:

<img width="255" height="90" alt="image" src="https://github.com/user-attachments/assets/0be96dbc-63a8-4c65-aa88-afaac994c8a8" />

Apologies for the oversight here, this was a trivial thing to miss on my part....
