### PR TITLE
CI fixes after merging online training

### DIFF
--- a/.github/workflows/test_suite_ubuntu_cpu_intel.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_intel.yml
@@ -165,3 +165,5 @@ jobs:
             -DCMAKE_Fortran_FLAGS="-std=${FORTRAN_STANDARD}"
           cmake --build .
           ctest -V
+
+# TODO: DO NOT MERGE (temporary touch)

--- a/.github/workflows/test_suite_ubuntu_cpu_intel.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_intel.yml
@@ -120,7 +120,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
             -DCMAKE_BUILD_TESTS=TRUE \
             -DCMAKE_PREFIX_PATH="${PFUNIT_DIR};${Torch_DIR}" \
-            -DCMAKE_Fortran_FLAGS="-stand ${FORTRAN_STANDARD}"
+            -DCMAKE_Fortran_FLAGS="-stand ${FORTRAN_STANDARD} -fpscomp logicals"
           cmake --build .
           cmake --install .
 
@@ -162,8 +162,6 @@ jobs:
             -DMPI_Fortran_COMPILER="${{ matrix.MPIFC }}" \
             -DCMAKE_PREFIX_PATH="${FTORCH_INSTALL_DIR};${Torch_DIR}" \
             -DCMAKE_BUILD_TESTS=TRUE \
-            -DCMAKE_Fortran_FLAGS="-std=${FORTRAN_STANDARD}"
+            -DCMAKE_Fortran_FLAGS="-stand ${FORTRAN_STANDARD} -fpscomp logicals"
           cmake --build .
           ctest -V
-
-# TODO: DO NOT MERGE (temporary touch)

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -100,6 +100,9 @@ jobs:
         env:
           FORTRAN_STANDARD: f2008
         run: |
