### PR TITLE
Update MacOS workflow to use OPENMP_ROOT instead of explicit flags.

### DIFF
--- a/.github/workflows/test_suite_macos_cpu_clang.yml
+++ b/.github/workflows/test_suite_macos_cpu_clang.yml
@@ -128,9 +128,7 @@ jobs:
             -DCMAKE_BUILD_TESTS=TRUE \
             -DCMAKE_PREFIX_PATH="${PFUNIT_DIR};${Torch_DIR}" \
             -DCMAKE_Fortran_FLAGS="-std=${FORTRAN_STANDARD}"\
-            -DCMAKE_C_FLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" \
-            -DCMAKE_CXX_FLAGS="-stdlib=libc++ -Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" \
-            -DCMAKE_EXE_LINKER_FLAGS="-L$(brew --prefix libomp)/lib -lomp"
+            -DOpenMP_ROOT="$(brew --prefix libomp)"
           cmake --build .
           cmake --install .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ For specific details see the [FTorch online documentation](https://cambridge-icc
 
 ### Changed
 
+- Guidance around OpenMP on MacOS and building updated (along with MacOS workflow) in
+  [#618](https://github.com/Cambridge-ICCS/FTorch/pull/618)
+
 ### Removed
 
 ### Fixed

--- a/pages/installation/systems.md
+++ b/pages/installation/systems.md
@@ -207,7 +207,8 @@ macOS system libraries.
 Apple does not provide a Fortran compiler so users will need to install one.
 We recommend GNU's `gfortran` which comes with GCC.
 
-Users will additionally need to install OpenMP (and, for some examples, Open-MPI).
+Users will additionally need to install OpenMP to run tests with pFUnit and, for some
+examples, Open-MPI.
 This can be done e.g. using the [homebrew package manager](https://brew.sh/) with:
 ```
 brew install gcc openmpi libomp
@@ -227,6 +228,7 @@ cmake .. \
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_CXX_COMPILER=clang++ \
   -DCMAKE_Fortran_COMPILER=gfortran \
+  -DCMAKE_BUILD_TESTS=TRUE \
   -DOpenMP_ROOT="$(brew --prefix libomp)" \
   -DGPU_DEVICE=MPS
 cmake --build .
@@ -234,6 +236,8 @@ cmake --install .
 ```
 
 To build without support for Apple Silicon MPS acceleration, remove the `-DGPU_DEVICE=MPS`.
+If not building tests remove `-DCMAKE_BUILD_TESTS` and there is no need to specify
+`OpenMP_ROOT`.
 
 We recommend Mac users review the MacOS continuous integration workflow
 ([`.github/workflows/test_suite_macos_cpu_clang.yml`](https://github.com/Cambridge-ICCS/FTorch/blob/main/.github/workflows/test_suite_macos_cpu_clang.yml))

--- a/pages/installation/systems.md
+++ b/pages/installation/systems.md
@@ -215,15 +215,11 @@ brew install gcc openmpi libomp
 
 #### Building
 
-MacOS requires explicit linking to the C++ standard library and OpenMP support via
-`libomp`. This can be done through C and C++ flags at compilation time:
-  - `-Xpreprocessor -fopenmp` which tells clang to use OpenMP, with `-Xpreprocessor`
-    passing the flag to the preprocessor,
-  - `-I<path/to/libomp>/include` to find OpenMP headers,
-  - `-stdlib=libc++` to ensure use of the native MacOS C++ standard library, and
-  - `-L<path/to/libomp>/lib -lomp` to link against the OpenMP library.
-
-If using homebrew you can replace `<path/to/libomp>` with `$(brew --prefix libomp)`.
+MacOS does not have OpenMP installed by default, unlike Linux, so Torch bundles its
+own version. To satisfy pFUnit's need to find OpenMP without conflicting the internal
+Torch OpenMP we pass an additional CMake flag (`OpenMP_ROOT`) pointing to the
+system installed version.
+If using homebrew you can set this to `$(brew --prefix libomp)`.
 
 Example CMake command:
 ```sh
@@ -231,9 +227,7 @@ cmake .. \
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_CXX_COMPILER=clang++ \
   -DCMAKE_Fortran_COMPILER=gfortran \
-  -DCMAKE_C_FLAGS="-Xpreprocessor -fopenmp -I<path/to/libomp>/include" \
-  -DCMAKE_CXX_FLAGS="-stdlib=libc++ -Xpreprocessor -fopenmp -I<path/to/libomp>/include" \
-  -DCMAKE_EXE_LINKER_FLAGS="-L<path/to/libomp>/lib -lomp" \
+  -DOpenMP_ROOT="$(brew --prefix libomp)" \
   -DGPU_DEVICE=MPS
 cmake --build .
 cmake --install .


### PR DESCRIPTION
Rebuilding on my machine and tacking a few issues it seems that the problem seen previously was a conflict between bundled OMP in Torch and the system OMP installed via brew.

This is a cleaner fix on my machine so seeing if it can be applied here.

Since it works I have also updated the MacOS documentation.