### PR TITLE
Add Flang test workflow

### DIFF
--- a/.github/workflows/test_suite_macos_cpu_clang.yml
+++ b/.github/workflows/test_suite_macos_cpu_clang.yml
@@ -35,7 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         std: [f2008, f2018]
-        pfunit_version: [4.18.2]
+        pfunit_longversion: [4.18.2]
+        pfunit_shortversion: [4.18]
 
     # Terminate the job if it runs for more than 20 minutes
     timeout-minutes: 20
@@ -89,7 +90,7 @@ jobs:
       - name: Install pFUnit
         run: |
           # NOTE: version pin needed because version appears in install path
-          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          git clone -b "v${{ matrix.pfunit_longversion }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           cmake ..\
@@ -112,7 +113,7 @@ jobs:
           export FTORCH_INSTALL_DIR=/tmp/ftorch-install
           mkdir -p ${FTORCH_INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_shortversion }}"
           cd ${FTORCH_BUILD_DIR}
 
           cmake .. \

--- a/.github/workflows/test_suite_macos_cpu_clang.yml
+++ b/.github/workflows/test_suite_macos_cpu_clang.yml
@@ -132,7 +132,7 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: Check pkg-config file 
+      - name: Check pkg-config file
         run: |
           # pkg-config looks in the `build` directory for libraries
           export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:build

--- a/.github/workflows/test_suite_macos_cpu_clang.yml
+++ b/.github/workflows/test_suite_macos_cpu_clang.yml
@@ -27,37 +27,15 @@ permissions: {}
 
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
-  # Dynamically build matrix for job
-  setup-matrix:
-    name: setup matrix
-    runs-on: macos-latest
-
-    # Terminate the job if it runs for more than 5 minutes
-    timeout-minutes: 5
-
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    env:
-      EVENT_NAME: ${{ github.event_name }}
-    steps:
-      - id: set-matrix
-        run: |
-          MATRIX_JSON='
-          {
-            "std": ["f2008", "f2018"]
-          }'
-          # Convert json to compact line expected by github action
-          MATRIX_JSON=$(echo "$MATRIX_JSON" | jq -c .)
-          echo "matrix=${MATRIX_JSON}" >> $GITHUB_OUTPUT
-
   test-suite:
     name: clang, ${{ matrix.std }}
-    needs: setup-matrix
     # The type of runner that the job will run on
     runs-on: macos-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
+      matrix:
+        std: [f2008, f2018]
+        pfunit_version: [4.18.2]
 
     # Terminate the job if it runs for more than 20 minutes
     timeout-minutes: 20
@@ -110,8 +88,8 @@ jobs:
 
       - name: Install pFUnit
         run: |
