### PR TITLE
Add Fortitude check for `ftorch_loss.f90`

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -110,6 +110,7 @@ jobs:
           fortitude check src/ftorch_tensor.f90
           fortitude check src/ftorch_model.f90
           fortitude check src/ftorch_optim.f90
+          fortitude check src/ftorch_loss.f90
           fortitude check src/ftorch_test_utils.f90
 
       # Apply C++ and C linter and formatter, clang


### PR DESCRIPTION
I just spotted that we missed `ftorch_loss.f90` here, too.

How come we are spelling out the files in `src/` rather than just doing `fortitude check src/`?