### PR TITLE
Fixes for Zizmor security alerts

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 
@@ -66,7 +66,7 @@ jobs:
         run: ford FTorch.md
 
       - name: Test docs build
-        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: docs-test # The branch the action should deploy to.
           folder: doc      # The folder the action should deploy.
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.2.0
         with:
           python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 
@@ -115,7 +115,7 @@ jobs:
         run: ford FTorch.md
 
       - name: Deploy Documentation for main
-        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc      # The folder the action should deploy.

--- a/.github/workflows/preprocessing.yml
+++ b/.github/workflows/preprocessing.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -116,7 +116,7 @@ jobs:
       # Configurable using the .clang-format and .clang-tidy config files if present
       - name: clang source
         if: always()
-        uses: cpp-linter/cpp-linter-action@b7fbdde0f6776f478f4d8867c2b746077fa7ea89 # v2
+        uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5 # v2.18.0
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -107,13 +107,13 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Fortran
-        uses: fortran-lang/setup-fortran@d2ba6ea44297a24407def2f6e117954d844a5368 # v1
+        uses: fortran-lang/setup-fortran@2a1b9c55897d827a9dfeb114408f3615e53b2b72 # v1.9.0
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
 
       - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/test_suite_ubuntu_cpu_intel.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_intel.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 
       - name: Install ftorch_utils
-        shell: cmd
+        shell: pwsh
         run: |
           pip install --upgrade pip
           python -m venv ftorch
@@ -69,7 +69,7 @@ jobs:
           pip install . --group test
 
       - name: Build FTorch
-        shell: cmd
+        shell: pwsh
         run: |
           call ftorch\Scripts\activate
           rem Find Python executable in venv
@@ -96,13 +96,13 @@ jobs:
           cmake --install build
 
       - name: Run Python unit tests
-        shell: cmd
+        shell: pwsh
         run: |
           call ftorch\Scripts\activate
           pytest --verbose test/ftorch_utils
 
       - name: Integration tests
-        shell: cmd
+        shell: pwsh
         run: |
           call ftorch\Scripts\activate
           set TORCH_PATH=
@@ -118,7 +118,7 @@ jobs:
           ctest --verbose --tests-regex example_autograd
 
       - name: Standalone SimpleNet example
-        shell: cmd
+        shell: pwsh
         run: |
           call ftorch\Scripts\activate
           for /f %%i in ('python -c "import sys; print(sys.executable)"') do set PYTHON_EXECUTABLE=%%i

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -72,11 +72,11 @@ jobs:
         shell: pwsh
         run: |
           .\ftorch\Scripts\Activate.ps1
-          rem Find Python executable in venv
+          # Find Python executable in venv
           $PYTHON_EXECUTABLE = python -c "import sys; print(sys.executable)"
-          rem Find torch location
+          # Find torch location
           $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
-          rem Set install location
+          # Set install location
           $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
           cmake `
             -Bbuild `
@@ -104,11 +104,11 @@ jobs:
         shell: pwsh
         run: |
           .\ftorch\Scripts\Activate.ps1
-          rem Find Python executable in venv
+          # Find Python executable in venv
           $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
-          rem Set install location
+          # Set install location
           $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
-          rem Add FTorch and PyTorch to the path for the test executables
+          # Add FTorch and PyTorch to the path for the test executables
           $PATH = "$env:FTORCH_INSTALL_DIR\bin;$env:TORCH_PATH\torch\lib;$env:PATH"
           cd build
           ctest --verbose --tests-regex example_tensor
@@ -121,13 +121,13 @@ jobs:
         shell: pwsh
         run: |
           .\ftorch\Scripts\Activate.ps1
-          rem Find Python executable in venv
+          # Find Python executable in venv
           $PYTHON_EXECUTABLE = python -c "import sys; print(sys.executable)"
-          rem Find torch location
+          # Find torch location
           $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
-          rem Set install location
+          # Set install location
           $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