-          # TODO: Avoid version pinning (needed because version appears in install path)
-          git clone -b v4.12.0 https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          # NOTE: version pin needed because version appears in install path
+          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           cmake ..\
@@ -134,7 +112,7 @@ jobs:
           export FTORCH_INSTALL_DIR=/tmp/ftorch-install
           mkdir -p ${FTORCH_INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR=$(pwd)/pFUnit/build/installed/PFUNIT-4.12
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
           cd ${FTORCH_BUILD_DIR}
 
           cmake .. \

--- a/.github/workflows/test_suite_macos_cpu_clang.yml
+++ b/.github/workflows/test_suite_macos_cpu_clang.yml
@@ -44,15 +44,14 @@ jobs:
         run: |
           MATRIX_JSON='
           {
-            "std": ["f2008", "f2018"],
-            "compiler": ["clang"]
+            "std": ["f2008", "f2018"]
           }'
           # Convert json to compact line expected by github action
           MATRIX_JSON=$(echo "$MATRIX_JSON" | jq -c .)
           echo "matrix=${MATRIX_JSON}" >> $GITHUB_OUTPUT
 
   test-suite:
-    name: test suite (${{ matrix.compiler }}, ${{ matrix.std }})
+    name: clang, ${{ matrix.std }}
     needs: setup-matrix
     # The type of runner that the job will run on
     runs-on: macos-latest

--- a/.github/workflows/test_suite_ubuntu_cpu_flang.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_flang.yml
@@ -1,0 +1,196 @@
+# Workflow to run the FTorch test suite using jobs for Flang compiler
+name: Test suite (Ubuntu CPU Flang)
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
+  push:
+    branches: [ "main" ]
+
+  # Triggers the workflow on pushes to open pull requests with changes to this workflow
+  pull_request:
+    paths:
+      - '.github/workflows/test_suite_ubuntu_cpu_flang.yml'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Write permissions are not required
+permissions: {}
+
+# Workflow run - one or more jobs that can run sequentially or in parallel
+jobs:
+  test-suite:
+    name: test suite
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        standard: [f2018]
+        flang_version: [21]
+        pfunit_version: [4.18.2]
+
+    # Terminate the job if it runs for more than 15 minutes
+    timeout-minutes: 15
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout FTorch repository
+        with:
+          persist-credentials: true
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Fortran
+        uses: fortran-lang/setup-fortran@2a1b9c55897d827a9dfeb114408f3615e53b2b72 # v1.9.0
+        with:
+          compiler: ${{ matrix.toolchain.compiler }}
+          version: ${{ matrix.toolchain.version }}
+
+      - name: Install Clang and Flang
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${flang_version} main"
+          sudo apt-get update
+          sudo apt-get install -y "llvm-${flang_version}-dev" "clang-${flang_version}" "flang-${flang_version}"
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Install ftorch_utils
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv ftorch
+          . ftorch/bin/activate
+          pip install . --extra-index-url https://download.pytorch.org/whl/cpu --group test
+
+      - name: Install OpenMPI
+        run: |
+          sudo apt update
+          sudo apt install -y openmpi-bin openmpi-common libopenmpi-dev
+
+      - name: Install pFUnit
+        run: |
+          # TODO: Avoid version pinning (needed because version appears in install path)
+          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          mkdir pFUnit/build
+          cd pFUnit/build
+          cmake ..\
+            -DCMAKE_Fortran_COMPILER=flang \
+            -DMPI_Fortran_COMPILER=mpif90
+          make -j 4 install
+
+      - name: Build FTorch
+        env:
+          FORTRAN_STANDARD: ${{ matrix.std }}
+        run: |
+          . ftorch/bin/activate
+          VN=$(python -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
+          export Torch_DIR=${VIRTUAL_ENV}/lib/python${VN}/site-packages
+          export BUILD_DIR=$(pwd)/build
+          mkdir -p ${BUILD_DIR}
+          # Install to /tmp/ to ensure independent from the CMake build in standalone check.
+          export INSTALL_DIR=/tmp/ftorch-install
+          mkdir -p ${INSTALL_DIR}
+          # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
+          cd ${BUILD_DIR}
+
+          cmake .. \
+            -DPython_EXECUTABLE="$(which python)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_Fortran_COMPILER=flang  \
+            -DCMAKE_C_COMPILER=clang  \
+            -DCMAKE_CXX_COMPILER=clang++  \
+            -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+            -DCMAKE_BUILD_TESTS=TRUE \
+            -DCMAKE_PREFIX_PATH="${PFUNIT_DIR};${Torch_DIR}" \
+            -DCMAKE_Fortran_FLAGS="-std=${FORTRAN_STANDARD}"
+          cmake --build .
+          cmake --install .
+
+      - name: Check pkg-config file 
+        run: |
+          # pkg-config looks in the `build` directory for libraries
+          export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:build
+
+          libs=$(pkg-config --libs ftorch)
+          cflags=$(pkg-config --cflags ftorch)
+
+          # Assert linker flags not empty
+          if [[ -z "${libs}" ]]
+          then
+            echo "::error ::pkg-config --libs ftorch returned empty output"
+            exit 1
+          fi
+
+          # Assert expected linker flags
+          lib_dir=$(grep -oE "\-L.*/lib" <<< ${libs})
+          lib=$(grep -oE "\-lftorch" <<< ${libs})
+          if [[ -z "${lib_dir}" || -z "${lib}" ]]
+          then
+            echo "::error ::pkg-config --libs ftorch do not contain expected linker flags"
+            exit 1
+          fi
+
+          # Assert compiler flags not empty
+          if [[ -z "${cflags}" ]]
+          then
+            echo "::error ::pkg-config --cflags ftorch returned empty output"
+            exit 1
+          fi
+
+          # Assert expected compiler flags
+          include_dir=$(grep -oE "/include " <<< ${cflags})
+          module_dir=$(grep -oE "/include/ftorch" <<< ${cflags})
+          if [[ -z ${include_dir} || -z ${module_dir} ]]
+          then
+              echo "::error ::pkg-config --cflags ftorch do not contain expected compiler flags"
+              exit 1
+          fi
+
+      - name: Run Fortran unit tests
+        run: |
+          . ftorch/bin/activate
+          cd build
+          ctest --verbose --tests-regex unit
+
+      - name: Run Python unit tests
+        run: |
+          . ftorch/bin/activate
+          pytest --verbose test/ftorch_utils
+
+      - name: Run integration tests
+        run: |
+          . ftorch/bin/activate
+          cd build
+          ctest --verbose --tests-regex example
+
+        # Check that we can successfully build and run an example outside the main FTorch build process
+      - name: Standalone SimpleNet example
+        env:
+          FORTRAN_STANDARD: ${{ matrix.std }}
+        run: |
+          . ftorch/bin/activate
+          VN=$(python -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
+          export Torch_DIR="${VIRTUAL_ENV}/lib/python${VN}/site-packages/torch"
+          export FTORCH_INSTALL_DIR="/tmp/ftorch-install"
+          export EXAMPLE_BUILD_DIR="examples/02_SimpleNet/build"
+          mkdir "${EXAMPLE_BUILD_DIR}"
+          cd "${EXAMPLE_BUILD_DIR}"
+          cmake .. \
+            -DPython_EXECUTABLE="$(which python)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="${FTORCH_INSTALL_DIR};${Torch_DIR}" \
+            -DCMAKE_BUILD_TESTS=TRUE \
+            -DCMAKE_Fortran_FLAGS="-std=${FORTRAN_STANDARD}"
+          cmake --build .
+          ctest -V

--- a/.github/workflows/test_suite_ubuntu_cpu_flang.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_flang.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        standard: [f2018]
+        std: [f2018]
         flang_version: [21]
         pfunit_version: [4.18.2]
 
@@ -56,9 +56,9 @@ jobs:
       - name: Install Clang and Flang
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${flang_version} main"
+          sudo apt-add-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ matrix.flang_version }} main"
           sudo apt-get update
-          sudo apt-get install -y "llvm-${flang_version}-dev" "clang-${flang_version}" "flang-${flang_version}"
+          sudo apt-get install -y "llvm-${{ matrix.flang_version }}-dev" "clang-${{ matrix.flang_version }}" "flang-${{ matrix.flang_version }}"
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/test_suite_ubuntu_cpu_flang.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_flang.yml
@@ -112,7 +112,7 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: Check pkg-config file 
+      - name: Check pkg-config file
         run: |
           # pkg-config looks in the `build` directory for libraries
           export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:build

--- a/.github/workflows/test_suite_ubuntu_cpu_flang.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_flang.yml
@@ -34,7 +34,8 @@ jobs:
       matrix:
         std: [f2018]
         flang_version: [21]
-        pfunit_version: [4.18.2]
+        pfunit_longversion: [4.18.2]
+        pfunit_shortversion: [4.18]
 
     # Terminate the job if it runs for more than 15 minutes
     timeout-minutes: 15
@@ -74,7 +75,7 @@ jobs:
       - name: Install pFUnit
         run: |
           # TODO: Avoid version pinning (needed because version appears in install path)
-          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          git clone -b "v${{ matrix.pfunit_longversion }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           cmake ..\
@@ -95,7 +96,7 @@ jobs:
           export INSTALL_DIR=/tmp/ftorch-install
           mkdir -p ${INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_shortversion }}"
           cd ${BUILD_DIR}
 
           cmake .. \

