### PR TITLE
Use specific modules in unit tests

### DIFF
--- a/test/unit/model/unittest_model_constructors_destructors.pf
+++ b/test/unit/model/unittest_model_constructors_destructors.pf
@@ -6,7 +6,8 @@
 !    file for details.
 module unittest_model_constructors_destructors
   use funit
-  use ftorch, only: torch_kCPU, torch_model, torch_model_delete, torch_model_load
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_model, only: torch_model, torch_model_delete, torch_model_load
   use iso_c_binding, only: c_associated
 
   implicit none

--- a/test/unit/model/unittest_model_forward.pf
+++ b/test/unit/model/unittest_model_forward.pf
@@ -6,8 +6,10 @@
 !    file for details.
 module unittest_model_forward
   use funit
-  use ftorch, only: torch_kCPU, torch_kFloat32, torch_model, torch_model_load, &
-                    torch_model_forward, torch_tensor
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: torch_kFloat32
+  use ftorch_model, only: torch_model, torch_model_load, torch_model_forward
+  use ftorch_tensor, only: torch_tensor
   use ftorch_test_utils, only: assert_allclose
   use, intrinsic :: iso_fortran_env, only : sp => real32
   use iso_c_binding, only: c_int64_t
@@ -80,7 +82,7 @@ contains
   ! Unit test for checking values are propagated correctly through the test model
   @test(testparameters={get_parameters_short()})
   subroutine test_torch_model_forward_value(this)
-    use ftorch, only: torch_tensor_from_array
+    use ftorch_tensor, only: torch_tensor_from_array
 
     implicit none
 
@@ -109,7 +111,7 @@ contains
   ! Unit test for checking that requires_grad is correctly propagated through the test model
   @test(testparameters={get_parameters_requires_grad()})
   subroutine test_tensor_requires_grad(this)
-    use ftorch, only: torch_tensor_ones, torch_tensor_empty
+    use ftorch_tensor, only: torch_tensor_ones, torch_tensor_empty
 
     implicit none
 

--- a/test/unit/model/unittest_model_interrogation.pf
+++ b/test/unit/model/unittest_model_interrogation.pf
@@ -6,7 +6,8 @@
 !    file for details.
 module unittest_model_interrogation
   use funit
-  use ftorch, only: torch_kCPU, torch_model, torch_model_load, torch_model_is_training
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_model, only: torch_model, torch_model_load, torch_model_is_training
 
   implicit none
 
@@ -69,7 +70,7 @@ contains
   ! Unit test for printing the parameters associated with a TorchScript model
   @test(testparameters={get_parameters_short()})
   subroutine test_torch_model_print_parameters(this)
-    use ftorch, only: torch_model_print_parameters
+    use ftorch_model, only: torch_model_print_parameters
     class(TestCaseType), intent(inout) :: this
     type(torch_model) :: model
 

--- a/test/unit/tensor/unittest_tensor_autograd.pf
+++ b/test/unit/tensor/unittest_tensor_autograd.pf
@@ -6,9 +6,10 @@
 !    file for details.
 module unittest_tensor_autograd
   use funit
-  use ftorch, only: assignment(=), ftorch_int, torch_kCPU, torch_kFloat32, torch_tensor, &
-                    torch_tensor_backward, torch_tensor_empty, torch_tensor_from_array, &
-                    torch_tensor_get_gradient, torch_tensor_ones
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: ftorch_int, torch_kFloat32
+  use ftorch_tensor, only: assignment(=), torch_tensor, torch_tensor_backward, torch_tensor_empty, &
+                           torch_tensor_from_array, torch_tensor_get_gradient, torch_tensor_ones
   use ftorch_test_utils, only: allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
@@ -255,7 +256,7 @@ contains
   ! assignment and a binary operator applied to tensors with the same requires_grad value
   @test(testparameters={get_parameters_binary()})
   subroutine test_requires_grad_binary_same(this)
