### PR TITLE
Fix deadlink to gpu user guide

### DIFF
--- a/pages/hpc.md
+++ b/pages/hpc.md
@@ -211,5 +211,5 @@ For a worked example of running with MPI, see the
 #### GPU
 
 For information on running on GPU architectures, see the
-[GPU user guide page](pages/gpu.html) and/or the
+[GPU user guide page](gpu.html) and/or the
 [MultiGPU example](https://github.com/Cambridge-ICCS/FTorch/tree/main/examples/6_MultiGPU).


### PR DESCRIPTION
GPU user guide link in HPC docs was previously a dead link (see below):

<img width="1700" height="655" alt="image" src="https://github.com/user-attachments/assets/6fee9925-2298-443a-8618-1c8625f9f8be" />

This is the result of the unnecessary "pages" included in the path (see bottom left):

<img width="1623" height="275" alt="image" src="https://github.com/user-attachments/assets/d2dbf19b-a8bd-454a-8532-a46221807286" />

Here is the fixed link (see bottom left):

<img width="1623" height="275" alt="image" src="https://github.com/user-attachments/assets/95135053-30ec-4457-891a-50808396df75" />