--- a/.github/workflows/test_suite_ubuntu_cpu_flang.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_flang.yml
@@ -47,12 +47,6 @@ jobs:
           persist-credentials: true
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Setup Fortran
-        uses: fortran-lang/setup-fortran@2a1b9c55897d827a9dfeb114408f3615e53b2b72 # v1.9.0
-        with:
-          compiler: flang
-          version: ${{ matrix.flang_version }}
-
       - name: Install Clang and Flang
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/.github/workflows/test_suite_ubuntu_cpu_flang.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_flang.yml
@@ -84,7 +84,7 @@ jobs:
           mkdir pFUnit/build
           cd pFUnit/build
           cmake ..\
-            -DCMAKE_Fortran_COMPILER=flang \
+            -DCMAKE_Fortran_COMPILER="flang-${{ matrix.flang_version }}" \
             -DMPI_Fortran_COMPILER=mpif90
           make -j 4 install
 
@@ -107,7 +107,7 @@ jobs:
           cmake .. \
             -DPython_EXECUTABLE="$(which python)" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_Fortran_COMPILER=flang  \
+            -DCMAKE_Fortran_COMPILER="flang-${{ matrix.flang_version }}" \
             -DCMAKE_C_COMPILER=clang  \
             -DCMAKE_CXX_COMPILER=clang++  \
             -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \

--- a/.github/workflows/test_suite_ubuntu_cpu_flang.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_flang.yml
@@ -1,5 +1,5 @@
 # Workflow to run the FTorch test suite using jobs for Flang compiler