-          rem Add FTorch and PyTorch to the path for the test executables
+          # Add FTorch and PyTorch to the path for the test executables
           $PATH = "$env:FTORCH_INSTALL_DIR\bin;$env:TORCH_PATH\torch\lib;$env:PATH"
           $EXAMPLE_BUILD_DIR = "examples\02_SimpleNet\build"
           if not exist $EXAMPLE_BUILD_DIR mkdir $EXAMPLE_BUILD_DIR

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -42,7 +42,8 @@ jobs:
 
     steps:
       # configure windows VM with intel compilers
-      - uses: fortran-lang/setup-fortran@d2ba6ea44297a24407def2f6e117954d844a5368 # v1
+      - name: Setup Fortran
+        uses: fortran-lang/setup-fortran@2a1b9c55897d827a9dfeb114408f3615e53b2b72 # v1.9.0
         id: setup-fortran
         with:
           compiler: ${{ matrix.toolchain.compiler }}
@@ -55,7 +56,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'  # Use 3.13 as no PyTorch wheels for 3.14 yet.
 

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -65,51 +65,51 @@ jobs:
         run: |
           pip install --upgrade pip
           python -m venv ftorch
-          call ftorch\Scripts\activate
+          .\ftorch\Scripts\Activate.ps1
           pip install . --group test
 
       - name: Build FTorch
         shell: pwsh
         run: |
-          call ftorch\Scripts\activate
+          .\ftorch\Scripts\Activate.ps1
           rem Find Python executable in venv
-          for /f %%i in ('python -c "import sys; print(sys.executable)"') do set PYTHON_EXECUTABLE=%%i
+          $PYTHON_EXECUTABLE = python -c "import sys; print(sys.executable)"
           rem Find torch location
-          set TORCH_PATH=
-          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set TORCH_PATH=%%i
+          $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
           rem Set install location