-    use ftorch, only: operator(+), operator(-), operator(*), operator(/)
+    use ftorch_tensor, only: operator(+), operator(-), operator(*), operator(/)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, tensor3
     integer, parameter :: ndims = 1
@@ -293,7 +294,7 @@ contains
   ! assignment and a binary operator applied to tensors with different requires_grad values
   @test(testparameters={get_parameters_binary()})
   subroutine test_requires_grad_binary_different(this)
-    use ftorch, only: operator(+), operator(-), operator(*), operator(/)
+    use ftorch_tensor, only: operator(+), operator(-), operator(*), operator(/)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, tensor3
     integer, parameter :: ndims = 1
@@ -332,7 +333,7 @@ contains
   ! assignment and a unary operator
   @test(testparameters={get_parameters_unary()})
   subroutine test_requires_grad_unary(this)
-    use ftorch, only: operator(-), operator(**)
+    use ftorch_tensor, only: operator(-), operator(**)
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2
     integer, parameter :: ndims = 1
@@ -367,7 +368,7 @@ contains
   ! assignment and a unary reduction operator
   @test(testparameters={get_parameters_reduction()})
   subroutine test_requires_grad_reduction(this)
-    use ftorch, only: torch_tensor_mean, torch_tensor_sum
+    use ftorch_tensor, only: torch_tensor_mean, torch_tensor_sum
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2
     integer, parameter :: ndims = 1

--- a/test/unit/tensor/unittest_tensor_constructors_destructors.pf
+++ b/test/unit/tensor/unittest_tensor_constructors_destructors.pf
@@ -6,8 +6,9 @@
 !    file for details.
 module unittest_tensor_constructors_destructors
   use funit
-  use ftorch, only: assignment(=), torch_kFloat32, torch_kCPU, torch_tensor, &
-                    torch_tensor_delete, torch_tensor_from_array
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: torch_kFloat32
+  use ftorch_tensor, only: assignment(=), torch_tensor, torch_tensor_delete, torch_tensor_from_array
   use ftorch_test_utils, only: allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use iso_c_binding, only: c_associated, c_int64_t
@@ -95,7 +96,7 @@ contains
   ! Unit test for the torch_tensor_empty subroutine
   @test(testparameters={get_parameters_requires_grad()})
   subroutine test_torch_tensor_empty(this)
-    use ftorch, only: torch_tensor_empty
+    use ftorch_tensor, only: torch_tensor_empty
 
     implicit none
 
@@ -124,7 +125,7 @@ contains
   ! Unit test for the torch_tensor_zeros subroutine
   @test(testParameters={get_parameters_requires_grad()})
   subroutine test_torch_tensor_zeros(this)
-    use ftorch, only: torch_tensor_zeros
+    use ftorch_tensor, only: torch_tensor_zeros
 
     implicit none
 
@@ -166,7 +167,7 @@ contains
   ! Unit test for the torch_tensor_ones subroutine
   @test(testParameters={get_parameters_requires_grad()})
   subroutine test_torch_tensor_ones(this)
-    use ftorch, only: torch_tensor_ones
+    use ftorch_tensor, only: torch_tensor_ones
 
     implicit none
 
@@ -353,7 +354,7 @@ contains
   ! Unit test for the torch_tensor_from_blob subroutine
   @test(testParameters={get_parameters_requires_grad()})
   subroutine test_torch_from_blob(this)
-    use ftorch, only: torch_tensor_from_blob
+    use ftorch_tensor, only: torch_tensor_from_blob
     use, intrinsic :: iso_c_binding, only : c_loc
 
     implicit none
@@ -395,7 +396,7 @@ contains
   ! torch_tensor's destructor)
   @test(testparameters={get_parameters_destruction()})
   subroutine test_torch_tensor_destruction(this)
-    use ftorch, only: torch_tensor_empty
+    use ftorch_tensor, only: torch_tensor_empty
 
     implicit none
 