-name: Test suite (Ubuntu CPU Flang)
+name: Test suite (Ubuntu CPU)
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/test_suite_ubuntu_cpu_flang.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_flang.yml
@@ -26,7 +26,7 @@ permissions: {}
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   test-suite:
-    name: test suite
+    name: flang ${{ matrix.flang_version }}, ${{ matrix.standard }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
@@ -50,8 +50,8 @@ jobs:
       - name: Setup Fortran
         uses: fortran-lang/setup-fortran@2a1b9c55897d827a9dfeb114408f3615e53b2b72 # v1.9.0
         with:
-          compiler: ${{ matrix.toolchain.compiler }}
-          version: ${{ matrix.toolchain.version }}
+          compiler: flang
+          version: ${{ matrix.flang_version }}
 
       - name: Install Clang and Flang
         run: |

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -52,27 +52,17 @@ jobs:
         pfunit_longversion: ["4.18.2"]
         pfunit_shortversion: ["4.18"]
         include:
+          - std: f2008
+          # Configuration for pushes to main
+          - gcc_version: ${{ github.event_name == 'push' && 9 }}
+          - gcc_version: ${{ github.event_name == 'push' && 10 }}
+          - gcc_version: ${{ github.event_name == 'push' && 11 }}
+          - gcc_version: ${{ github.event_name == 'push' && 12 }}
           - gcc_version: 13
-            std: f2008
-            if: github.event_name == 'push'
-          - gcc_version: 13
-            std: f2018
-            if: github.event_name == 'push'
-          - gcc_version: 9
-            std: f2008
-            if: github.event_name != 'push'
-          - gcc_version: 10
-            std: f2008
-            if: github.event_name != 'push'
-          - gcc_version: 11
-            std: f2008
-            if: github.event_name != 'push'
-          - gcc_version: 12
-            std: f2008
-            if: github.event_name != 'push'
-          - gcc_version: 13
-            std: f2008
-            if: github.event_name != 'push'
+          - std: ${{ github.event_name == 'push' && 'f2018' }}
+            gcc_version: 13
+          # Configuration for pull requests etc.
+          - std: ${{ github.event_name != 'push' && 'f2018' }}
 
     # Terminate the job if it runs for more than 15 minutes
     timeout-minutes: 15

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -40,64 +40,21 @@ permissions: {}
 
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
-  # Dynamically build matrix for GNU job
-  setup-matrix:
-    name: setup matrix
-    runs-on: ubuntu-latest
-
-    # Terminate the job if it runs for more than 5 minutes
-    timeout-minutes: 5
-
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    env:
-      EVENT_NAME: ${{ github.event_name }}
-    steps:
-      - id: set-matrix
-        run: |
-          if [[ "$EVENT_NAME" == 'push' ]]
-          then
-            # Include GCC 9–13 for PRs to main
-            MATRIX_JSON='
-            {
-              "toolchain": [
-                {"compiler": "gcc", "version": 13},
-                {"compiler": "gcc", "version": 12},
-                {"compiler": "gcc", "version": 11},
-                {"compiler": "gcc", "version": 10},
-                {"compiler": "gcc", "version": 9}
-              ],
-              "std": ["f2008"],
-              "include": [
-                {"toolchain": {"compiler": "gcc", "version": 13}, "std": "f2018"}
-              ],
-              "pfunit_longversion": ["4.18.2"],
-              "pfunit_shortversion": ["4.18"]
-            }'
-          else
-            # Only GCC 13 for everything else
-            MATRIX_JSON='
-            {
-              "toolchain": [
-                {"compiler": "gcc", "version": 13}
-              ],
-              "std": ["f2008", "f2018"],
-              "pfunit_longversion": ["4.18.2"],
-              "pfunit_shortversion": ["4.18"]
-            }'
-          fi
-          # Convert json to compact line expected by github action
-          MATRIX_JSON=$(echo "$MATRIX_JSON" | jq -c .)
-          echo "matrix=${MATRIX_JSON}" >> $GITHUB_OUTPUT
-
   test-suite:
-    name: gfortran ${{ matrix.toolchain.version }}, ${{ matrix.toolchain.std }}
+    name: gfortran ${{ matrix.gcc_version }}, ${{ matrix.std }}
     needs: setup-matrix
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
+      matrix:
+        std: ["f2008"]
+        gcc_version: [9, 10, 11, 12, 13]
+        pfunit_longversion: ["4.18.2"]
+        pfunit_shortversion: ["4.18"]
+        include:
+          - gcc_version: ${{ github.event_name == 'push' && 13 }}
+          - std: ${{ github.event_name != 'push' && f2018 }}
 
     # Terminate the job if it runs for more than 15 minutes
     timeout-minutes: 15
@@ -113,8 +70,8 @@ jobs:
       - name: Setup Fortran
         uses: fortran-lang/setup-fortran@2a1b9c55897d827a9dfeb114408f3615e53b2b72 # v1.9.0
         with:
-          compiler: ${{ matrix.toolchain.compiler }}
-          version: ${{ matrix.toolchain.version }}
+          compiler: gcc
+          version: ${{ matrix.gcc_version }}
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -42,7 +42,6 @@ permissions: {}
 jobs:
   test-suite:
     name: gfortran ${{ matrix.gcc_version }}, ${{ matrix.std }}
-    needs: setup-matrix
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -54,7 +54,7 @@ jobs:
         pfunit_shortversion: ["4.18"]
         include:
           - gcc_version: ${{ github.event_name == 'push' && 13 }}
-          - std: ${{ github.event_name != 'push' && f2018 }}
+          - std: ${{ github.event_name != 'push' && 'f2018' }}
 
     # Terminate the job if it runs for more than 15 minutes
     timeout-minutes: 15

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -47,22 +47,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        std: ["f2008"]
+        std: ["f2008", "f2018"]
         gcc_version: [9, 10, 11, 12, 13]
         pfunit_longversion: ["4.18.2"]
         pfunit_shortversion: ["4.18"]
-        include:
-          - std: f2008
+        exclude:
           # Configuration for pushes to main
           - gcc_version: ${{ github.event_name == 'push' && 9 }}
+            std: f2018
           - gcc_version: ${{ github.event_name == 'push' && 10 }}
+            std: f2018
           - gcc_version: ${{ github.event_name == 'push' && 11 }}
+            std: f2018
           - gcc_version: ${{ github.event_name == 'push' && 12 }}
-          - gcc_version: 13
-          - std: ${{ github.event_name == 'push' && 'f2018' }}
-            gcc_version: 13
+            std: f2018
           # Configuration for pull requests etc.
-          - std: ${{ github.event_name != 'push' && 'f2018' }}
+          - gcc_version: ${{ github.event_name != 'push' && 9 }}
+          - gcc_version: ${{ github.event_name != 'push' && 10 }}
+          - gcc_version: ${{ github.event_name != 'push' && 11 }}
+          - gcc_version: ${{ github.event_name != 'push' && 12 }}
 
     # Terminate the job if it runs for more than 15 minutes
     timeout-minutes: 15

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -70,7 +70,8 @@ jobs:
               "std": ["f2008"],
               "include": [
                 {"toolchain": {"compiler": "gcc", "version": 13}, "std": "f2018"}
-              ]
+              ],
+              "pfunit_version": [4.18.2]
             }'
           else
             # Only GCC 13 for everything else
