### PR TITLE
Ensure model output file is not `None`

### DIFF
--- a/ftorch_utils/pt2ts.py
+++ b/ftorch_utils/pt2ts.py
@@ -129,8 +129,7 @@ def main_cli():
     if input_model_file is not None:
         validate_input_model_file(input_model_file)
     output_model_file = parsed_args.output_model_file
-    if output_model_file is not None:
-        validate_output_model_file(output_model_file, input_model_file)
+    validate_output_model_file(output_model_file, input_model_file)
     trace = parsed_args.trace
     test = parsed_args.test
     input_tensor_file = parsed_args.input_tensor_file

--- a/ftorch_utils/validation.py
+++ b/ftorch_utils/validation.py
@@ -78,6 +78,9 @@ def validate_output_model_file(output_model_file, input_model_file):
     input_model_file : str
         Name of the input model file
     """
+    if output_model_file is None:
+        value_error = "No output model file provided via --output_model_file argument."
+        raise ValueError(value_error)
     _, output_model_ext = os.path.splitext(output_model_file)
     if output_model_ext != ".pt":
         value_error = (

--- a/test/ftorch_utils/test_validation.py
+++ b/test/ftorch_utils/test_validation.py
@@ -64,6 +64,12 @@ class TestValidateInputTensor:
 class TestValidateOutputModel:
     """Tests for validate_output_model_file."""
 
+    def test_is_not_none(self):
+        """Check that an error is raised for invalid output model file extension."""
+        expected = "No output model file provided via --output_model_file argument."
+        with pytest.raises(ValueError, match=expected):
+            validate_output_model_file(None, "input.pt")
+
     def test_invalid_extension(self):
         """Check that an error is raised for invalid output model file extension."""
         expected = "TorchScript output model file 'output.py' has extension .py but .pt was expected."


### PR DESCRIPTION
Closes #607

Does what it says on the tin.

Note that we were skipping the model output name validation if it was `None`, allowing this to be used as the output filename.