--- a/test/unit/tensor/unittest_tensor_interrogation.pf
+++ b/test/unit/tensor/unittest_tensor_interrogation.pf
@@ -6,7 +6,9 @@
 !    file for details.
 module unittest_tensor_interrogation
   use funit
-  use ftorch, only: torch_kFloat32, torch_kCPU, torch_tensor, torch_tensor_empty
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: torch_kFloat32
+  use ftorch_tensor, only: torch_tensor, torch_tensor_empty
   use iso_c_binding, only: c_int64_t
 
   implicit none

--- a/test/unit/tensor/unittest_tensor_interrogation_cuda.pf
+++ b/test/unit/tensor/unittest_tensor_interrogation_cuda.pf
@@ -6,7 +6,9 @@
 !    file for details.
 module unittest_tensor_interrogation_cuda
   use funit
-  use ftorch, only: torch_kFloat32, torch_kCUDA, torch_tensor, torch_tensor_empty
+  use ftorch_devices, only: torch_kCUDA
+  use ftorch_types, only: torch_kFloat32
+  use ftorch_tensor, only: torch_tensor, torch_tensor_empty
   use iso_c_binding, only: c_int64_t
 
   implicit none

--- a/test/unit/tensor/unittest_tensor_manipulation.pf
+++ b/test/unit/tensor/unittest_tensor_manipulation.pf
@@ -6,7 +6,9 @@
 !    file for details.
 module unittest_tensor_manipulation
   use funit
-  use ftorch, only: torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_from_array
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: torch_kFloat32
+  use ftorch_tensor, only: torch_tensor, torch_tensor_from_array
   use ftorch_test_utils, only: allclose
   use, intrinsic :: iso_c_binding, only : c_int64_t
 

--- a/test/unit/tensor/unittest_tensor_manipulation_cuda.pf
+++ b/test/unit/tensor/unittest_tensor_manipulation_cuda.pf
@@ -6,9 +6,10 @@
 !    file for details.
 module unittest_tensor_manipulation_cuda
   use funit
-  use ftorch, only: torch_kCPU, torch_kCUDA, torch_kFloat64, torch_kFloat32, &
-                    torch_tensor, torch_tensor_delete, torch_tensor_print, &
-                    torch_tensor_from_array, torch_tensor_empty, torch_tensor_to
+  use ftorch_devices, only: torch_kCPU, torch_kCUDA
+  use ftorch_types, only: torch_kFloat32, torch_kFloat64
+  use ftorch_tensor, only: torch_tensor, torch_tensor_delete, torch_tensor_print, &
+                           torch_tensor_from_array, torch_tensor_empty, torch_tensor_to
   use ftorch_test_utils, only: allclose
   use, intrinsic :: iso_c_binding, only : c_int64_t
 

--- a/test/unit/tensor/unittest_tensor_operator_overloads.pf
+++ b/test/unit/tensor/unittest_tensor_operator_overloads.pf
@@ -6,7 +6,9 @@
 !    file for details.
 module unittest_tensor_operator_overloads
   use funit
-  use ftorch, only: assignment(=), torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_from_array
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: torch_kFloat32
+  use ftorch_tensor, only: assignment(=), torch_tensor, torch_tensor_from_array
   use ftorch_test_utils, only: allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use, intrinsic :: iso_c_binding, only : c_int64_t
@@ -109,7 +111,7 @@ contains
   ! Unit test for the addition operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_add(this)
-    use ftorch, only: operator(+)
+    use ftorch_tensor, only: operator(+)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, tensor3
@@ -145,7 +147,7 @@ contains
   ! Unit test for the subtraction operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_subtract(this)
-    use ftorch, only: operator(-)
+    use ftorch_tensor, only: operator(-)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, tensor3
@@ -182,7 +184,7 @@ contains
   ! Unit test for the negative operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_negative(this)
-    use ftorch, only: operator(-)
+    use ftorch_tensor, only: operator(-)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2
@@ -214,7 +216,7 @@ contains
   ! Unit test for the tensor multiplication operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_multiply(this)