@@ -79,7 +80,8 @@ jobs:
               "toolchain": [
                 {"compiler": "gcc", "version": 13}
               ],
-              "std": ["f2008", "f2018"]
+              "std": ["f2008", "f2018"],
+              "pfunit_version": [4.18.2]
             }'
           fi
           # Convert json to compact line expected by github action
@@ -131,8 +133,8 @@ jobs:
 
       - name: Install pFUnit
         run: |
-          # TODO: Avoid version pinning (needed because version appears in install path)
-          git clone -b v4.12.0 https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          # NOTE: version pin needed because version appears in install path
+          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           cmake ..\
@@ -153,7 +155,7 @@ jobs:
           export INSTALL_DIR=/tmp/ftorch-install
           mkdir -p ${INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR=$(pwd)/pFUnit/build/installed/PFUNIT-4.12
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
           cd ${BUILD_DIR}
 
           cmake .. \

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -87,7 +87,7 @@ jobs:
           echo "matrix=${MATRIX_JSON}" >> $GITHUB_OUTPUT
 
   test-suite:
-    name: test suite
+    name: gfortran ${{ matrix.toolchain.version }}, $${{ matrix.toolchain.std }}
     needs: setup-matrix
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -89,7 +89,7 @@ jobs:
           echo "matrix=${MATRIX_JSON}" >> $GITHUB_OUTPUT
 
   test-suite:
-    name: gfortran ${{ matrix.toolchain.version }}, $${{ matrix.toolchain.std }}
+    name: gfortran ${{ matrix.toolchain.version }}, ${{ matrix.toolchain.std }}
     needs: setup-matrix
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -1,5 +1,5 @@
 # Workflow to run the FTorch test suite using jobs for GNU compiler
-name: Test suite (Ubuntu CPU GNU)
+name: Test suite (Ubuntu CPU)
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -71,7 +71,7 @@ jobs:
               "include": [
                 {"toolchain": {"compiler": "gcc", "version": 13}, "std": "f2018"}
               ],
-              "pfunit_version": [4.18.2]
+              "pfunit_version": ["4.18.2"]
             }'
           else
             # Only GCC 13 for everything else