-          set FTORCH_INSTALL_DIR=%TEMP%\ftorch-install
-          cmake ^
-            -Bbuild ^
-            -G "NMake Makefiles" ^
-            -DPython_EXECUTABLE=%PYTHON_EXECUTABLE% ^
-            -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" ^
-            -DCMAKE_CXX_FLAGS="/D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" ^
-            -DCMAKE_PREFIX_PATH=%TORCH_PATH% ^
-            -DCMAKE_BUILD_TYPE=Release ^
-            -DCMAKE_Fortran_COMPILER=ifx ^
-            -DCMAKE_C_COMPILER=icx ^
-            -DCMAKE_CXX_COMPILER=icx ^
-            -DCMAKE_BUILD_TESTS=TRUE ^
-            -DCMAKE_INSTALL_PREFIX=%FTORCH_INSTALL_DIR%
+          $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
+          cmake `
+            -Bbuild `
+            -G "NMake Makefiles" `
+            -DPython_EXECUTABLE=$PYTHON_EXECUTABLE `
+            -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" `
+            -DCMAKE_CXX_FLAGS="/D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
+            -DCMAKE_PREFIX_PATH=$TORCH_PATH `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_Fortran_COMPILER=ifx `
+            -DCMAKE_C_COMPILER=icx `
+            -DCMAKE_CXX_COMPILER=icx `
+            -DCMAKE_BUILD_TESTS=TRUE `
+            -DCMAKE_INSTALL_PREFIX=$FTORCH_INSTALL_DIR
           cmake --build build
           cmake --install build
 
       - name: Run Python unit tests
         shell: pwsh
         run: |
-          call ftorch\Scripts\activate
+          .\ftorch\Scripts\Activate.ps1
           pytest --verbose test/ftorch_utils
 
       - name: Integration tests
         shell: pwsh
         run: |
-          call ftorch\Scripts\activate
-          set TORCH_PATH=
-          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set TORCH_PATH=%%i
-          set FTORCH_INSTALL_DIR=%TEMP%\ftorch-install
-          set PATH=%FTORCH_INSTALL_DIR%\bin;%PATH%
-          set PATH=%TORCH_PATH%\torch\lib;%PATH%
+          .\ftorch\Scripts\Activate.ps1
+          rem Find Python executable in venv
+          $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
+          rem Set install location
+          $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
+          rem Add FTorch and PyTorch to the path for the test executables
+          $PATH = "$env:FTORCH_INSTALL_DIR\bin;$env:TORCH_PATH\torch\lib;$env:PATH"
           cd build
           ctest --verbose --tests-regex example_tensor
           ctest --verbose --tests-regex example_simplenet
@@ -120,23 +120,25 @@ jobs:
       - name: Standalone SimpleNet example
         shell: pwsh
         run: |
-          call ftorch\Scripts\activate
-          for /f %%i in ('python -c "import sys; print(sys.executable)"') do set PYTHON_EXECUTABLE=%%i
-          set TORCH_PATH=
-          for /f "tokens=2*" %%i in ('pip show torch ^| findstr /R "^Location"') do set TORCH_PATH=%%i
-          set FTORCH_INSTALL_DIR=%TEMP%\ftorch-install
-          set PATH=%FTORCH_INSTALL_DIR%\bin;%PATH%
-          set PATH=%TORCH_PATH%\torch\lib;%PATH%
-          set EXAMPLE_BUILD_DIR=examples\02_SimpleNet\build
-          if not exist %EXAMPLE_BUILD_DIR% mkdir %EXAMPLE_BUILD_DIR%
-          cd %EXAMPLE_BUILD_DIR%
-          cmake .. ^
-            -G "NMake Makefiles" ^
-            -DCMAKE_Fortran_COMPILER=ifx ^
-            -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" ^
-            -DPython_EXECUTABLE=%PYTHON_EXECUTABLE% ^
-            -DCMAKE_BUILD_TYPE=Release ^
-            -DCMAKE_PREFIX_PATH=%FTORCH_INSTALL_DIR%;%TORCH_PATH% ^
+          .\ftorch\Scripts\Activate.ps1
+          rem Find Python executable in venv
+          $PYTHON_EXECUTABLE = python -c "import sys; print(sys.executable)"
+          rem Find torch location
+          $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
+          rem Set install location
+          $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
+          rem Add FTorch and PyTorch to the path for the test executables
+          $PATH = "$env:FTORCH_INSTALL_DIR\bin;$env:TORCH_PATH\torch\lib;$env:PATH"
+          $EXAMPLE_BUILD_DIR = "examples\02_SimpleNet\build"
+          if not exist $EXAMPLE_BUILD_DIR mkdir $EXAMPLE_BUILD_DIR
+          cd $EXAMPLE_BUILD_DIR
+          cmake .. `
+            -G "NMake Makefiles" `
+            -DCMAKE_Fortran_COMPILER=ifx `
+            -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" `
+            -DPython_EXECUTABLE=%PYTHON_EXECUTABLE% `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_PREFIX_PATH=%FTORCH_INSTALL_DIR%;%TORCH_PATH% `
             -DCMAKE_BUILD_TESTS=TRUE
           cmake --build .
           ctest -V

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -75,22 +75,22 @@ jobs:
           # Find Python executable in venv
           $PYTHON_EXECUTABLE = python -c "import sys; print(sys.executable)"
           # Find torch location
-          $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
+          $Torch_DIR = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line -replace "^Location:\s*", "" })
           # Set install location
           $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
           cmake `
             -Bbuild `
             -G "NMake Makefiles" `
-            -DPython_EXECUTABLE=$PYTHON_EXECUTABLE `
+            -DPython_EXECUTABLE="$PYTHON_EXECUTABLE" `
             -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" `
             -DCMAKE_CXX_FLAGS="/D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