-    use ftorch, only: operator(*)
+    use ftorch_tensor, only: operator(*)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, tensor3
@@ -251,7 +253,7 @@ contains
   ! Unit test for the scalar multiplication operator
   @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_scalar_multiply(this)
-    use ftorch, only: operator(*)
+    use ftorch_tensor, only: operator(*)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, multiplier
@@ -289,7 +291,7 @@ contains
   ! Unit test for the tensor division operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_divide(this)
-    use ftorch, only: operator(/)
+    use ftorch_tensor, only: operator(/)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, tensor3
@@ -325,7 +327,7 @@ contains
   ! Unit test for the scalar division operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_scalar_divide(this)
-    use ftorch, only: operator(/)
+    use ftorch_tensor, only: operator(/)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2, divisor
@@ -365,7 +367,7 @@ contains
   ! Unit test for the integer exponentiation operator
   @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_square(this)
-    use ftorch, only: operator(**)
+    use ftorch_tensor, only: operator(**)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2
@@ -402,7 +404,7 @@ contains
   ! Unit test for the fractional exponentiation operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_sqrt(this)
-    use ftorch, only: operator(**)
+    use ftorch_tensor, only: operator(**)
 
     class(TestCaseType), intent(inout) :: this
     type(torch_tensor) :: tensor1, tensor2

--- a/test/unit/tensor/unittest_tensor_operator_overloads_autograd.pf
+++ b/test/unit/tensor/unittest_tensor_operator_overloads_autograd.pf
@@ -6,9 +6,11 @@
 !    file for details.
 module unittest_tensor_operator_overloads_autograd
   use funit
-  use ftorch, only: assignment(=), ftorch_int, torch_kCPU, torch_kFloat32, &
-                    torch_tensor, torch_tensor_backward, torch_tensor_delete, torch_tensor_empty, &
-                    torch_tensor_from_array, torch_tensor_ones, torch_tensor_get_gradient
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: ftorch_int, torch_kFloat32
+  use ftorch_tensor, only: assignment(=), torch_tensor, torch_tensor_backward, &
+                           torch_tensor_delete, torch_tensor_empty, torch_tensor_from_array, &
+                           torch_tensor_ones, torch_tensor_get_gradient
   use ftorch_test_utils, only: allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use, intrinsic :: iso_c_binding, only : c_associated, c_int64_t
@@ -118,7 +120,7 @@ contains
   ! Unit test for the derivative of the addition operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_add(this)
-    use ftorch, only: operator(+)
+    use ftorch_tensor, only: operator(+)
 
     implicit none
 
@@ -164,7 +166,7 @@ contains
   ! Unit test for the derivative of the negative operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_negative(this)
-    use ftorch, only: operator(-)
+    use ftorch_tensor, only: operator(-)
 
     implicit none
 
@@ -201,7 +203,7 @@ contains
   ! Unit test for the derivative of the subtraction operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_subtract(this)
-    use ftorch, only: operator(-)
+    use ftorch_tensor, only: operator(-)
 
     implicit none
 
@@ -247,7 +249,7 @@ contains
   ! Unit test for the derivative of the tensor multiplication operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_multiply(this)
-    use ftorch, only: operator(*)
+    use ftorch_tensor, only: operator(*)
 
     implicit none
 
@@ -293,7 +295,7 @@ contains
   ! Unit test for the derivative of the scalar multiplication operator
   @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_scalar_multiply(this)
-    use ftorch, only: operator(*)
+    use ftorch_tensor, only: operator(*)
 
     implicit none
 
@@ -338,7 +340,7 @@ contains
   ! Unit test for the derivative of the tensor division operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_divide(this)
-    use ftorch, only: operator(/)
+    use ftorch_tensor, only: operator(/)
 
     implicit none
 
