### PR TITLE
WIP: init debian package generation via cpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,3 +253,6 @@ install(
   "${PROJECT_BINARY_DIR}/${LIB_NAME}.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
+
+# CPack stuff
+include("${PROJECT_SOURCE_DIR}/cmake/FTorchPackaging.cmake")

--- a/cmake/FTorchPackaging.cmake
+++ b/cmake/FTorchPackaging.cmake
@@ -1,0 +1,35 @@
+# Set package information
+set(
+  CPACK_PACKAGE_VENDOR
+  "University of Cambridge Institute of Computing for Climate Science")
+set(CPACK_PACKAGE_CONTACT "Jared Frazier (cscidev001@gmail.com)")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fortran interface to PyTorch models")
+set(CPACK_PACKAGE_DESCRIPTION
+  "FTorch is a library for calling PyTorch machine learning models directly
+from Fortran code. It enables coupling TorchScript models trained in PyTorch
+to existing Fortran applications without requiring Python at runtime.")
+set(CPACK_PACKAGE_VERSION_MAJOR "${CMAKE_PROJECT_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR "${CMAKE_PROJECT_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH "${CMAKE_PROJECT_VERSION_PATCH}")
+set(CPACK_PACKAGE_VERSION "${CMAKE_PROJECT_VERSION}")
+
+# Explicitly set architecture
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+
+# Set the names of the package that get generated
+# e.g., `make package` produces ${CPACK_PACKAGE_FILE_NAME}.tar.gz
+set(
+  CPACK_PACKAGE_FILE_NAME
+  "${CMAKE_PROJECT_NAME}-"
+  "${CPACK_PACKAGE_VERSION}-"
+  "${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
+set(
+  CPACK_SOURCE_PACKAGE_FILE_NAME
+  "${CMAKE_PROJECT_NAME}-"
+  "${CPACK_PACKAGE_VERSION}-"
+  "${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
+
+# Generate better dependency list
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS TRUE)
+
+include(CPack)


### PR DESCRIPTION
Towards https://github.com/Cambridge-ICCS/FTorch/issues/499

Work in progress, just opening PR to show ongoing effort. Definitely not shippable yet.

Adds some basic cpack logic to generate a debian package for FTorch. I have been able to successfully generate a debian package on an x86_64 Ubuntu 24.04 LTS machine. You can try out the debian package generation via the following commands:

```shell
git clone git@github.com:jfdev001/FTorch.git
cd FTorch
git checkout -b jfrazier/499-debian-package origin/jfrazier/499-debian-package
export Torch_DIR=<your path to cpu torch installation here> # gpu torch has not been tried
mkdir build
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build
cd build 
cpack -G DEB --config CPackConfig.cmake 
```

You can then inspect the generated debian package with `dpkg`. E.g.,

```shell
dpkg -e FTorch-1.0.0-amd64.deb
```

outputs `DEBIAN/control` which contains

```text
Architecture: amd64
Depends: libc6 (>= 2.32), libgcc-s1 (>= 3.0), libgfortran5 (>= 8), libstdc++6 (>= 5.2)
Description: Fortran interface to PyTorch models
 FTorch is a library for calling PyTorch machine learning models directly
 from Fortran code. It enables coupling TorchScript models trained in PyTorch
 to existing Fortran applications without requiring Python at runtime.
Maintainer: Jared Frazier (cscidev001@gmail.com)
Package: ftorch
Priority: optional
Section: devel
Version: 1.0.0
Installed-Size: 296
```

Similarly, 

```shell
dpkg -c FTorch-1.0.0-amd64.deb
```

outputs

```text
drwxrwxr-x root/root         0 2026-02-26 14:56 ./usr/include/
-rw-r--r-- root/root     14079 2026-02-26 11:15 ./usr/include/ctorch.h
drwxrwxr-x root/root         0 2026-02-26 14:56 ./usr/include/ftorch/
-rw-r--r-- root/root     10342 2026-02-26 14:56 ./usr/include/ftorch/ftorch.mod
-rw-r--r-- root/root       393 2026-02-26 14:56 ./usr/include/ftorch/ftorch_devices.mod
-rw-r--r-- root/root      3404 2026-02-26 14:56 ./usr/include/ftorch/ftorch_model.mod
-rw-r--r-- root/root     10593 2026-02-26 14:56 ./usr/include/ftorch/ftorch_tensor.mod
-rw-r--r-- root/root      2037 2026-02-26 14:56 ./usr/include/ftorch/ftorch_test_utils.mod
-rw-r--r-- root/root       454 2026-02-26 14:56 ./usr/include/ftorch/ftorch_types.mod
drwxrwxr-x root/root         0 2026-02-26 14:56 ./usr/lib/
drwxrwxr-x root/root         0 2026-02-26 14:56 ./usr/lib/cmake/
drwxrwxr-x root/root         0 2026-02-26 14:56 ./usr/lib/cmake/FTorch/
-rw-r--r-- root/root      1255 2026-02-26 14:56 ./usr/lib/cmake/FTorch/FTorchConfig.cmake
-rw-r--r-- root/root       888 2026-02-26 14:56 ./usr/lib/cmake/FTorch/FTorchTargets-release.cmake
-rw-r--r-- root/root      4074 2026-02-26 14:56 ./usr/lib/cmake/FTorch/FTorchTargets.cmake
-rw-r--r-- root/root    226560 2026-02-26 14:56 ./usr/lib/libftorch.so
drwxrwxr-x root/root         0 2026-02-26 14:56 ./usr/lib/pkgconfig/
-rw-r--r-- root/root       321 2026-02-26 14:56 ./usr/lib/pkgconfig/ftorch.pc
```

TODO:

- [ ] Test debian package (currently built with CPU torch version only)
- [ ] Update CI to add some lightweight smoke test for the generated debian package
- [ ] More modular logic for desired architecture (e.g., only amd64 is explicitly supported at the moment)
- [ ] Add logic for RPM package generation
- [ ] Update CI that automatically builds the .deb/.rpm packages to be pushed to releases when releasing a new version of FTorch (see e.g., https://github.com/aaddrick/claude-desktop-debian/blob/4093324f0691e8789f6ab45acd2027394e8d5ff2/.github/workflows/ci.yml#L76-L82 and replace https://github.com/aaddrick/claude-desktop-debian/blob/4093324f0691e8789f6ab45acd2027394e8d5ff2/.github/workflows/build-amd64.yml#L44-L61 with calls to `cpack`)