@@ -81,7 +81,7 @@ jobs:
                 {"compiler": "gcc", "version": 13}
               ],
               "std": ["f2008", "f2018"],
-              "pfunit_version": [4.18.2]
+              "pfunit_version": ["4.18.2"]
             }'
           fi
           # Convert json to compact line expected by github action

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -52,8 +52,27 @@ jobs:
         pfunit_longversion: ["4.18.2"]
         pfunit_shortversion: ["4.18"]
         include:
-          - gcc_version: ${{ github.event_name == 'push' && 13 }}
-          - std: ${{ github.event_name != 'push' && 'f2018' }}
+          - gcc_version: 13
+            std: f2008
+            if: github.event_name == 'push'
+          - gcc_version: 13
+            std: f2018
+            if: github.event_name == 'push'
+          - gcc_version: 9
+            std: f2008
+            if: github.event_name != 'push'
+          - gcc_version: 10
+            std: f2008
+            if: github.event_name != 'push'
+          - gcc_version: 11
+            std: f2008
+            if: github.event_name != 'push'
+          - gcc_version: 12
+            std: f2008
+            if: github.event_name != 'push'
+          - gcc_version: 13
+            std: f2008
+            if: github.event_name != 'push'
 
     # Terminate the job if it runs for more than 15 minutes
     timeout-minutes: 15

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -71,7 +71,8 @@ jobs:
               "include": [
                 {"toolchain": {"compiler": "gcc", "version": 13}, "std": "f2018"}
               ],
-              "pfunit_version": ["4.18.2"]
+              "pfunit_longversion": ["4.18.2"],
+              "pfunit_shortversion": ["4.18"]
             }'
           else
             # Only GCC 13 for everything else
@@ -81,7 +82,8 @@ jobs:
                 {"compiler": "gcc", "version": 13}
               ],
               "std": ["f2008", "f2018"],
-              "pfunit_version": ["4.18.2"]
+              "pfunit_longversion": ["4.18.2"],
+              "pfunit_shortversion": ["4.18"]
             }'
           fi
           # Convert json to compact line expected by github action
@@ -134,7 +136,7 @@ jobs:
       - name: Install pFUnit
         run: |
           # NOTE: version pin needed because version appears in install path
-          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          git clone -b "v${{ matrix.pfunit_longversion }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           cmake ..\
@@ -155,7 +157,7 @@ jobs:
           export INSTALL_DIR=/tmp/ftorch-install
           mkdir -p ${INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_shortversion }}"
           cd ${BUILD_DIR}
 
           cmake .. \

--- a/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_gnu.yml
@@ -148,7 +148,7 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: Check pkg-config file 
+      - name: Check pkg-config file
         run: |
           # pkg-config looks in the `build` directory for libraries
           export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:build

--- a/.github/workflows/test_suite_ubuntu_cpu_intel.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_intel.yml
@@ -47,7 +47,8 @@ jobs:
             MPIFC: mpiifort
             version: 2024.2.0  # Last release of oneapi with ifort
         std: [f08]
-        pfunit_version: [4.18.2]
+        pfunit_longversion: [4.18.2]
+        pfunit_shortversion: [4.18]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -85,7 +86,7 @@ jobs:
       - name: Install pFUnit
         run: |
           # NOTE: version pin needed because version appears in install path
-          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          git clone -b "v${{ matrix.pfunit_longversion }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           cmake .. \
@@ -107,7 +108,7 @@ jobs:
           export INSTALL_DIR="/tmp/ftorch-install"
           mkdir -p ${INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_shortversion }}"
           mkdir -p ${BUILD_DIR}
           cd ${BUILD_DIR}
 