+          # GitHub Actions doesn't source /etc/profile.d/ scripts, so the CUDA bin directory
+          # (added by the apt package post-install script) won't be in PATH automatically.
+          export PATH=/usr/local/cuda/bin:$PATH
           . ftorch/bin/activate
           VN=$(python -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
           export Torch_DIR=${VIRTUAL_ENV}/lib/python${VN}/site-packages

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -72,13 +72,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m venv ftorch
           . ftorch/bin/activate
-          # CUDA v12.9 chosen as latest supported by PyTorch
-          # Check this is <= what GPU-runner has installed (backwards compatible)
-          pip install . --extra-index-url https://download.pytorch.org/whl/cu129 --group test
+          pip install . --extra-index-url https://download.pytorch.org/whl/cu132 --group test
 
       - name: Install cmake and CUDA toolkit
         run: |
           sudo apt update
+          # NOTE: CUDA version should be consistent with the download above, i.e., 13.2
           sudo apt install -y cmake cuda-toolkit
 
         # Currently used by example_mpi

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -51,8 +51,8 @@ jobs:
     strategy:
       fail-fast: true
 
-    # Terminate the job if it runs for more than 15 minutes
-    timeout-minutes: 15
+    # Terminate the job if it runs for more than 20 minutes
+    timeout-minutes: 20
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -76,7 +76,7 @@ jobs:
           # Check this is <= what GPU-runner has installed (backwards compatible)
           pip install . --extra-index-url https://download.pytorch.org/whl/cu129 --group test
 
-      - name: Install cmake and NVIDIA dev toolkit
+      - name: Install cmake and CUDA toolkit
         run: |
           sudo apt update
           sudo apt install -y cmake cuda-toolkit

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -72,6 +72,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m venv ftorch
           . ftorch/bin/activate
+          # NOTE: CUDA version should be consistent with the download below, i.e., 13.2
           pip install . --extra-index-url https://download.pytorch.org/whl/cu132 --group test
 
       - name: Install cmake and CUDA toolkit

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install cmake and NVIDIA dev toolkit
         run: |
           sudo apt update
-          sudo apt install -y cmake nvidia-cuda-toolkit
+          sudo apt install -y cmake cuda-toolkit
 
         # Currently used by example_mpi
       - name: Install an MPI distribution

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -82,7 +82,7 @@ jobs:
             -Bbuild `
             -G "NMake Makefiles" `
             -DPython_EXECUTABLE="$PYTHON_EXECUTABLE" `
-            -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" `
+            -DCMAKE_Fortran_FLAGS="/stand:08 /fpscomp:logicals" `
             -DCMAKE_CXX_FLAGS="/D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
             -DCMAKE_PREFIX_PATH="$Torch_DIR\torch" `
             -DCMAKE_BUILD_TYPE=Release `
@@ -135,12 +135,10 @@ jobs:
           cmake .. `
             -G "NMake Makefiles" `
             -DCMAKE_Fortran_COMPILER=ifx `
-            -DCMAKE_Fortran_FLAGS="/fpscomp:logicals" `
+            -DCMAKE_Fortran_FLAGS="/stand:08 /fpscomp:logicals" `
             -DPython_EXECUTABLE="$PYTHON_EXECUTABLE" `
             -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_PREFIX_PATH="$FTORCH_INSTALL_DIR;$Torch_DIR\torch" `
             -DCMAKE_BUILD_TESTS=TRUE
           cmake --build .
           ctest -V
-
-# TODO: DO NOT MERGE (temporary touch)

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -142,3 +142,5 @@ jobs:
             -DCMAKE_BUILD_TESTS=TRUE
           cmake --build .
           ctest -V
+
+# TODO: DO NOT MERGE (temporary touch)

--- a/src/ftorch_model.f90
+++ b/src/ftorch_model.f90
@@ -214,7 +214,8 @@ contains
     n_outputs = size(output_tensors)
     do i = 1, n_outputs
       if (c_associated(output_tensors(i)%p)) then
-        write(*,*) "Warning :: tensor pointer will be lost in call to torch_model_parameters"
+        write(*,*) "Error :: tensor pointer will be lost in call to torch_model_parameters"
+        exit 1
       end if
     end do
 

--- a/src/ftorch_model.f90
+++ b/src/ftorch_model.f90
@@ -213,8 +213,7 @@ contains
     ! Check the tensors aren't already associated
     do i = 1, n_outputs
       if (c_associated(output_tensors(i)%p)) then
-        write(*,*) "Error :: tensor pointer will be lost in call to torch_model_parameters"
-        stop 1
+        write(*,*) "Warning :: tensor pointer will be lost in call to torch_model_parameters"
       end if
     end do
 

--- a/src/ftorch_model.f90
+++ b/src/ftorch_model.f90
@@ -215,7 +215,7 @@ contains
     do i = 1, n_outputs
       if (c_associated(output_tensors(i)%p)) then
         write(*,*) "Error :: tensor pointer will be lost in call to torch_model_parameters"
-        exit 1
+        stop 1
       end if
     end do
 

--- a/src/ftorch_model.f90
+++ b/src/ftorch_model.f90
@@ -211,6 +211,7 @@ contains
     end interface
 
     ! Check the tensors aren't already associated
+    n_outputs = size(output_tensors)
     do i = 1, n_outputs
       if (c_associated(output_tensors(i)%p)) then
         write(*,*) "Warning :: tensor pointer will be lost in call to torch_model_parameters"
@@ -218,7 +219,6 @@ contains
     end do
 
     ! Get the parameters that were created during model construction
-    n_outputs = size(output_tensors)
     call torch_jit_model_parameters_c(model%p, c_loc(output_ptrs), n_outputs)
 
     ! Copy updated pointers back to output tensors

--- a/src/ftorch_tensor.f90
+++ b/src/ftorch_tensor.f90
@@ -2921,14 +2921,15 @@ contains
       end subroutine torch_tensor_backward_without_external_gradient_c
     end interface
 
-    ! Accept a rank-0 tensor (0-dim PyTorch scalar) or a rank-1 size-1 tensor
     if (tensor%get_rank() == 1) then
+      ! Accept rank-1 tensors so long as they only have a single entry
       sizes(:) = tensor%get_shape()
       if (sizes(1) /= 1) then
         write(*,*) "Error :: external gradient can only be implicitly created for scalar fields"
         stop 1
       end if
     else if (tensor%get_rank() /= 0) then
+      ! Disallow anything else except rank-0 tensors (i.e., 0-dim PyTorch scalars)
       write(*,*) "Error :: external gradient can only be implicitly created for scalar fields"
       stop 1
     end if


### PR DESCRIPTION
This PR fixes the following CI failures:
* https://github.com/Cambridge-ICCS/FTorch/actions/runs/26089177778/job/76710058860 (fypp)
* https://github.com/Cambridge-ICCS/FTorch/actions/runs/26089177838/job/76710058731 (CUDA)
* https://github.com/Cambridge-ICCS/FTorch/actions/runs/26089177768/job/76710058940 (Windows)
* https://github.com/Cambridge-ICCS/FTorch/actions/runs/26089177791/job/76710058759 (Ubuntu / Intel)

## Summary

* Apply `fypp` to get `ftorch_tensor.fypp` and `ftorch_tensor.f90` realigned.
* Fix a rather silly error in `ftorch_model.f90` that was causing the Intel compiler to crash.
* Align CUDA version between toolkit and PyTorch.

## Other changes added in

* Tweaked flags passed to Intel compiler to reduce warnings.