### PR TITLE
Fix link to use cases page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,5 +204,5 @@ for a full list of contributors.
 
 Multiple projects build on FTorch in their work.
 Those we are aware of are listed on the
-[use cases page](https://cambridge-iccs.github.io/FTorch/community/case_studies.html)
+[use cases page](https://cambridge-iccs.github.io/FTorch/page/community/case_studies.html)
 in the online documentation.


### PR DESCRIPTION
The link in the README to the read the docs page on 'Case studies' was broken. This fixes it.