@@ -384,7 +386,7 @@ contains
   ! Unit test for the derivative of the scalar division operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_scalar_divide(this)
-    use ftorch, only: operator(/)
+    use ftorch_tensor, only: operator(/)
 
     implicit none
 
@@ -425,7 +427,7 @@ contains
   ! Unit test for the derivative of the integer exponentiation operator
   @test(testParameters={get_parameters_full()})
   subroutine test_torch_tensor_square(this)
-    use ftorch, only: operator(**)
+    use ftorch_tensor, only: operator(**)
 
     implicit none
 
@@ -466,7 +468,7 @@ contains
   ! Unit test for the derivative of the fractional exponentiation operator
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_sqrt(this)
-    use ftorch, only: operator(**)
+    use ftorch_tensor, only: operator(**)
 
     implicit none
 

--- a/test/unit/tensor/unittest_tensor_operators.pf
+++ b/test/unit/tensor/unittest_tensor_operators.pf
@@ -6,7 +6,9 @@
 !    file for details.
 module unittest_tensor_operators
   use funit
-  use ftorch, only: torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_from_array
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: torch_kFloat32
+  use ftorch_tensor, only: torch_tensor, torch_tensor_from_array
   use ftorch_test_utils, only: allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use, intrinsic :: iso_c_binding, only : c_int64_t
@@ -30,7 +32,7 @@ contains
   ! Unit test for the summation reduction
   @test
   subroutine test_torch_tensor_sum()
-    use ftorch, only: torch_tensor_sum
+    use ftorch_tensor, only: torch_tensor_sum
 
     type(torch_tensor) :: in_tensor, out_tensor
     real(wp), dimension(2,3), target :: in_data
@@ -64,7 +66,7 @@ contains
   ! Unit test for the mean reduction
   @test(testParameters={get_parameters_short()})
   subroutine test_torch_tensor_mean()
-    use ftorch, only: torch_tensor_mean
+    use ftorch_tensor, only: torch_tensor_mean
 
     type(torch_tensor) :: in_tensor, out_tensor
     real(wp), dimension(2,3), target :: in_data

--- a/test/unit/tensor/unittest_tensor_operators_autograd.pf
+++ b/test/unit/tensor/unittest_tensor_operators_autograd.pf
@@ -6,8 +6,10 @@
 !    file for details.
 module unittest_tensor_operators_autograd
   use funit
-  use ftorch, only: torch_kCPU, torch_kFloat32, torch_tensor, torch_tensor_backward, &
-                    torch_tensor_empty, torch_tensor_get_gradient, torch_tensor_from_array
+  use ftorch_devices, only: torch_kCPU
+  use ftorch_types, only: torch_kFloat32
+  use ftorch_tensor, only: torch_tensor, torch_tensor_backward, torch_tensor_empty, &
+                           torch_tensor_get_gradient, torch_tensor_from_array
   use ftorch_test_utils, only: allclose
   use, intrinsic :: iso_fortran_env, only: sp => real32
   use, intrinsic :: iso_c_binding, only : c_int64_t
@@ -33,7 +35,7 @@ contains
   ! Unit test for derivative of the summation reduction
   @test
   subroutine test_torch_tensor_sum()
-    use ftorch, only: torch_tensor_sum
+    use ftorch_tensor, only: torch_tensor_sum
 
     type(torch_tensor) :: a, Q, dQda
     real(wp), dimension(2,3), target :: in_data, out_data
@@ -66,7 +68,7 @@ contains
   ! Unit test for the derivative of the mean reduction
   @test
   subroutine test_torch_tensor_mean()
-    use ftorch, only: torch_tensor_mean
+    use ftorch_tensor, only: torch_tensor_mean
 
     type(torch_tensor) :: a, Q, dQda
     real(wp), dimension(2,3), target :: in_data, out_data


### PR DESCRIPTION
Follows on from #508.

Makes use of the new modules in the unit tests. As agreed, the examples are left as-is with `use ftorch`.