### PR TITLE
Add some clarification docs to Cross Entropy Loss.

### DIFF
--- a/src/ftorch_loss.f90
+++ b/src/ftorch_loss.f90
@@ -23,8 +23,8 @@ contains
   !
   !  Note that the reduction type relates to the operation to perform within a (mini)batch. With
   !  torch_kNone, no reduction is applied and the loss tensor will have the same dimensions as the
-  !  input tensor. If torch_kMean or torch_kSum is applied then the loss tensor will differ in the
-  !  first dimension (for the batch), which will be collapsed.
+  !  input tensor. If torch_kMean (default) or torch_kSum is applied then the loss tensor will differ
+  !  in the first dimension (for the batch), which will be collapsed.
   !
   !  We refer to the PyTorch docs for the specifics of how this works for MSELoss
   !  https://docs.pytorch.org/docs/main/nn.functional.html#torch.nn.functional.mse_loss
@@ -64,6 +64,19 @@ contains
   end subroutine torch_loss_mse
 
   !> Evaluate CrossEntropyLoss
+  !
+  !  Note that the reduction type relates to the operation to perform within a (mini)batch. With
+  !  torch_kNone, no reduction is applied and the loss tensor will have the same dimensions as the
+  !  input tensor. If torch_kMean (default) or torch_kSum is applied then the loss tensor will differ
+  !  in the first dimension (for the batch), which will be collapsed.
+  !
+  !  Note also that, by definition, the result of CrossEntropyLoss will collapse across the
+  !  class dimension. This is true even for reduction torch_kNone. This is important to
+  !  consider if setting the size/shape of a Fortran array to hold these results.
+  !  For more details see https://docs.pytorch.org/docs/main/generated/torch.nn.CrossEntropyLoss.html
+  !
+  !  We refer to the PyTorch docs for the specifics of how this works for CrossEntropyLoss
+  !  https://docs.pytorch.org/docs/main/nn.functional.html#torch.nn.functional.cross_entropy
   subroutine torch_loss_cross_entropy(loss_tensor, input_tensor, target_tensor, reduction_type)
     use, intrinsic :: iso_c_binding, only : c_associated, c_int
     type(torch_tensor), intent(inout) :: loss_tensor  !! Tensor to hold the loss value


### PR DESCRIPTION
Short docs follow-up to #593 

Adds warning from MSELoss to CrossEntropyLoss, as well as a note about the collapsing over class dimensions (see discussion on #593).