### PR TITLE
Reduce duplication in unit test names

### DIFF
--- a/test/unit/model/unittest_model_constructors_destructors.pf
+++ b/test/unit/model/unittest_model_constructors_destructors.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_constructors_destructors
+module unittest_model_constructors_destructors
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_model, only: torch_model, torch_model_delete, torch_model_load
@@ -40,4 +40,4 @@ contains
 
   end subroutine test_pointers
 
-end module unittest_constructors_destructors
+end module unittest_model_constructors_destructors

--- a/test/unit/model/unittest_model_forward.pf
+++ b/test/unit/model/unittest_model_forward.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_forward
+module unittest_model_forward
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: torch_kFloat32
@@ -137,4 +137,4 @@ contains
 
   end subroutine test_output_requires_grad
 
-end module unittest_forward
+end module unittest_model_forward

--- a/test/unit/model/unittest_model_interrogation.pf
+++ b/test/unit/model/unittest_model_interrogation.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_interrogation
+module unittest_model_interrogation
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_model, only: torch_model, torch_model_load, torch_model_is_training
@@ -110,4 +110,4 @@ contains
 
   end subroutine test_is_training
 
-end module unittest_interrogation
+end module unittest_model_interrogation

--- a/test/unit/tensor/unittest_tensor_autograd.pf
+++ b/test/unit/tensor/unittest_tensor_autograd.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_autograd
+module unittest_tensor_autograd
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: ftorch_int, torch_kFloat32
@@ -396,4 +396,4 @@ contains
 
   end subroutine test_requires_grad_reduction
 
-end module unittest_autograd
+end module unittest_tensor_autograd

--- a/test/unit/tensor/unittest_tensor_constructors_destructors.pf
+++ b/test/unit/tensor/unittest_tensor_constructors_destructors.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_constructors_destructors
+module unittest_tensor_constructors_destructors
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: torch_kFloat32
@@ -429,4 +429,4 @@ contains
 
   end subroutine test_destruction
 
-end module unittest_constructors_destructors
+end module unittest_tensor_constructors_destructors

--- a/test/unit/tensor/unittest_tensor_interrogation.pf
+++ b/test/unit/tensor/unittest_tensor_interrogation.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_interrogation
+module unittest_tensor_interrogation
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: torch_kFloat32
@@ -286,4 +286,4 @@ contains
 
   end subroutine test_requires_grad
 
-end module unittest_interrogation
+end module unittest_tensor_interrogation

--- a/test/unit/tensor/unittest_tensor_interrogation_cuda.pf
+++ b/test/unit/tensor/unittest_tensor_interrogation_cuda.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_interrogation_cuda
+module unittest_tensor_interrogation_cuda
   use funit
   use ftorch_devices, only: torch_kCUDA
   use ftorch_types, only: torch_kFloat32
@@ -60,4 +60,4 @@ contains
 
   end subroutine test_get_device_index_default
 
-end module unittest_interrogation_cuda
+end module unittest_tensor_interrogation_cuda

--- a/test/unit/tensor/unittest_tensor_manipulation.pf
+++ b/test/unit/tensor/unittest_tensor_manipulation.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_manipulation
+module unittest_tensor_manipulation
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: torch_kFloat32
@@ -49,4 +49,4 @@ contains
 
   end subroutine test_zero
 
-end module unittest_manipulation
+end module unittest_tensor_manipulation

--- a/test/unit/tensor/unittest_tensor_manipulation_cuda.pf
+++ b/test/unit/tensor/unittest_tensor_manipulation_cuda.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_manipulation_cuda
+module unittest_tensor_manipulation_cuda
   use funit
   use ftorch_devices, only: torch_kCPU, torch_kCUDA
   use ftorch_types, only: torch_kFloat32, torch_kFloat64
@@ -74,4 +74,4 @@ contains
 
   end subroutine test_to
 
-end module unittest_manipulation_cuda
+end module unittest_tensor_manipulation_cuda

--- a/test/unit/tensor/unittest_tensor_operator_overloads.pf
+++ b/test/unit/tensor/unittest_tensor_operator_overloads.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_operator_overloads
+module unittest_tensor_operator_overloads
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: torch_kFloat32
@@ -434,4 +434,4 @@ contains
 
   end subroutine test_sqrt
 
-end module unittest_operator_overloads
+end module unittest_tensor_operator_overloads

--- a/test/unit/tensor/unittest_tensor_operator_overloads_autograd.pf
+++ b/test/unit/tensor/unittest_tensor_operator_overloads_autograd.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_operator_overloads_autograd
+module unittest_tensor_operator_overloads_autograd
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: ftorch_int, torch_kFloat32
@@ -502,4 +502,4 @@ contains
 
   end subroutine test_sqrt
 
-end module unittest_operator_overloads_autograd
+end module unittest_tensor_operator_overloads_autograd

--- a/test/unit/tensor/unittest_tensor_operators.pf
+++ b/test/unit/tensor/unittest_tensor_operators.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_operators
+module unittest_tensor_operators
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: torch_kFloat32
@@ -97,4 +97,4 @@ contains
 
   end subroutine test_mean
 
-end module unittest_operators
+end module unittest_tensor_operators

--- a/test/unit/tensor/unittest_tensor_operators_autograd.pf
+++ b/test/unit/tensor/unittest_tensor_operators_autograd.pf
@@ -4,7 +4,7 @@
 !    FTorch is released under an MIT license.
 !    See the [LICENSE](https://github.com/Cambridge-ICCS/FTorch/blob/main/LICENSE)
 !    file for details.
-module unittest_operators_autograd
+module unittest_tensor_operators_autograd
   use funit
   use ftorch_devices, only: torch_kCPU
   use ftorch_types, only: torch_kFloat32
@@ -98,4 +98,4 @@ contains
 
   end subroutine test_mean
 
-end module unittest_operators_autograd
+end module unittest_tensor_operators_autograd


### PR DESCRIPTION
Closes #531 

From the issue:
> Now that we put the unit tests in subdirectories by module in https://github.com/Cambridge-ICCS/FTorch/pull/511, there is some redundancy in the filenames, test names, and error messages. While writing tests for https://github.com/Cambridge-ICCS/FTorch/pull/528, I started hitting line truncation errors due to excessively long test names, so this is a good opportunity to cut down.

Unfortunately, if we remove the `_tensor` and `_model` from the filenames then we end up with conflicting test names and get a build failure. This is because the test suite names need to match and so pFUnit registers multiple test suites with the same name. As such, I was only able to shorten the names of the tests within the suite. Anything else would require broader changes to the naming scheme.