-            -DCMAKE_PREFIX_PATH=$TORCH_PATH `
+            -DCMAKE_PREFIX_PATH="$Torch_DIR\torch" `
             -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_Fortran_COMPILER=ifx `
             -DCMAKE_C_COMPILER=icx `
             -DCMAKE_CXX_COMPILER=icx `
             -DCMAKE_BUILD_TESTS=TRUE `
-            -DCMAKE_INSTALL_PREFIX=$FTORCH_INSTALL_DIR
+            -DCMAKE_INSTALL_PREFIX="$FTORCH_INSTALL_DIR"
           cmake --build build
           cmake --install build
 
@@ -105,11 +105,11 @@ jobs:
         run: |
           .\ftorch\Scripts\Activate.ps1
           # Find Python executable in venv
-          $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
+          $Torch_DIR = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line -replace "^Location:\s*", "" })
           # Set install location
           $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
           # Add FTorch and PyTorch to the path for the test executables
-          $PATH = "$env:FTORCH_INSTALL_DIR\bin;$env:TORCH_PATH\torch\lib;$env:PATH"
+          $env:PATH = "$FTORCH_INSTALL_DIR\bin;$Torch_DIR\torch\lib;$env:PATH"
           cd build
           ctest --verbose --tests-regex example_tensor
           ctest --verbose --tests-regex example_simplenet
@@ -124,21 +124,21 @@ jobs:
           # Find Python executable in venv
           $PYTHON_EXECUTABLE = python -c "import sys; print(sys.executable)"
           # Find torch location
-          $TORCH_PATH = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line.Split(':')[1].Trim() })
+          $Torch_DIR = (pip show torch | Select-String -Pattern "^Location" | ForEach-Object { $_.Line -replace "^Location:\s*", "" })
           # Set install location
           $FTORCH_INSTALL_DIR = "$env:TEMP\ftorch-install"
           # Add FTorch and PyTorch to the path for the test executables
-          $PATH = "$env:FTORCH_INSTALL_DIR\bin;$env:TORCH_PATH\torch\lib;$env:PATH"
+          $env:PATH = "$FTORCH_INSTALL_DIR\bin;$Torch_DIR\torch\lib;$env:PATH"
           $EXAMPLE_BUILD_DIR = "examples\02_SimpleNet\build"
-          if not exist $EXAMPLE_BUILD_DIR mkdir $EXAMPLE_BUILD_DIR
+          if (-not (Test-Path $EXAMPLE_BUILD_DIR)) { New-Item -ItemType Directory -Path $EXAMPLE_BUILD_DIR | Out-Null }
           cd $EXAMPLE_BUILD_DIR
           cmake .. `
             -G "NMake Makefiles" `
             -DCMAKE_Fortran_COMPILER=ifx `
             -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" `
-            -DPython_EXECUTABLE=%PYTHON_EXECUTABLE% `
+            -DPython_EXECUTABLE="$PYTHON_EXECUTABLE" `
             -DCMAKE_BUILD_TYPE=Release `
-            -DCMAKE_PREFIX_PATH=%FTORCH_INSTALL_DIR%;%TORCH_PATH% `
+            -DCMAKE_PREFIX_PATH="$FTORCH_INSTALL_DIR;$Torch_DIR\torch" `
             -DCMAKE_BUILD_TESTS=TRUE
           cmake --build .
           ctest -V


### PR DESCRIPTION
Closes #518

There are currently several security alerts on the [Code scanning](https://github.com/Cambridge-ICCS/FTorch/security/code-scanning) panel. There are two issues being reported in several places:
* Commit hash for a version tag not matching the tag referenced in the inline comment following it. This has happened in places where we weren't specific enough about the tag and it changed. For example, some packages update the `vX` tag whenever a minor `vX.Y.Z` tag is released, so using `vX` mean things get out of date.
* Use of Windows CMD, which has not been the recommended shell for several years. I updated these to use Powershell. (See https://docs.zizmor.sh/audits/#misfeature.)