--- a/.github/workflows/test_suite_ubuntu_cpu_intel.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_intel.yml
@@ -26,7 +26,7 @@ permissions: {}
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   test-suite:
-    name: ${{ matrix.FC }} ${{ matrix.version }}, $${{ matrix.std }}
+    name: ${{ matrix.FC }} ${{ matrix.version }}, ${{ matrix.std }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test_suite_ubuntu_cpu_intel.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_intel.yml
@@ -47,6 +47,7 @@ jobs:
             MPIFC: mpiifort
             version: 2024.2.0  # Last release of oneapi with ifort
         std: [f08]
+        pfunit_version: [4.18.2]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -83,8 +84,8 @@ jobs:
 
       - name: Install pFUnit
         run: |
-          # TODO: Avoid version pinning (needed because version appears in install path)
-          git clone -b v4.12.0 https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          # NOTE: version pin needed because version appears in install path
+          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           cmake .. \
@@ -106,7 +107,7 @@ jobs:
           export INSTALL_DIR="/tmp/ftorch-install"
           mkdir -p ${INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR=$(pwd)/pFUnit/build/installed/PFUNIT-4.12
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
           mkdir -p ${BUILD_DIR}
           cd ${BUILD_DIR}
 

--- a/.github/workflows/test_suite_ubuntu_cpu_intel.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_intel.yml
@@ -26,7 +26,7 @@ permissions: {}
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   test-suite:
-    name: test suite
+    name: ${{ matrix.FC }} ${{ matrix.version }}, $${{ matrix.std }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test_suite_ubuntu_cpu_intel.yml
+++ b/.github/workflows/test_suite_ubuntu_cpu_intel.yml
@@ -1,5 +1,5 @@
 # Workflow to run the FTorch test suite using jobs for Intel compiler
-name: Test suite (Ubuntu CPU Intel)
+name: Test suite (Ubuntu CPU)
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -1,5 +1,5 @@
 # Workflow to run the FTorch test suite on a CUDA enabled runner with the GNU compiler
-name: Test suite (Ubuntu CUDA GNU)
+name: Test suite (Ubuntu CUDA)
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -44,7 +44,7 @@ permissions: {}
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   test-suite:
-    name: gfortran, $${{ matrix.std }}
+    name: gfortran, ${{ matrix.std }}
 
     # The type of runner that the job will run on
     runs-on: GPU-runner

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Install pFUnit
         run: |
           export FC=/usr/bin/gfortran
-          # TODO: Avoid version pinning (needed because version appears in install path)
-          git clone -b v4.12.0 https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          # NOTE: version pin needed because version appears in install path
+          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           # MPI support is currently not needed for the unit testing
@@ -112,7 +112,7 @@ jobs:
           export INSTALL_DIR=/tmp/ftorch-install
           mkdir -p ${INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR=$(pwd)/pFUnit/build/installed/PFUNIT-4.12
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
           mkdir -p ${BUILD_DIR}
           cd ${BUILD_DIR}
           cmake .. \

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -52,6 +52,8 @@ jobs:
       fail-fast: true
       matrix:
         std: [f2008]
+        pfunit_longversion: [4.18.2]
+        pfunit_shortversion: [4.18]
 
     # Terminate the job if it runs for more than 20 minutes
     timeout-minutes: 20
@@ -92,7 +94,7 @@ jobs:
         run: |
           export FC=/usr/bin/gfortran
           # NOTE: version pin needed because version appears in install path
-          git clone -b "v${{ matrix.pfunit_version }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+          git clone -b "v${{ matrix.pfunit_longversion }}" https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
           mkdir pFUnit/build
           cd pFUnit/build
           # MPI support is currently not needed for the unit testing
@@ -112,7 +114,7 @@ jobs:
           export INSTALL_DIR=/tmp/ftorch-install
           mkdir -p ${INSTALL_DIR}
           # NOTE: The pFUnit version (pinned during installation above) is used in the install path.
-          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_version }}"
+          export PFUNIT_DIR="$(pwd)/pFUnit/build/installed/PFUNIT-${{ matrix.pfunit_shortversion }}"
           mkdir -p ${BUILD_DIR}
           cd ${BUILD_DIR}
           cmake .. \

--- a/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
+++ b/.github/workflows/test_suite_ubuntu_cuda_gnu.yml
@@ -44,12 +44,14 @@ permissions: {}
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   test-suite:
-    name: test suite
+    name: gfortran, $${{ matrix.std }}
 
     # The type of runner that the job will run on
     runs-on: GPU-runner
     strategy:
       fail-fast: true
+      matrix:
+        std: [f2008]
 
     # Terminate the job if it runs for more than 20 minutes
     timeout-minutes: 20
@@ -98,8 +100,6 @@ jobs:
           make -j 4 install
 
       - name: Build FTorch
-        env:
-          FORTRAN_STANDARD: f2008
         run: |
           # GitHub Actions doesn't source /etc/profile.d/ scripts, so the CUDA bin directory
           # (added by the apt package post-install script) won't be in PATH automatically.
@@ -123,7 +123,7 @@ jobs:
             -DGPU_DEVICE=CUDA \
             -DMULTI_GPU=OFF \
             -DCMAKE_PREFIX_PATH="${PFUNIT_DIR};${Torch_DIR}" \
-            -DCMAKE_Fortran_FLAGS="-std=${FORTRAN_STANDARD}"
+            -DCMAKE_Fortran_FLAGS="-std=${{ matrix.std }}"
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -27,7 +27,7 @@ permissions: {}
 jobs:
   # This workflow contains a single job called "test-suite-windows"
   test-suite:
-    name: test suite
+    name: ifx ${{ matrix.toolchain.version }}, ${{ matrix.std }}
 
     # The type of runner that the job will run on
     runs-on: windows-latest
@@ -36,6 +36,7 @@ jobs:
       matrix:
         toolchain:
           - {compiler: intel, version: '2023.2'}
+        std: [f08]
 
     # Terminate the job if it runs for more than 15 minutes
     timeout-minutes: 15

--- a/.github/workflows/test_suite_windows_cpu_intel.yml
+++ b/.github/workflows/test_suite_windows_cpu_intel.yml
@@ -1,5 +1,5 @@
 # Workflow to run the FTorch test suite
-name: Test suite (Windows CPU Intel)
+name: Test suite (Windows CPU)
 
 # Controls when the workflow will run
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
   [#581](https://github.com/Cambridge-ICCS/FTorch/pull/581)
 - Ability to build only integration or unit tests as desired using CMake options in
   [#584](https://github.com/Cambridge-ICCS/FTorch/pull/584)
+- Added Flang CI workflow in
+  [#595](https://github.com/Cambridge-ICCS/FTorch/pull/595)
 
 
 ### Changed
@@ -39,6 +41,8 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
   [#320](https://github.com/Cambridge-ICCS/FTorch/pull/320)
 - Example numbering updated to double digits to incorporate example 10.
   [#320](https://github.com/Cambridge-ICCS/FTorch/pull/320)
+- Updated CI workflows to use pFUnit 4.18.2 in
+  [#595](https://github.com/Cambridge-ICCS/FTorch/pull/595)
 
 ### Removed
 

--- a/pages/developer/testing.md
+++ b/pages/developer/testing.md
@@ -41,6 +41,11 @@ Note that pFUnit includes the version number in the install directory name,
 so for version 4.12 that path will need to be specified as
 `/path/to/pFUnit/build/installed/PFUNIT-4.12`, for example.
 
+@note
+If you are using the Flang compiler then you will need to use pFUnit 4.18.2 or
+later due to a bug in pFUnit that was fixed in that release.
+@endnote
+
 Integration tests can be built without pFUnit by disabling the unit tests:
 ```shell
 cmake -DCMAKE_BUILD_TESTS=TRUE -DFTORCH_BUILD_UNIT_TESTS=OFF \

--- a/pages/usage/troubleshooting.md
+++ b/pages/usage/troubleshooting.md
@@ -129,7 +129,9 @@ If FTorch unit tests segfault when built with `flang`, a common cause is an
 older `pFUnit` version which then exposes a bug in `flang`.
 
 The solution is to use `pFUnit v4.18.2` or newer, then reconfigure and rebuild FTorch (and its unit
-tests).
+tests), e.g., specifying to `cmake` an explicit path to the newer `pFUnit` (e.g.
+`-DCMAKE_INSTALL_PREFIX="path/pfunit-4.18.2`).
+
 
 
 ### Common warnings

--- a/pages/usage/troubleshooting.md
+++ b/pages/usage/troubleshooting.md
@@ -10,6 +10,7 @@ If you are experiencing problems building or using FTorch please see below for g
 - [Common Errors](#common-errors)
     - [No specific subroutine](#no-specific-subroutine)
     - [Segmentation faults](#segmentation-faults)
+     - [Unit test segfaults with flang](#unit-test-segfaults-with-flang)
 - [Common warnings](#common-warnings)
 
 
@@ -121,6 +122,14 @@ the overloaded assignment operator should be triggered. As such, if you aren't
 using the bare `use ftorch` import then you should ensure you specify
 `use ftorch, only: assignment(=)` (as well as any other module members you
 require). See the [tensor documentation](|page|/usage/tensor.html) for more details.
+
+##### Unit test segfaults with flang
+
+If FTorch unit tests segfault when built with `flang`, a common cause is an
+older `pFUnit` version which then exposes a bug in `flang`.
+
+The solution is to use `pFUnit v4.18.2` or newer, then reconfigure and rebuild FTorch (and its unit
+tests).
 
 
 ### Common warnings


### PR DESCRIPTION
Closes #590 

While adding the Flang CI workflow and the pFUnit version used across the other test workflows, I took the liberty of improving the consistency of names so that the platforms, compilers, and standards appear in a clear way in the actions report below.

To check the reworking of the matrices works properly on `push` events, see the CI jobs in test PR #597.

## Checklist

- [x] Add Flang test workflow
- [x] Update the version pin in the CI workflows in other workflows.
- [x] Update the version pin in the CI workflows in docs.
- [x] Add a common error entry for unit test segfaults with flang (and remedy) on the `pages/usage/troubleshooting.md` page.
- [x] Changelog entry.